### PR TITLE
Include <cerrno>

### DIFF
--- a/test_helpers/Utils.cpp
+++ b/test_helpers/Utils.cpp
@@ -26,7 +26,7 @@
 #include <cctype>
 #include <iomanip>
 #include <string>
-
+#include <cerrno>
 namespace
 {
 /* Advance the iterator to the first character which is not a comment


### PR DESCRIPTION
When compiling on Linux host to armv7a target following to the tutorial, got error of "errno undeclared". Include this header fixed this problem.