### PR TITLE
Add a build flag to control whether or not the example programs get built

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -29,6 +29,7 @@ vars.AddVariables(
     EnumVariable("arch", "Target Architecture", "armv7a", allowed_values=("armv7a", "arm64-v8a", "arm64-v8.2-a", "x86_32", "x86_64")),
     EnumVariable("os", "Target OS", "linux", allowed_values=("linux", "android", "bare_metal")),
     EnumVariable("build", "Build type", "cross_compile", allowed_values=("native", "cross_compile")),
+    BoolVariable("examples", "Build example programs", False),
     BoolVariable("Werror", "Enable/disable the -Werror compilation flag", True),
     BoolVariable("opencl", "Enable OpenCL support", True),
     BoolVariable("neon", "Enable Neon support", False),

--- a/sconscript
+++ b/sconscript
@@ -351,30 +351,32 @@ alias = env.Alias("arm_compute",objects)
 Default(alias)
 
 # Build examples
-test_helpers = env.Object("test_helpers/Utils.cpp")
 
-if env['opencl'] and env['neon']:
-    for file in Glob("examples/neoncl_*.cpp"):
-        example =  os.path.basename( os.path.splitext(str(file))[0])
-        prog = env.Program(example, ['examples/%s.cpp' % example, test_helpers], LIBS=example_libs+['OpenCL'])
-        alias = env.Alias(example, prog)
-        Depends(prog, objects)
-        Default( alias )
+if env['examples']:
+    test_helpers = env.Object("test_helpers/Utils.cpp")
 
-if env['opencl']:
-    for file in Glob("examples/cl_*.cpp"):
-        example =  os.path.basename( os.path.splitext(str(file))[0])
-        prog = env.Program(example, ['examples/%s.cpp' % example, test_helpers], LIBS=example_libs+['OpenCL'])
-        alias = env.Alias(example, prog)
-        Depends(prog, objects)
-        Default( alias )
+    if env['opencl'] and env['neon']:
+        for file in Glob("examples/neoncl_*.cpp"):
+            example =  os.path.basename( os.path.splitext(str(file))[0])
+            prog = env.Program(example, ['examples/%s.cpp' % example, test_helpers], LIBS=example_libs+['OpenCL'])
+            alias = env.Alias(example, prog)
+            Depends(prog, objects)
+            Default( alias )
 
-if env['neon']:
-    for file in Glob("examples/neon_*.cpp"):
-        example =  os.path.basename( os.path.splitext(str(file))[0])
-        prog = env.Program(example, ['examples/%s.cpp' % example, test_helpers], LIBS=example_libs)
-        alias = env.Alias(example, prog)
-        Depends(prog, objects)
-        Default( alias )
+    if env['opencl']:
+        for file in Glob("examples/cl_*.cpp"):
+            example =  os.path.basename( os.path.splitext(str(file))[0])
+            prog = env.Program(example, ['examples/%s.cpp' % example, test_helpers], LIBS=example_libs+['OpenCL'])
+            alias = env.Alias(example, prog)
+            Depends(prog, objects)
+            Default( alias )
+
+    if env['neon']:
+        for file in Glob("examples/neon_*.cpp"):
+            example =  os.path.basename( os.path.splitext(str(file))[0])
+            prog = env.Program(example, ['examples/%s.cpp' % example, test_helpers], LIBS=example_libs)
+            alias = env.Alias(example, prog)
+            Depends(prog, objects)
+            Default( alias )
 
 Export('env')


### PR DESCRIPTION
At present, compilation of some example programs fails, causing the build of the library to fail. However, the library itself builds fine, and the problem seems to be with the example programs. This changeset adds the flag examples=(yes|no) to scons, so that the library can be built without also building the example programs. In addition, some files and directories which are created automatically by scons have been added to the .gitignore so that git does not try to add built objects to commits.