### PR TITLE
Fix Yocto cross-compiles

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -142,7 +142,7 @@ env['RANLIB'] = prefix + "ranlib"
 
 if not GetOption("help"):
     try:
-        compiler_ver = subprocess.check_output([env['CXX'], "-dumpversion"]).strip()
+        compiler_ver = subprocess.check_output([env['CXX'].strip() + ["-dumpversion"]).strip()
     except OSError:
         print("ERROR: Compiler '%s' not found" % env['CXX'])
         Exit(1)


### PR DESCRIPTION
Yocto defines it's compilers in the environment complete with some arch flags.
For example:

```
CC="arm-poky-linux-gnueabi-gcc \
  -march=armv7-a \
  -mfloat-abi=hard \
  -mfpu=neon \
  -mtune=cortex-a9 \
  --sysroot=/home/ubuntu/device/build/tmp/sysroots/pico-imx6"
```

The SConstruct file would fail to find the compiler because it was calling
python's subprocess.check_output which expects the first argument of the list
to be _only_ the name of the executable.

This patch allows the SConstruct script to check the version of the compiler
even with funny environment variables.