### PR TITLE
feat : Support Leaky-ReLU Activation

### DIFF
--- a/arm_compute/core/Types.h
+++ b/arm_compute/core/Types.h
@@ -469,7 +469,8 @@ public:
         ABS,          /**< Absolute */
         SQUARE,       /**< Square */
         SQRT,         /**< Square root */
-        LINEAR        /**< Linear */
+        LINEAR,       /**< Linear */
+        LEAKY_RELU    /**< Leaky ReLU : y = x > 0 ? x : a*x*/
     };
 
     /** Default Constructor

--- a/src/core/CL/cl_kernels/activation_layer.cl
+++ b/src/core/CL/cl_kernels/activation_layer.cl
@@ -82,6 +82,9 @@ __kernel void activation_layer(
     data = sqrt(data);
 #elif defined LINEAR
     data = (VEC_DATA_TYPE(DATA_TYPE, 16))A * data + (VEC_DATA_TYPE(DATA_TYPE, 16))B;
+#elif defined LEAKY_RELU
+    VEC_DATA_TYPE(int, 16) flag = isgreater(data, (VEC_DATA_TYPE(DATA_TYPE, 16))0.0);
+    data = select((VEC_DATA_TYPE(DATA_TYPE, 16))A * data, data, flag);
 #endif
 
     // Store result

--- a/src/core/Utils.cpp
+++ b/src/core/Utils.cpp
@@ -160,6 +160,7 @@ const std::string &arm_compute::string_from_activation_func(ActivationLayerInfo:
         { ActivationLayerInfo::ActivationFunction::SQRT, "SQRT" },
         { ActivationLayerInfo::ActivationFunction::SQUARE, "SQUARE" },
         { ActivationLayerInfo::ActivationFunction::TANH, "TANH" },
+        { ActivationLayerInfo::ActivationFunction::LEAKY_RELU, "LEAKY_RELU" },
     };
 
     return act_map[act];


### PR DESCRIPTION
- Added support for Leaky-RELU activation function to the OpenCL kernel
- Leaky-RELU uses parameter `a` as the negative slope.

TODO:
- Add NEON implementation for Leaky-RELU.