### PR TITLE
Bugfix: must zero all values in all slices

### DIFF
--- a/src/runtime/NEON/functions/NEDeconvolutionLayer.cpp
+++ b/src/runtime/NEON/functions/NEDeconvolutionLayer.cpp
@@ -92,7 +92,7 @@ void NEDeconvolutionLayer::run()
     const int stride_x      = _info.stride().first;
     const int stride_y      = _info.stride().second;
 
-    std::fill_n(reinterpret_cast<float *>(_scaled_output.buffer()), _scaled_output.info()->tensor_shape().total_size(), 0.f);
+    std::fill_n(_scaled_output.buffer(), _scaled_output.info()->total_size(), 0);
 
     // scaled_output is the input for the forward convolution. We copy the input elements to scaled_output
     // and insert rows and columns with zeroes depending on the stride values.


### PR DESCRIPTION
Only first 2d slice was zeroed out leading to wrong convolution results. Window method might not be the most efficient?