### PR TITLE
Bugfix for NumPyBinLoader with SubTensor output.

### DIFF
--- a/utils/GraphUtils.cpp
+++ b/utils/GraphUtils.cpp
@@ -24,6 +24,7 @@
 
 #include "utils/GraphUtils.h"
 #include "utils/Utils.h"
+#include "arm_compute/runtime/SubTensor.h"
 
 #ifdef ARM_COMPUTE_CL
 #include "arm_compute/core/CL/OpenCL.h"
@@ -206,7 +207,7 @@ void RandomAccessor::fill(ITensor &tensor, D &&distribution)
 {
     std::mt19937 gen(_seed);
 
-    if(tensor.info()->padding().empty())
+    if(tensor.info()->padding().empty() && !dynamic_cast<SubTensor*>(&tensor))
     {
         for(size_t offset = 0; offset < tensor.info()->total_size(); offset += tensor.info()->element_size())
         {
@@ -349,11 +350,10 @@ bool NumPyBinLoader::access_tensor(ITensor &tensor)
     }
 
     // Read data
-    if(tensor.info()->padding().empty())
+    if(tensor.info()->padding().empty() && !dynamic_cast<SubTensor*>(&tensor))
     {
         // If tensor has no padding read directly from stream.
-        size_t offset = tensor.info()->offset_first_element_in_bytes();
-        stream.read(reinterpret_cast<char *>(tensor.buffer() + offset), tensor.info()->total_size() - offset);
+        stream.read(reinterpret_cast<char *>(tensor.buffer()), tensor.info()->total_size());
     }
     else
     {

--- a/utils/GraphUtils.cpp
+++ b/utils/GraphUtils.cpp
@@ -352,7 +352,8 @@ bool NumPyBinLoader::access_tensor(ITensor &tensor)
     if(tensor.info()->padding().empty())
     {
         // If tensor has no padding read directly from stream.
-        stream.read(reinterpret_cast<char *>(tensor.buffer() + tensor.info()->offset_first_element_in_bytes()), tensor.info()->total_size());
+        size_t offset = tensor.info()->offset_first_element_in_bytes();
+        stream.read(reinterpret_cast<char *>(tensor.buffer() + offset), tensor.info()->total_size() - offset);
     }
     else
     {

--- a/utils/GraphUtils.cpp
+++ b/utils/GraphUtils.cpp
@@ -352,7 +352,7 @@ bool NumPyBinLoader::access_tensor(ITensor &tensor)
     if(tensor.info()->padding().empty())
     {
         // If tensor has no padding read directly from stream.
-        stream.read(reinterpret_cast<char *>(tensor.buffer()), tensor.info()->total_size());
+        stream.read(reinterpret_cast<char *>(tensor.buffer() + tensor.info()->offset_first_element_in_bytes()), tensor.info()->total_size());
     }
     else
     {


### PR DESCRIPTION
When a SubTensor is used as output from a NumPyBinLoader, data should
not be written to the begining of the buffer.

Change-Id: I6ed4b24710ac09b41ca92c7e21f24d44a3ed2881