### PR TITLE
fix warning hit with Android clang version 5.0.300080

### DIFF
--- a/src/core/NEON/kernels/winograd/transforms/output_4x4_3x3_fp32.cpp
+++ b/src/core/NEON/kernels/winograd/transforms/output_4x4_3x3_fp32.cpp
@@ -41,9 +41,6 @@ int Transform::ops_performed(const Tensor4DShape &shape)
   return 170 * tile_M * tile_N * shape.n_channels;
 }
 
-// Instantiate cost methods
-template int Transform::ops_performed(const Tensor4DShape&);
-
 /* F(4x4, 3x3) constructs 4x4 output tiles from a 3x3 convolution. Since we use
  * enough tiles to cover the output space each output tile may contain up to 3
  * padded values to the right and bottom columns or rows of the tile, e.g.:


### PR DESCRIPTION
I found 18.01 doesn't compile with Werror=1 for Neon using:

$ CXX=clang++ CC=clang scons Werror=1 -j8 debug=1 neon=1 opencl=0 os=android arch=arm64-v8a

The error is:

src/core/NEON/kernels/winograd/transforms/output_4x4_3x3_fp32.cpp:45:25: error: explicit
      instantiation of 'ops_performed' that occurs after an explicit specialization has no effect
      [-Werror,-Winstantiation-after-specialization]
template int Transform::ops_performed(const Tensor4DShape&);
                        ^
src/core/NEON/kernels/winograd/transforms/output_4x4_3x3_fp32.cpp:36:16: note: previous template
      specialization is here
int Transform::ops_performed(const Tensor4DShape &shape)
               ^
1 error generated.
