### PR TITLE
Bugfix: uninitialised buffer access in NEGEMMConvolutionLayer can lea…

### DIFF
--- a/src/runtime/NEON/functions/NEGEMMConvolutionLayer.cpp
+++ b/src/runtime/NEON/functions/NEGEMMConvolutionLayer.cpp
@@ -614,6 +614,8 @@ void NEGEMMConvolutionLayer::run()
     // Run input reshaping
     NEScheduler::get().schedule(&_input_im2col_kernel, Window::DimY);
 
+    std::fill_n(_gemm_output.buffer(), _gemm_output.info()->total_size(), 0);
+
     // Runs matrix multiply on reshaped matrices
     if(_mm_optimised_kernel != nullptr)
     {


### PR DESCRIPTION
…d to invalid results

 I implemented a vgg16-fcn8 model that worked fine with 18.01, but predicts nan's since 18.02.
Finally time for debugging it: 1x1 NEON Convolution Layer, utilising NEGEMMConvolutionLayer inside access uninitialised memory leading to invalid results.