### PR TITLE
Correct the use of OpenMP private

### DIFF
--- a/src/runtime/OMP/OMPScheduler.cpp
+++ b/src/runtime/OMP/OMPScheduler.cpp
@@ -71,7 +71,7 @@ void OMPScheduler::schedule(ICPPKernel *kernel, unsigned int split_dimension)
     }
     else
     {
-        #pragma omp parallel private(info) num_threads(info.num_threads)
+        #pragma omp parallel firstprivate(info) num_threads(info.num_threads)
         {
             const int tid  = omp_get_thread_num();
             Window win     = max_window.split_window(split_dimension, tid, info.num_threads);


### PR DESCRIPTION
Correction to my previous commit since private(...) is not copying the value of info into the generated threads. firstprivate(...) should be used instead. 

Previously I wasn't able to run the code because OPENMP can only be used with NEON. Now, I have setup an ODROID-C2 and run the benchmarks locally and they all pass.

---
Version = arm_compute_version=v18.03 Build options: {'arch': 'arm64-v8a', 'opencl': '0', 'neon': '1', 'examples': '1', 'asserts': '0', 'debug': '0', 'openmp': '1', 'cppthreads': '0', 'Werror': '1', 'build': 'native'} Git hash=7329f53f728ffecc872766b5fa81c12f324719d8
Seed = 4135802228
Iterations = 1
Threads = 4
Dataset mode = PRECOMMIT

Executed 1280 test(s) (1199 passed, 0 expected failures, 0 failed, 0 crashed, 0 disabled) in 29 second(s)
---
