### PR TITLE
bugfix: CLDeconvolutionLayer::validate fails if bias==NULL

### DIFF
--- a/src/runtime/CL/functions/CLDeconvolutionLayer.cpp
+++ b/src/runtime/CL/functions/CLDeconvolutionLayer.cpp
@@ -62,8 +62,8 @@ Status CLDeconvolutionLayer::validate(const ITensorInfo *input, const ITensorInf
 
     const TensorShape output_shape = deconvolution_output_shape(out_dims, input->tensor_shape(), weights->tensor_shape());
 
-    ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_DATA_TYPES(input, output, weights, bias);
-    ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_FIXED_POINT(input, output, weights, bias);
+    ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_DATA_TYPES(input, output, weights);
+    ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_FIXED_POINT(input, output, weights);
 
     if(bias != nullptr)
     {


### PR DESCRIPTION
Validation fails for a parametrisation without bias. The lines below correctly check bias if available. 