### PR TITLE
Removed redundant const qualifier on cast

### DIFF
--- a/src/core/NEON/kernels/NEMinMaxLayerKernel.cpp
+++ b/src/core/NEON/kernels/NEMinMaxLayerKernel.cpp
@@ -147,7 +147,7 @@ void NEMinMaxLayerKernel::run(const Window &window, const ThreadInfo &info)
         execute_window_loop(window_input, [&](const Coordinates & id)
         {
             int        x      = x_start;
-            const auto in_ptr = reinterpret_cast<const float *const>(input.ptr() + id_batch[1] * _input->info()->strides_in_bytes()[3]);
+            const auto in_ptr = reinterpret_cast<const float *>(input.ptr() + id_batch[1] * _input->info()->strides_in_bytes()[3]);
 
             // Vector loop
             for(; x <= x_end - 8; x += 8)
@@ -181,7 +181,7 @@ void NEMinMaxLayerKernel::run(const Window &window, const ThreadInfo &info)
         const float min_i = std::min(vget_lane_f32(carry_min, 0), carry_min_scalar);
         const float max_i = std::max(vget_lane_f32(carry_max, 0), carry_max_scalar);
 
-        auto out_ptr = reinterpret_cast<float *const>(output.ptr());
+        auto out_ptr = reinterpret_cast<float *>(output.ptr());
 
         // Perform reduction of local min/max values
         update_min_max(out_ptr, min_i, max_i);
@@ -205,7 +205,7 @@ void NEMinMaxLayerKernel::reset()
 
     execute_window_loop(window_output, [&](const Coordinates & id)
     {
-        vst1_f32(reinterpret_cast<float *const>(output.ptr()), reset_values);
+        vst1_f32(reinterpret_cast<float *>(output.ptr()), reset_values);
     },
     output);
 }

--- a/src/core/NEON/kernels/NEMinMaxLocationKernel.cpp
+++ b/src/core/NEON/kernels/NEMinMaxLocationKernel.cpp
@@ -212,7 +212,7 @@ void NEMinMaxKernel::minmax_S16(Window win)
     execute_window_loop(win, [&](const Coordinates & id)
     {
         int        x      = x_start;
-        const auto in_ptr = reinterpret_cast<const int16_t *const>(input.ptr());
+        const auto in_ptr = reinterpret_cast<const int16_t *>(input.ptr());
 
         // Vector loop
         for(; x <= x_end - 16; x += 16)
@@ -271,7 +271,7 @@ void NEMinMaxKernel::minmax_F32(Window win)
     execute_window_loop(win, [&](const Coordinates & id)
     {
         int        x      = x_start;
-        const auto in_ptr = reinterpret_cast<const float *const>(input.ptr());
+        const auto in_ptr = reinterpret_cast<const float *>(input.ptr());
 
         // Vector loop
         for(; x <= x_end - 8; x += 8)

--- a/src/core/NEON/kernels/arm_gemm/transforms/a32_transpose_interleave_8way_32bit.hpp
+++ b/src/core/NEON/kernels/arm_gemm/transforms/a32_transpose_interleave_8way_32bit.hpp
@@ -37,7 +37,7 @@ inline void TransformImpl<8, 1, true, 4, 4>::Transform(
     // Redirect to a 16x uint16_t specialisation
     TransformImpl<16, 1, true, 2, 2>::Transform(
         reinterpret_cast<uint16_t *>(out),
-        reinterpret_cast<const uint16_t *const>(in),
+        reinterpret_cast<const uint16_t *>(in),
         stride * 2, x0 * 2, xmax * 2, k0, kmax);
 }
 
@@ -51,7 +51,7 @@ inline void TransformImpl<16, 1, true, 2, 2>::Transform(
     // Redirect to a uint16_t specialisation
     Transform(
         reinterpret_cast<uint16_t *>(out),
-        reinterpret_cast<const uint16_t *const>(in),
+        reinterpret_cast<const uint16_t *>(in),
         stride, x0, xmax, k0, kmax);
 }
 

--- a/src/core/NEON/kernels/arm_gemm/transforms/a64_transpose_interleave_12way_16bit.hpp
+++ b/src/core/NEON/kernels/arm_gemm/transforms/a64_transpose_interleave_12way_16bit.hpp
@@ -37,7 +37,7 @@ inline void TransformImpl<6, 1, true, 4, 4>::Transform(
     // Redirect to a 12 x uint16_t specialisation
     TransformImpl<12, 1, true, 2, 2>::Transform(
         reinterpret_cast<uint16_t *>(out),
-        reinterpret_cast<const uint16_t *const>(in),
+        reinterpret_cast<const uint16_t *>(in),
         stride * 2, x0 * 2, xmax * 2, k0, kmax);
 }
 
@@ -51,7 +51,7 @@ inline void TransformImpl<12, 1, true, 2, 2>::Transform(
     // Redirect to a uint16_t specialisation
     Transform(
         reinterpret_cast<uint16_t *>(out),
-        reinterpret_cast<const uint16_t *const>(in),
+        reinterpret_cast<const uint16_t *>(in),
         stride, x0, xmax, k0, kmax);
 }
 

--- a/src/core/NEON/kernels/arm_gemm/transforms/a64_transpose_interleave_24way_16bit.hpp
+++ b/src/core/NEON/kernels/arm_gemm/transforms/a64_transpose_interleave_24way_16bit.hpp
@@ -37,7 +37,7 @@ inline void TransformImpl<12, 1, true, 4, 4>::Transform(
     // Redirect to a 24 x uint16_t specialisation
     TransformImpl<24, 1, true, 2, 2>::Transform(
         reinterpret_cast<uint16_t *>(out),
-        reinterpret_cast<const uint16_t *const>(in),
+        reinterpret_cast<const uint16_t *>(in),
         stride * 2, x0 * 2, xmax * 2, k0, kmax);
 }
 
@@ -51,7 +51,7 @@ inline void TransformImpl<24, 1, true, 2, 2>::Transform(
     // Redirect to a uint16_t specialisation
     Transform(
         reinterpret_cast<uint16_t *>(out),
-        reinterpret_cast<const uint16_t *const>(in),
+        reinterpret_cast<const uint16_t *>(in),
         stride, x0, xmax, k0, kmax);
 }
 

--- a/tests/AssetsLibrary.h
+++ b/tests/AssetsLibrary.h
@@ -480,7 +480,7 @@ void AssetsLibrary::fill(T &&tensor, D &&distribution, std::random_device::resul
         for(int channel = 0; channel < tensor.num_channels(); ++channel)
         {
             const ResultType value        = distribution(gen);
-            ResultType      &target_value = reinterpret_cast<ResultType *const>(tensor(id))[channel];
+            ResultType      &target_value = reinterpret_cast<ResultType *>(tensor(id))[channel];
 
             store_value_with_data_type(&target_value, value, tensor.data_type());
         }


### PR DESCRIPTION
GCC (>=8) yields warning w/ -Wignored-qualifers (enabled by -Wextra) on such usage.