### PR TITLE
Enable QASYMM8 in LOGISTIC of CLActivationLayerKernel.

### DIFF
--- a/src/core/CL/CLKernelLibrary.cpp
+++ b/src/core/CL/CLKernelLibrary.cpp
@@ -149,6 +149,7 @@ const std::map<std::string, std::string> CLKernelLibrary::_kernel_program_map =
     { "accumulate_weighted", "accumulate.cl" },
     { "activation_layer", "activation_layer.cl" },
     { "activation_layer_qa8", "activation_layer_qa8.cl" },
+    { "activation_layer_logistic_qa8", "activation_layer_qa8.cl" },
     { "arithmetic_add", "arithmetic_op.cl" },
     { "arithmetic_sub", "arithmetic_op.cl" },
     { "batchnormalization_layer_nchw", "batchnormalization_layer.cl" },

--- a/src/core/CL/cl_kernels/activation_layer_qa8.cl
+++ b/src/core/CL/cl_kernels/activation_layer_qa8.cl
@@ -21,10 +21,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "helpers.h"
+#include "helpers_asymm.h"
 
 #define TYPE VEC_DATA_TYPE(DATA_TYPE, VEC_SIZE)
 
+// Logistic Activation
+inline TYPE logistic_op(TYPE x)
+{
+    // This function is a temporary function that is not actually executed.
+    // To keep the existing structure, it is added.
+    return x;
+}
 // RELU Activation
 inline TYPE relu_op(TYPE x)
 {
@@ -120,3 +127,99 @@ __kernel void activation_layer_qa8(
 }
 
 #endif /* defined(ACT) */
+
+/** This performs a logistic activation function on QASYMM8 inputs.
+ *
+ * @note In order to perform the logistic activation function "in-place", the pre-processor -DIN_PLACE must be passed at compile time
+ *
+ * @note Datatype should be given as a preprocessor argument using -DDATA_TYPE=type. e.g. -DDATA_TYPE=short
+ * @note Vector size should be given as a preprocessor argument using -DVEC_SIZE=size. e.g. -DVEC_SIZE=16
+ * @note Quantization scales of the input/output tensors are passed in with -DS1_VAL= and -DS2_VAL= respectively.
+ * @note Quantization offsets of the input/output tensors are passed in with -DO1_VAL= and -DO2_VAL= respectively.
+ * @note Quantized value of constant zero should be given as a preprocessor argument using -DCONST_0=value. e.g. -DCONST_0=128.
+ * @note Quantized can be optionally passed at compile time using -DINPUT_MULTIPLIER and -DINPUT_LEFT_SHIFT (if undefined, assume that the original data is used and not scaled separately.
+ * @note Number of integer bits should be given as a preprocessor argument using -DINPUT_INTEGER_BITS=value. e.g. -DINPUT_INTEGER_BITS=4.
+ * @note Number of input range radius should be given at compile time using -DINPUT_RANGE_RADIUS.
+ *
+ * @param[in]  input_ptr                            Pointer to the source image. Supported data types: QASYMM8
+ * @param[in]  input_stride_x                       Stride of the source image in X dimension (in bytes)
+ * @param[in]  input_step_x                         input_stride_x * number of elements along X processed per workitem(in bytes)
+ * @param[in]  input_stride_y                       Stride of the source image in Y dimension (in bytes)
+ * @param[in]  input_step_y                         input_stride_y * number of elements along Y processed per workitem(in bytes)
+ * @param[in]  input_stride_z                       Stride of the source tensor in Z dimension (in bytes)
+ * @param[in]  input_step_z                         input_stride_z * number of elements along Z processed per workitem(in bytes)
+ * @param[in]  input_offset_first_element_in_bytes  The offset of the first element in the source image
+ * @param[out] output_ptr                           Pointer to the destination image. Supported data types: same as @p input_ptr
+ * @param[in]  output_stride_x                      Stride of the destination image in X dimension (in bytes)
+ * @param[in]  output_step_x                        output_stride_x * number of elements along X processed per workitem(in bytes)
+ * @param[in]  output_stride_y                      Stride of the destination image in Y dimension (in bytes)
+ * @param[in]  output_step_y                        output_stride_y * number of elements along Y processed per workitem(in bytes)
+ * @param[in]  output_stride_z                      Stride of the source tensor in Z dimension (in bytes)
+ * @param[in]  output_step_z                        output_stride_z * number of elements along Z processed per workitem(in bytes)
+ * @param[in]  output_offset_first_element_in_bytes The offset of the first element in the destination image
+ */
+__kernel void activation_layer_logistic_qa8(
+    TENSOR3D_DECLARATION(input)
+#ifndef IN_PLACE
+    ,
+    TENSOR3D_DECLARATION(output)
+#endif /* not IN_PLACE */
+)
+{
+    // Get pixels pointer
+    Tensor3D input = CONVERT_TO_TENSOR3D_STRUCT(input);
+#ifdef IN_PLACE
+    Tensor3D output = input;
+#else  /* IN_PLACE */
+    Tensor3D output = CONVERT_TO_TENSOR3D_STRUCT(output);
+#endif /* IN_PLACE */
+
+    // Load data
+    VEC_DATA_TYPE(int, 16)
+    data = CONVERT(VLOAD(VEC_SIZE)(0, (__global DATA_TYPE *)input.ptr), VEC_DATA_TYPE(int, 16));
+
+    VEC_DATA_TYPE(int, 16)
+    result = data;
+
+#if defined(INPUT_INTEGER_BITS) && defined(INPUT_RANGE_RADIUS)
+    const VEC_DATA_TYPE(int, 16) Q0_one      = INT_MAX;
+    const VEC_DATA_TYPE(int, 16) Q0_one_half = (1 << 30);
+
+    VEC_DATA_TYPE(int, 16)
+    input_val_centered = data;
+#ifdef O1_VAL
+    input_val_centered = data - O1_VAL;
+#endif /* O1_VAL */
+
+    VEC_DATA_TYPE(int, 16) result_left  = ASYMM_SELECT_USING_MASK(input_val_centered <= -INPUT_RANGE_RADIUS, 1, 0, 16);
+    VEC_DATA_TYPE(int, 16) result_right = ASYMM_SELECT_USING_MASK(input_val_centered >= INPUT_RANGE_RADIUS, 255, 0, 16);
+
+    VEC_DATA_TYPE(int, 16) input_mask         = ASYMM_SELECT_USING_MASK(input_val_centered > -INPUT_RANGE_RADIUS && input_val_centered < INPUT_RANGE_RADIUS, 1, 0, 16);
+    VEC_DATA_TYPE(int, 16) input_val_rescaled = input_val_centered * input_mask;
+#if defined(INPUT_MULTIPLIER) && defined(INPUT_LEFT_SHIFT)
+    if(INPUT_MULTIPLIER > 1)
+    {
+        input_val_rescaled   = ASYMM_MULT(input_val_rescaled * (1 << INPUT_LEFT_SHIFT), INPUT_MULTIPLIER, 16);
+    }
+#endif /* defined(INPUT_MULTIPLIER) && defined(INPUT_LEFT_SHIFT) */
+
+    VEC_DATA_TYPE(int, 16) mask_if_positive   = ASYMM_MASK_IF_NON_ZERO(input_val_rescaled > CONST_0, 16);
+    VEC_DATA_TYPE(int, 16) mask_if_zero       = ASYMM_MASK_IF_NON_ZERO(!input_val_rescaled, 16);
+    VEC_DATA_TYPE(int, 16) abs_input          = ASYMM_SELECT_USING_MASK(mask_if_positive, input_val_rescaled, -input_val_rescaled, 16);
+    VEC_DATA_TYPE(int, 16) result_exp         = ASYMM_EXP_ON_NEGATIVE_VALUES(-abs_input, INPUT_INTEGER_BITS, 16);
+    VEC_DATA_TYPE(int, 16) result_if_positive = ASYMM_ONE_OVER_ONE_PLUS_X_FOR_X_IN_0_1(result_exp, 16);
+    VEC_DATA_TYPE(int, 16) result_if_negative = Q0_one - result_if_positive;
+    VEC_DATA_TYPE(int, 16) result_logistic    = ASYMM_SELECT_USING_MASK(mask_if_zero, Q0_one_half, ASYMM_SELECT_USING_MASK(mask_if_positive, result_if_positive, result_if_negative, 16), 16);
+
+    result_logistic = ASYMM_ROUNDING_DIVIDE_BY_POW2(result_logistic, 23, 16);
+    result_logistic = ASYMM_SELECT_USING_MASK(result_logistic == 256, 255, result_logistic, 16);
+    result_logistic = result_logistic * input_mask;
+
+    result = result_left + result_right + result_logistic;
+#endif /* defined(INPUT_INTEGER_BITS) && defined(INPUT_RANGE_RADIUS) */
+
+    // Store result
+    TYPE tmp = CONVERT(result, TYPE);
+    VSTORE(VEC_SIZE)
+    (tmp, 0, (__global DATA_TYPE *)output.ptr);
+}


### PR DESCRIPTION
This commit enables QASYMM8 in the LOGISTIC activation function.
The datatype of inputs and output must all be QASYMM8.

Signed-off-by: Jiyoung Yun <jy910.yun@samsung.com>