### PR TITLE
Patch for building

### DIFF
--- a/arm_compute/core/Size3D.h
+++ b/arm_compute/core/Size3D.h
@@ -40,7 +40,7 @@ public:
      * @param[in] h Height of the 3D shape or object
      * @param[in] d Depth of the 3D shape or object
      */
-    Size3D(size_t w, size_t h, size_t d)
+    Size3D(size_t w, size_t h, size_t d) noexcept
         : width(w), height(h), depth(d)
     {
     }

--- a/arm_compute/core/Types.h
+++ b/arm_compute/core/Types.h
@@ -772,7 +772,7 @@ private:
 /** Padding information for 3D operations like Conv3d */
 struct Padding3D
 {
-    Padding3D()
+    Padding3D() noexcept
     {
     }
 

--- a/src/cpu/kernels/conv3d/neon/list.h
+++ b/src/cpu/kernels/conv3d/neon/list.h
@@ -150,7 +150,7 @@ void directconv3d_float_neon_ndhwc(const ITensor *src0, const ITensor *src1, con
                         {
                             const auto src_vec = wrapper::vloadq(in_ptr_mover);
                             //Load Cin weights
-                            for(unsigned int k = 0; k < num_elems_read_per_iteration; ++k, weights_ptr_mover += index_c_out_end)
+                            for(int k = 0; k < num_elems_read_per_iteration; ++k, weights_ptr_mover += index_c_out_end)
                             {
                                 w_vec = wrapper::vsetlane(*weights_ptr_mover, w_vec, k);
                             }

--- a/src/cpu/kernels/conv3d/neon/quantized.h
+++ b/src/cpu/kernels/conv3d/neon/quantized.h
@@ -171,7 +171,7 @@ void directconv3d_quantized_neon_ndhwc(const ITensor *src0, const ITensor *src1,
                         {
                             const auto src_vec = wrapper::vloadq(in_ptr_mover);
                             //Load Cin weights
-                            for(unsigned int k = 0; k < num_elems_read_per_iteration; ++k, weights_ptr_mover += index_c_out_end)
+                            for(int k = 0; k < num_elems_read_per_iteration; ++k, weights_ptr_mover += index_c_out_end)
                             {
                                 w_vec = wrapper::vsetlane(*weights_ptr_mover, w_vec, k);
                             }


### PR DESCRIPTION
This patch solves the problems regarding the building on a Raspberry Pi 4 model B.
"noexcept" is added to "Size3D.h" and to "Types.h" following the solution in https://github.com/ARM-software/ComputeLibrary/issues/948 whereas I slightly change "list.h" and "quantized.h" for a type mismatch error respectively at lines 154 and 174, which does not modify the behavior of the code. It is just an index defined as "int" instead of "unsigned int".