### PR TITLE
Add missing headers for gcc v12.

### DIFF
--- a/include/libnpy/npy.hpp
+++ b/include/libnpy/npy.hpp
@@ -35,6 +35,7 @@
 #include <algorithm>
 #include <regex>
 #include <unordered_map>
+#include <iterator>
 
 
 namespace npy {

--- a/utils/command_line/CommandLineParser.h
+++ b/utils/command_line/CommandLineParser.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <cstring>
 
 namespace arm_compute
 {


### PR DESCRIPTION

A tiny fix for failing gcc v12 series.

Thank you.
~cristian.
