### PR TITLE
fix(build): Resolve linker error for `libarm_compute_graph.dylib` on macOS arm64(M4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ set_target_properties(
   INCLUDE_DIRECTORIES "${ARM_COMPUTE_GRAPH_INCLUDE}"
   LINK_LIBRARIES "${ARM_COMPUTE_LINK_LIBS}"
 )
+target_link_libraries(arm_compute_graph PUBLIC arm_compute)
 
 add_library(
   arm_compute


### PR DESCRIPTION
Fixes the "symbol(s) not found for architecture arm64" linker error on Apple Silicon.