### PR TITLE
perf: Add FP16 GEMM MMUL Reshaped Only Rhs Kernel

### DIFF
--- a/arm_compute/core/CL/CLHelpers.h
+++ b/arm_compute/core/CL/CLHelpers.h
@@ -276,6 +276,14 @@ void set_unroll_with_pragma(CLBuildOptions &built_opts, std::initializer_list<in
  */
 bool arm_matrix_multiply_supported(const cl::Device &device);
 
+/** Helper function to check whether the cl_arm_matrix_multiply with fp16 extension is supported
+ *
+ * @param[in] device A CL device
+ *
+ * @return True if the extension is supported
+ */
+bool arm_matrix_multiply_fp16_supported(const cl::Device &device);
+
 /** Check whether cl_khr_command_buffer extension is supported by the specified CL device.
  *
  * @param[in] device The CL device

--- a/arm_compute/core/CL/OpenCL.h
+++ b/arm_compute/core/CL/OpenCL.h
@@ -44,8 +44,8 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #if defined(__GNUG__) && __GNUG__ >= 8
 #pragma GCC diagnostic ignored "-Wcatch-value"
-#endif                   // defined(__GNUG__) && __GNUG__ >= 8
-#include <CL/opencl.hpp> // include new hpp header instead of cl2.hpp
+#endif // defined(__GNUG__) && __GNUG__ >= 8
+#include "arm_compute/core/CL/cl_definitions.h"
 #pragma GCC diagnostic pop
 
 namespace cl

--- a/arm_compute/core/CL/cl_definitions.h
+++ b/arm_compute/core/CL/cl_definitions.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Arm Limited.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef ACL_ARM_COMPUTE_CORE_CL_CL_DEFINITIONS_H
+#define ACL_ARM_COMPUTE_CORE_CL_CL_DEFINITIONS_H
+
+#include "include/CL/opencl.hpp"
+
+#define CL_DEVICE_MATRIX_MULTIPLY_FP16_WITH_FP16_ACCUMULATORS_ARM (1ULL << 0)
+#define CL_DEVICE_MATRIX_MULTIPLY_CAPABILITIES_ARM                0x41F4
+
+namespace cl
+{
+namespace detail
+{
+#ifdef CL_DEVICE_MATRIX_MULTIPLY_CAPABILITIES_ARM
+CL_HPP_DECLARE_PARAM_TRAITS_(cl_device_info, CL_DEVICE_MATRIX_MULTIPLY_CAPABILITIES_ARM, cl_ulong)
+#endif // CL_DEVICE_MATRIX_MULTIPLY_CAPABILITIES_ARM
+} // namespace detail
+} // namespace cl
+#endif // ACL_ARM_COMPUTE_CORE_CL_CL_DEFINITIONS_H

--- a/arm_compute/core/GPUTarget.h
+++ b/arm_compute/core/GPUTarget.h
@@ -69,6 +69,7 @@ enum class GPUTarget
     G615                = 0x351,
     G720                = 0x410,
     G620                = 0x411,
+    G1                  = 0x480
 
     // When new models are added, watch out for heuristics.
     // The default/unrecognized Gpu will be the latest one and

--- a/src/core/CL/CLHelpers.cpp
+++ b/src/core/CL/CLHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 Arm Limited.
+ * Copyright (c) 2016-2023, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -499,6 +499,21 @@ void set_unroll_with_pragma(CLBuildOptions &built_opts, std::initializer_list<in
 bool arm_matrix_multiply_supported(const cl::Device &device)
 {
     return device_supports_extension(device, "cl_arm_matrix_multiply");
+}
+
+bool arm_matrix_multiply_fp16_supported(const cl::Device &device)
+{
+    if (!arm_matrix_multiply_supported(device))
+    {
+        return false;
+    }
+
+    cl_ulong   caps = 0;
+    const auto err  = clGetDeviceInfo( //
+        device(), CL_DEVICE_MATRIX_MULTIPLY_CAPABILITIES_ARM, sizeof(caps), &caps, nullptr);
+
+    const auto supported = err == CL_SUCCESS && (caps & CL_DEVICE_MATRIX_MULTIPLY_FP16_WITH_FP16_ACCUMULATORS_ARM) != 0;
+    return supported;
 }
 
 bool command_buffer_supported(const cl::Device &device)

--- a/src/core/CL/cl_kernels/common/gemm_reshaped_only_rhs_mmul.cl
+++ b/src/core/CL/cl_kernels/common/gemm_reshaped_only_rhs_mmul.cl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Arm Limited.
+ * Copyright (c) 2022-2023, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -24,6 +24,8 @@
 #include "activation_float_helpers.h"
 #include "helpers.h"
 #include "tile_helpers.h"
+
+#define SHIFT_BACK(IDX, N0, PARTIAL_N0) (max((int)((IDX) * N0 - (N0 - PARTIAL_N0) % N0), 0))
 
 #if defined(GEMM_MM_RESHAPED_ONLY_RHS_NT_MMUL)
 /** This OpenCL kernel computes the matrix multiplication between 2 matrices using the MMUL extension:
@@ -219,7 +221,7 @@ __kernel void gemm_mm_reshaped_only_rhs_nt_mmul(
 
 #ifndef UNIT_BETA
     T_SCALE_CONSTANT(DATA_TYPE, 1, N0, bias0, (DATA_TYPE)BETA, bias0);
-#endif // UNIT_BIAS
+#endif // UNIT_BETA
 
     // c = c + bias[broadcasted]
     T_ELTWISE_BROADCAST_X(V_ADD, DATA_TYPE, M0, N0, c, bias0, c);
@@ -252,7 +254,7 @@ __kernel void gemm_mm_reshaped_only_rhs_nt_mmul(
 
 #ifndef UNIT_BETA
     T_SCALE_CONSTANT(DATA_TYPE, M0, N0, bias0, (DATA_TYPE)BETA, bias0);
-#endif // UNIT_BIAS
+#endif // UNIT_BETA
 
     // c = c + bias
     T_ADD(DATA_TYPE, M0, N0, c, bias0, c);
@@ -285,12 +287,307 @@ __kernel void gemm_mm_reshaped_only_rhs_nt_mmul(
             }
         })
     }
-
-#undef RHS_BLOCK_SIZE
-#undef RHS_OFFSET_X
-#undef RHS_STEP_X
 }
 #endif // defined(GEMM_MM_RESHAPED_ONLY_RHS_MMUL)
+
+#if defined(GEMM_MM_RESHAPED_ONLY_RHS_NT_MMUL_FP16)
+/** This OpenCL kernel computes the matrix multiplication between 2 matrices using the MMUL extension:
+ *
+ *  The LHS matrix is NOT reshaped
+ *  The RHS is reshaped with @ref ClGemmMatrixMultiplyReshapedOnlyRhsKernel and the block K0xN0 is NOT transposed
+ *
+ * @note The block's dimensions used for reshaping the RHS matrix (N0 and K0) must be passed at compile time using -DN0 and -DK0 (e.g. -DN0=8, -DK0=4).
+ * @note The number of M0 rows to process must be passed at compile time using -DM0 (e.g. -DM0=2)
+ * @note The number of output columns processed by the the cooperative mmul extension must be passed at compile time using -DMMUL_N0 (e.g., -DMMUL_N0=2)
+ * @note The number of output rows processed by the the cooperative mmul extension must be passed at compile time using -DMMUL_M0 (e.g., -DMMUL_M0=2)
+ * @note The number of lhs columns (or rhs rows) processed by the the cooperative mmul extension must be passed at compile time using -DMMUL_K0 (e.g., -DMMUL_K0=2)
+ * @note Only the following configurations of M0, N0 and K0 are currently supported:
+ *  - M0 > 0
+ *  - N0 = 2, 4, 8, 16
+ *  - K0 = 1
+ *
+ * @note If the activation type were passed at compile time through -DACTIVATION_TYPE (e.g. -DACTIVATION_TYPE=RELU), A, B variables, required by some activation functions, should be passed at compile time as well using -DA_VAL= and -DB_VAL= respectively.
+ *       The activation function is performed after the bias addition
+ *
+ * @param[in]  lhs_ptr                           Pointer to the LHS tensor. Supported data types: F16
+ * @param[in]  lhs_stride_y                      Stride of the LHS tensor in Y dimension (in bytes)
+ * @param[in]  lhs_stride_z                      Stride of the LHS tensor in Z dimension (in bytes)
+ * @param[in]  lhs_w                             The size of the width dimension of the LHS tensor
+ * @param[in]  lhs_h                             The size of the height dimension of the LHS tensor
+ * @param[in]  lhs_n                             The size of the depth dimension of the LHS tensor
+ * @param[in]  lhs_offset_first_element_in_bytes The offset of the first element in the LHS tensor
+ * @param[in]  rhs_ptr                           Pointer to the RHS reshaped tensor. Supported data type: same as @p lhs_ptr
+ * @param[in]  rhs_stride_y                      Stride of the RHS tensor in Y dimension (in bytes)
+ * @param[in]  rhs_stride_z                      Stride of the RHS tensor in Z dimension (in bytes)
+ * @param[in]  rhs_w                             The size of the width dimension of the RHS tensor
+ * @param[in]  rhs_h                             The size of the height dimension of the RHS tensor
+ * @param[in]  rhs_n                             The size of the depth dimension of the RHS tensor
+ * @param[in]  rhs_offset_first_element_in_bytes The offset of the first element in the RHS tensor
+ * @param[in]  bia_ptr                           (Optional) Pointer to the bias tensor. Supported data type: same as @p lhs_ptr
+ * @param[in]  bia_stride_y                      (Optional) Stride of the bias tensor in Y dimension (in bytes)
+ * @param[in]  bia_stride_z                      (Optional) Stride of the bias tensor in Z dimension (in bytes)
+ * @param[in]  bia_w                             (Optional) The size of the width dimension of the bias tensor
+ * @param[in]  bia_h                             (Optional) The size of the height dimension of the bias tensor
+ * @param[in]  bia_n                             (Optional) The size of the depth dimension of the bias tensor
+ * @param[in]  bia_offset_first_element_in_bytes (Optional) The offset of the first element in the bias tensor
+ * @param[out] dst_ptr                           Pointer to the destination tensor. Supported data type: same as @p lhs_ptr
+ * @param[in]  dst_stride_y                      Stride of the destination tensor in Y dimension (in bytes)
+ * @param[in]  dst_stride_z                      Stride of the destination tensor in Z dimension (in bytes)
+ * @param[in]  dst_w                             The size of the width dimension of the destination tensor
+ * @param[in]  dst_h                             The size of the height dimension of the destination tensor
+ * @param[in]  dst_n                             The size of the depth dimension of the destination tensor
+ * @param[in]  dst_offset_first_element_in_bytes The offset of the first element in the destination tensor
+ * @param[in]  M                                 Number of rows in LHS matrix not reshaped
+ * @param[in]  N                                 Number of columns in RHS matrix not reshaped
+ * @param[in]  K                                 Number of columns in LHS matrix and rows in RHS matrix not reshaped
+ */
+__kernel void gemm_mm_reshaped_only_rhs_nt_mmul_fp16(
+    TENSOR3D_T(lhs, BUFFER),
+    TENSOR3D_T(rhs, BUFFER),
+#if defined(BETA)
+    TENSOR3D_T(bia, BUFFER),
+#endif // defined(BETA)
+    TENSOR3D_T(dst, BUFFER),
+    const int M,
+    const int N,
+    const int K)
+{
+#if(N0 != 2 && N0 != 4 && N0 != 8 && N0 != 16)
+#error "N0 can only be 2,4,8,16"
+#endif
+
+#if(K0 != 1)
+#error "K0 can only be 1"
+#endif
+
+#define MMUL_BLOCK_SIZE (MMUL_N0 * MMUL_M0)
+
+    const uint x0 = get_global_id(0); // (N / N0) / MMUL_N0 * MMUL_BLOCK_SIZE
+    const uint y0 = get_global_id(1); // (M / M0) / MMUL_M0
+    const uint z  = get_global_id(2); // Batch
+
+    // Get block ID and thread ID within the block
+    const uint block_id  = (x0 / MMUL_BLOCK_SIZE);
+    const uint thread_id = (x0 % MMUL_BLOCK_SIZE);
+
+    // Coordinate within a block
+    const uint block_x = (thread_id % MMUL_N0);
+    const uint block_y = (thread_id / MMUL_M0);
+
+    // Starting destination coordinates
+    const uint x = block_x + block_id * MMUL_N0;
+    const uint y = block_y + y0 * MMUL_M0;
+
+    uint dst_y = SHIFT_BACK(y, M0, M0_LEFTOVER);
+    uint dst_x = SHIFT_BACK(x, N0, 0);
+
+    // Note: We need to clamp dst_x and dst_y because we always need to execute a complete MMUL block! Only after the matrix multiplication
+    // part can we exit the kernel if it is out-of-bound. Remember, we have a cooperative matrix multiplication. Therefore, we need a full block to get the correct results
+
+    uint lhs_x = (block_x % 2) * 2; // 2 is required for MATMUL FP16 acc.
+    uint lhs_y = min(dst_y, (uint)(M - M0)); // It can go out-of-bound for M0=1 and M0 > 1
+
+    // Starting RHS coordinates
+    // We cannot have out-of-bound memory accesses for RHS
+    uint rhs_x = block_y * N0 * MMUL_N0 + block_x * N0;
+    uint rhs_y = block_id;
+
+    // Compute LHS/RHS/DST matrix address
+    lhs_offset_first_element_in_bytes += lhs_x * sizeof(DATA_TYPE) + lhs_y * lhs_stride_y + z * lhs_stride_z;
+    rhs_offset_first_element_in_bytes += rhs_x * sizeof(DATA_TYPE) + rhs_y * rhs_stride_y + z * rhs_stride_z;
+    dst_offset_first_element_in_bytes += dst_x * sizeof(DATA_TYPE) + dst_y * dst_stride_y + z * dst_stride_z;
+
+    // Note: If RHS derives from the weights of convolution 2d layer, RHS will always be 2D and rhs_stride_z will always be equal to 0 for
+    // not sliding the tensor
+
+    // Initialize the accumulators
+
+    TILE(DATA_TYPE, M0, N0, c);
+
+    LOOP_UNROLLING(int, i, 0, 1, M0,
+    {
+        c[i].v = 0;
+    })
+
+    // --------------------------------------------------
+    // Matrix multiplication
+    // --------------------------------------------------
+    int k = 0;
+    for(; k <= K - MMUL_K0; k += MMUL_K0)
+    {
+        TILE(DATA_TYPE, M0, 2, a);
+        TILE(DATA_TYPE, 1, N0, b);
+
+        // Load tile from the lhs/rhs tensors
+        T_LOAD(DATA_TYPE, M0, 2, BUFFER, lhs, 0, 0, 1, lhs_stride_y, a);
+        T_LOAD(DATA_TYPE, 1, N0, BUFFER, rhs, 0, 0, 1, rhs_stride_y, b);
+
+        LOOP_UNROLLING(int, m0, 0, 1, M0,
+        {
+#if N0 == 2
+            c[m0].v = arm_matrix_multiply_af0(a[m0].v, b[0].v, c[m0].v);
+#endif
+
+#if N0 == 4
+            c[m0].v.s01 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s01, c[m0].v.s01);
+            c[m0].v.s23 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s23, c[m0].v.s23);
+#endif
+
+#if N0 == 8
+            c[m0].v.s01 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s01, c[m0].v.s01);
+            c[m0].v.s23 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s23, c[m0].v.s23);
+            c[m0].v.s45 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s45, c[m0].v.s45);
+            c[m0].v.s67 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s67, c[m0].v.s67);
+#endif
+
+#if N0 == 16
+            c[m0].v.s01 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s01, c[m0].v.s01);
+            c[m0].v.s23 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s23, c[m0].v.s23);
+            c[m0].v.s45 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s45, c[m0].v.s45);
+            c[m0].v.s67 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s67, c[m0].v.s67);
+            c[m0].v.s89 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s89, c[m0].v.s89);
+            c[m0].v.sab = arm_matrix_multiply_af0(a[m0].v, b[0].v.sab, c[m0].v.sab);
+            c[m0].v.scd = arm_matrix_multiply_af0(a[m0].v, b[0].v.scd, c[m0].v.scd);
+            c[m0].v.sef = arm_matrix_multiply_af0(a[m0].v, b[0].v.sef, c[m0].v.sef);
+#endif
+
+        })
+        lhs_offset_first_element_in_bytes += MMUL_K0 * sizeof(DATA_TYPE);
+        rhs_offset_first_element_in_bytes += MMUL_BLOCK_SIZE * N0 * sizeof(DATA_TYPE);
+    }
+
+    // Return immediately if dst_x and dst_y are out-of-bound
+    if(dst_x >= N)
+    {
+        return;
+    }
+
+    if(dst_y >= M)
+    {
+        return;
+    }
+
+    // --------------------------------------------------
+    // Apply alpha (weight of matrix-matrix product)
+    // --------------------------------------------------
+
+    // Multiply by the weight of matrix-matrix product and store the result
+#if defined(ALPHA)
+    T_SCALE_CONSTANT(DATA_TYPE, M0, N0, c, (DATA_TYPE)ALPHA, c);
+#endif // defined(ALPHA)
+
+    // --------------------------------------------------
+    // Add beta * bias
+    // --------------------------------------------------
+
+#if defined(BETA)
+#if defined(BROADCAST_BIAS)
+    TILE(DATA_TYPE, 1, N0, bias0);
+
+    bia_offset_first_element_in_bytes += dst_x * sizeof(DATA_TYPE);
+
+    if(dst_x + N0 <= N || N0_LEFTOVER == 0)
+    {
+        bias0[0].v = VLOAD(N0)(0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes));
+    }
+    else
+    {
+        VLOAD_PARTIAL(N0, N0_LEFTOVER)
+        (bias0[0].v, 0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes));
+    }
+
+#ifndef UNIT_BETA
+    T_SCALE_CONSTANT(DATA_TYPE, 1, N0, bias0, (DATA_TYPE)BETA, bias0);
+#endif // UNIT_BETA
+
+    // c = c + bias[broadcasted]
+    T_ELTWISE_BROADCAST_X(V_ADD, DATA_TYPE, M0, N0, c, bias0, c);
+#else // defined(BROADCAST_BIAS)
+    TILE(DATA_TYPE, M0, N0, bias0);
+
+    bia_offset_first_element_in_bytes += dst_x * sizeof(DATA_TYPE) + dst_y * bia_stride_y + z * bia_stride_z;
+
+    if(dst_x + N0 <= N || N0_LEFTOVER == 0)
+    {
+        LOOP_UNROLLING(int, m0, 0, 1, M0,
+        {
+            if(dst_y + m0 < M || M0_LEFTOVER == 0)
+            {
+                bias0[m0].v = VLOAD(N0)(0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes + m0 * bia_stride_y));
+            }
+        })
+    }
+    else
+    {
+        LOOP_UNROLLING(int, m0, 0, 1, M0,
+        {
+            if(dst_y + m0 < M || M0_LEFTOVER == 0)
+            {
+                VLOAD_PARTIAL(N0, N0_LEFTOVER)
+                (bias0[m0].v, 0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes + m0 * bia_stride_y));
+            }
+        })
+    }
+
+#ifndef UNIT_BETA
+    T_SCALE_CONSTANT(DATA_TYPE, M0, N0, bias0, (DATA_TYPE)BETA, bias0);
+#endif // UNIT_BETA
+
+    // c = c + bias
+    T_ADD(DATA_TYPE, M0, N0, c, bias0, c);
+#endif // defined(BROADCAST_BIAS)
+#endif // defined(BETA)
+
+    // --------------------------------------------------
+    // Apply activation function
+    // --------------------------------------------------
+    T_ACTIVATION(DATA_TYPE, M0, N0, ACTIVATION_TYPE, A_VAL, B_VAL, c, c);
+    // --------------------------------------------------
+
+    // --------------------------------------------------
+    // Store
+    // --------------------------------------------------
+
+    if(dst_x + N0 <= N || N0_LEFTOVER == 0)
+    {
+        if(dst_y + M0 <= M || M0_LEFTOVER == 0)
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0,
+            {
+                VSTORE(N0)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+        else
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0_LEFTOVER,
+            {
+                VSTORE(N0)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+    }
+    else
+    {
+        if(dst_y + M0 <= M || M0_LEFTOVER == 0)
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0,
+            {
+                VSTORE_PARTIAL(N0, N0_LEFTOVER)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+        else
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0_LEFTOVER,
+            {
+                VSTORE_PARTIAL(N0, N0_LEFTOVER)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+    }
+}
+#endif // defined(GEMM_MM_RESHAPED_ONLY_RHS_MMUL_FP16)
 
 #if defined(GEMM_MM_RESHAPED_ONLY_RHS_NT_MMUL_TEXTURE)
 /** This OpenCL kernel computes the matrix multiplication between 2 matrices using the MMUL extension and the OpenCL image for RHS:
@@ -318,6 +615,7 @@ __kernel void gemm_mm_reshaped_only_rhs_nt_mmul(
  * @param[in]  lhs_h                             The size of the height dimension of the LHS tensor
  * @param[in]  lhs_n                             The size of the depth dimension of the LHS tensor
  * @param[in]  lhs_offset_first_element_in_bytes The offset of the first element in the LHS tensor
+ * @param[in]  rhs_img                           The RHS reshaped tensor as OpenCL image object. Supported data type: same as @p lhs_ptr
  * @param[in]  rhs_ptr                           Pointer to the RHS reshaped tensor. Supported data type: same as @p lhs_ptr
  * @param[in]  rhs_stride_y                      Stride of the RHS tensor in Y dimension (in bytes)
  * @param[in]  rhs_stride_z                      Stride of the RHS tensor in Z dimension (in bytes)
@@ -482,7 +780,7 @@ __kernel void gemm_mm_reshaped_only_rhs_nt_mmul_texture(
 
 #ifndef UNIT_BETA
     T_SCALE_CONSTANT(DATA_TYPE, 1, N0, bias0, (DATA_TYPE)BETA, bias0);
-#endif // UNIT_BIAS
+#endif // UNIT_BETA
 
     // c = c + bias[broadcasted]
     T_ELTWISE_BROADCAST_X(V_ADD, DATA_TYPE, M0, N0, c, bias0, c);
@@ -515,7 +813,7 @@ __kernel void gemm_mm_reshaped_only_rhs_nt_mmul_texture(
 
 #ifndef UNIT_BETA
     T_SCALE_CONSTANT(DATA_TYPE, M0, N0, bias0, (DATA_TYPE)BETA, bias0);
-#endif // UNIT_BIAS
+#endif // UNIT_BETA
 
     // c = c + bias
     T_ADD(DATA_TYPE, M0, N0, c, bias0, c);
@@ -548,9 +846,304 @@ __kernel void gemm_mm_reshaped_only_rhs_nt_mmul_texture(
             }
         })
     }
-
-#undef RHS_BLOCK_SIZE
-#undef RHS_OFFSET_X
-#undef RHS_STEP_X
 }
 #endif // defined(GEMM_MM_RESHAPED_ONLY_RHS_MMUL_TEXTURE)
+
+#if defined(GEMM_MM_RESHAPED_ONLY_RHS_NT_MMUL_TEXTURE_FP16)
+/** This OpenCL kernel computes the matrix multiplication between 2 matrices using the MMUL extension:
+ *
+ *  The LHS matrix is NOT reshaped
+ *  The RHS is reshaped with @ref ClGemmMatrixMultiplyReshapedOnlyRhsKernel and the block K0xN0 is NOT transposed
+ *
+ * @note The block's dimensions used for reshaping the RHS matrix (N0 and K0) must be passed at compile time using -DN0 and -DK0 (e.g. -DN0=8, -DK0=4).
+ * @note The number of M0 rows to process must be passed at compile time using -DM0 (e.g. -DM0=2)
+ * @note The number of output columns processed by the the cooperative mmul extension must be passed at compile time using -DMMUL_N0 (e.g., -DMMUL_N0=2)
+ * @note The number of output rows processed by the the cooperative mmul extension must be passed at compile time using -DMMUL_M0 (e.g., -DMMUL_M0=2)
+ * @note The number of lhs columns (or rhs rows) processed by the the cooperative mmul extension must be passed at compile time using -DMMUL_K0 (e.g., -DMMUL_K0=2)
+ * @note Only the following configurations of M0, N0 and K0 are currently supported:
+ *  - M0 > 0
+ *  - N0 = 2, 4, 8, 16
+ *  - K0 = 1
+ *
+ * @note If the activation type were passed at compile time through -DACTIVATION_TYPE (e.g. -DACTIVATION_TYPE=RELU), A, B variables, required by some activation functions, should be passed at compile time as well using -DA_VAL= and -DB_VAL= respectively.
+ *       The activation function is performed after the bias addition
+ *
+ * @param[in]  lhs_ptr                           Pointer to the LHS tensor. Supported data types: F16
+ * @param[in]  lhs_stride_y                      Stride of the LHS tensor in Y dimension (in bytes)
+ * @param[in]  lhs_stride_z                      Stride of the LHS tensor in Z dimension (in bytes)
+ * @param[in]  lhs_w                             The size of the width dimension of the LHS tensor
+ * @param[in]  lhs_h                             The size of the height dimension of the LHS tensor
+ * @param[in]  lhs_n                             The size of the depth dimension of the LHS tensor
+ * @param[in]  lhs_offset_first_element_in_bytes The offset of the first element in the LHS tensor
+ * @param[in]  rhs_img                           The RHS reshaped tensor as OpenCL image object. Supported data type: same as @p lhs_ptr
+ * @param[in]  rhs_ptr                           Pointer to the RHS reshaped tensor. Supported data type: same as @p lhs_ptr
+ * @param[in]  rhs_stride_y                      Stride of the RHS tensor in Y dimension (in bytes)
+ * @param[in]  rhs_stride_z                      Stride of the RHS tensor in Z dimension (in bytes)
+ * @param[in]  rhs_w                             The size of the width dimension of the RHS tensor
+ * @param[in]  rhs_h                             The size of the height dimension of the RHS tensor
+ * @param[in]  rhs_n                             The size of the depth dimension of the RHS tensor
+ * @param[in]  rhs_offset_first_element_in_bytes The offset of the first element in the RHS tensor
+ * @param[in]  bia_ptr                           (Optional) Pointer to the bias tensor. Supported data type: same as @p lhs_ptr
+ * @param[in]  bia_stride_y                      (Optional) Stride of the bias tensor in Y dimension (in bytes)
+ * @param[in]  bia_stride_z                      (Optional) Stride of the bias tensor in Z dimension (in bytes)
+ * @param[in]  bia_w                             (Optional) The size of the width dimension of the bias tensor
+ * @param[in]  bia_h                             (Optional) The size of the height dimension of the bias tensor
+ * @param[in]  bia_n                             (Optional) The size of the depth dimension of the bias tensor
+ * @param[in]  bia_offset_first_element_in_bytes (Optional) The offset of the first element in the bias tensor
+ * @param[out] dst_ptr                           Pointer to the destination tensor. Supported data type: same as @p lhs_ptr
+ * @param[in]  dst_stride_y                      Stride of the destination tensor in Y dimension (in bytes)
+ * @param[in]  dst_stride_z                      Stride of the destination tensor in Z dimension (in bytes)
+ * @param[in]  dst_w                             The size of the width dimension of the destination tensor
+ * @param[in]  dst_h                             The size of the height dimension of the destination tensor
+ * @param[in]  dst_n                             The size of the depth dimension of the destination tensor
+ * @param[in]  dst_offset_first_element_in_bytes The offset of the first element in the destination tensor
+ * @param[in]  M                                 Number of rows in LHS matrix not reshaped
+ * @param[in]  N                                 Number of columns in RHS matrix not reshaped
+ * @param[in]  K                                 Number of columns in LHS matrix and rows in RHS matrix not reshaped
+ */
+__kernel void gemm_mm_reshaped_only_rhs_nt_mmul_texture_fp16(
+    TENSOR3D_T(lhs, BUFFER),
+    TENSOR3D_T(rhs, IMAGE),
+#if defined(BETA)
+    TENSOR3D_T(bia, BUFFER),
+#endif // defined(BETA)
+    TENSOR3D_T(dst, BUFFER),
+    const int M,
+    const int N,
+    const int K)
+{
+#if(N0 != 2 && N0 != 4 && N0 != 8 && N0 != 16)
+#error "N0 can only be 2,4,8,16"
+#endif
+
+#if(K0 != 1)
+#error "K0 can only be 1"
+#endif
+
+#define MMUL_BLOCK_SIZE (MMUL_N0 * MMUL_M0)
+
+    const uint x0 = get_global_id(0); // (N / N0) / MMUL_N0 * MMUL_BLOCK_SIZE
+    const uint y0 = get_global_id(1); // (M / M0) / MMUL_M0
+    const uint z  = get_global_id(2); // Batch
+
+    // Get block ID and thread ID within the block
+    const uint block_id  = (x0 / MMUL_BLOCK_SIZE);
+    const uint thread_id = (x0 % MMUL_BLOCK_SIZE);
+
+    // Coordinate within a block
+    const uint block_x = (thread_id % MMUL_N0);
+    const uint block_y = (thread_id / MMUL_M0);
+
+    // Starting destination coordinates
+    const uint x = block_x + block_id * MMUL_N0;
+    const uint y = block_y + y0 * MMUL_M0;
+
+    uint dst_y = SHIFT_BACK(y, M0, M0_LEFTOVER);
+    uint dst_x = SHIFT_BACK(x, N0, 0);
+
+    // Note: We need to clamp dst_x and dst_y because we always need to execute a complete MMUL block! Only after the matrix multiplication
+    // part can we exit the kernel if it is out-of-bound. Remember, we have a cooperative matrix multiplication. Therefore, we need a full block to get the correct results
+
+    uint lhs_x = (block_x % 2) * 2; // 2 is required for MATMUL FP16 acc.
+    uint lhs_y = min(dst_y, (uint)(M - M0)); // It can go out-of-bound for M0=1 and M0 > 1
+
+    // Starting RHS coordinates
+    // We cannot have out-of-bound memory accesses for RHS
+    uint rhs_x = block_y * N0 * MMUL_N0 + block_x * N0;
+    uint rhs_y = block_id + z * rhs_h;
+
+    // Compute LHS/RHS/DST matrix address
+    lhs_offset_first_element_in_bytes += lhs_x * sizeof(DATA_TYPE) + lhs_y * lhs_stride_y + z * lhs_stride_z;
+    dst_offset_first_element_in_bytes += dst_x * sizeof(DATA_TYPE) + dst_y * dst_stride_y + z * dst_stride_z;
+
+    // Note: If RHS derives from the weights of convolution 2d layer, RHS will always be 2D and rhs_stride_z will always be equal to 0 for
+    // not sliding the tensor
+
+    // Initialize the accumulators
+
+    TILE(DATA_TYPE, M0, N0, c);
+
+    LOOP_UNROLLING(int, i, 0, 1, M0,
+    {
+        c[i].v = 0;
+    })
+
+    // --------------------------------------------------
+    // Matrix multiplication
+    // --------------------------------------------------
+    int k = 0;
+    for(; k <= K - MMUL_K0; k += MMUL_K0)
+    {
+        TILE(DATA_TYPE, M0, 2, a);
+        TILE(DATA_TYPE, 1, N0, b);
+
+        // Load tile from the lhs/rhs tensors
+        T_LOAD(DATA_TYPE, M0, 2, BUFFER, lhs, 0, 0, 1, lhs_stride_y, a);
+        T_LOAD(DATA_TYPE, 1, N0, IMAGE, rhs, rhs_x, rhs_y, 1, rhs_stride_y, b);
+
+        LOOP_UNROLLING(int, m0, 0, 1, M0,
+        {
+#if N0 == 2
+            c[m0].v = arm_matrix_multiply_af0(a[m0].v, b[0].v, c[m0].v);
+#endif
+
+#if N0 == 4
+            c[m0].v.s01 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s01, c[m0].v.s01);
+            c[m0].v.s23 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s23, c[m0].v.s23);
+#endif
+
+#if N0 == 8
+            c[m0].v.s01 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s01, c[m0].v.s01);
+            c[m0].v.s23 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s23, c[m0].v.s23);
+            c[m0].v.s45 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s45, c[m0].v.s45);
+            c[m0].v.s67 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s67, c[m0].v.s67);
+#endif
+
+#if N0 == 16
+            c[m0].v.s01 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s01, c[m0].v.s01);
+            c[m0].v.s23 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s23, c[m0].v.s23);
+            c[m0].v.s45 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s45, c[m0].v.s45);
+            c[m0].v.s67 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s67, c[m0].v.s67);
+            c[m0].v.s89 = arm_matrix_multiply_af0(a[m0].v, b[0].v.s89, c[m0].v.s89);
+            c[m0].v.sab = arm_matrix_multiply_af0(a[m0].v, b[0].v.sab, c[m0].v.sab);
+            c[m0].v.scd = arm_matrix_multiply_af0(a[m0].v, b[0].v.scd, c[m0].v.scd);
+            c[m0].v.sef = arm_matrix_multiply_af0(a[m0].v, b[0].v.sef, c[m0].v.sef);
+#endif
+
+        })
+        lhs_offset_first_element_in_bytes += MMUL_K0 * sizeof(DATA_TYPE);
+        rhs_x += MMUL_BLOCK_SIZE * N0;
+    }
+
+    // Return immediately if dst_x and dst_y are out-of-bound
+    if(dst_x >= N)
+    {
+        return;
+    }
+
+    if(dst_y >= M)
+    {
+        return;
+    }
+
+    // --------------------------------------------------
+    // Apply alpha (weight of matrix-matrix product)
+    // --------------------------------------------------
+
+    // Multiply by the weight of matrix-matrix product and store the result
+#if defined(ALPHA)
+    T_SCALE_CONSTANT(DATA_TYPE, M0, N0, c, (DATA_TYPE)ALPHA, c);
+#endif // defined(ALPHA)
+
+    // --------------------------------------------------
+    // Add beta * bias
+    // --------------------------------------------------
+
+#if defined(BETA)
+#if defined(BROADCAST_BIAS)
+    TILE(DATA_TYPE, 1, N0, bias0);
+
+    bia_offset_first_element_in_bytes += dst_x * sizeof(DATA_TYPE);
+
+    if(dst_x + N0 <= N || N0_LEFTOVER == 0)
+    {
+        bias0[0].v = VLOAD(N0)(0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes));
+    }
+    else
+    {
+        VLOAD_PARTIAL(N0, N0_LEFTOVER)
+        (bias0[0].v, 0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes));
+    }
+
+#ifndef UNIT_BETA
+    T_SCALE_CONSTANT(DATA_TYPE, 1, N0, bias0, (DATA_TYPE)BETA, bias0);
+#endif // UNIT_BETA
+
+    // c = c + bias[broadcasted]
+    T_ELTWISE_BROADCAST_X(V_ADD, DATA_TYPE, M0, N0, c, bias0, c);
+#else // defined(BROADCAST_BIAS)
+    TILE(DATA_TYPE, M0, N0, bias0);
+
+    bia_offset_first_element_in_bytes += dst_x * sizeof(DATA_TYPE) + dst_y * bia_stride_y + z * bia_stride_z;
+
+    if(dst_x + N0 <= N || N0_LEFTOVER == 0)
+    {
+        LOOP_UNROLLING(int, m0, 0, 1, M0,
+        {
+            if(dst_y + m0 < M || M0_LEFTOVER == 0)
+            {
+                bias0[m0].v = VLOAD(N0)(0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes + m0 * bia_stride_y));
+            }
+        })
+    }
+    else
+    {
+        LOOP_UNROLLING(int, m0, 0, 1, M0,
+        {
+            if(dst_y + m0 < M || M0_LEFTOVER == 0)
+            {
+                VLOAD_PARTIAL(N0, N0_LEFTOVER)
+                (bias0[m0].v, 0, (DATA_TYPE *)(bia_ptr + bia_offset_first_element_in_bytes + m0 * bia_stride_y));
+            }
+        })
+    }
+
+#ifndef UNIT_BETA
+    T_SCALE_CONSTANT(DATA_TYPE, M0, N0, bias0, (DATA_TYPE)BETA, bias0);
+#endif // UNIT_BETA
+
+    // c = c + bias
+    T_ADD(DATA_TYPE, M0, N0, c, bias0, c);
+#endif // defined(BROADCAST_BIAS)
+#endif // defined(BETA)
+
+    // --------------------------------------------------
+    // Apply activation function
+    // --------------------------------------------------
+    T_ACTIVATION(DATA_TYPE, M0, N0, ACTIVATION_TYPE, A_VAL, B_VAL, c, c);
+    // --------------------------------------------------
+
+    // --------------------------------------------------
+    // Store
+    // --------------------------------------------------
+
+    if(dst_x + N0 <= N || N0_LEFTOVER == 0)
+    {
+        if(dst_y + M0 <= M || M0_LEFTOVER == 0)
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0,
+            {
+                VSTORE(N0)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+        else
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0_LEFTOVER,
+            {
+                VSTORE(N0)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+    }
+    else
+    {
+        if(dst_y + M0 <= M || M0_LEFTOVER == 0)
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0,
+            {
+                VSTORE_PARTIAL(N0, N0_LEFTOVER)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+        else
+        {
+            LOOP_UNROLLING(int, m0, 0, 1, M0_LEFTOVER,
+            {
+                VSTORE_PARTIAL(N0, N0_LEFTOVER)
+                (c[m0].v, 0, (__global DATA_TYPE *)(dst_ptr + dst_offset_first_element_in_bytes + m0 * dst_stride_y));
+            })
+        }
+    }
+}
+#endif // defined(GEMM_MM_RESHAPED_ONLY_RHS_MMUL_TEXTURE_FP16)

--- a/src/core/CL/cl_kernels/tile_helpers.h
+++ b/src/core/CL/cl_kernels/tile_helpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024 Arm Limited.
+ * Copyright (c) 2021-2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -193,6 +193,7 @@
 #if !defined(UNROLL_WITH_PRAGMA)
 #define UNROLL_INCR(idx, step, macro) idx += (step); (macro)
 
+#define LOOP_UNROLLING_0(idx, step, macro) ;
 #define LOOP_UNROLLING_1(idx, step, macro) (macro)
 #define LOOP_UNROLLING_2(idx, step, macro) LOOP_UNROLLING_1(idx, step, macro); UNROLL_INCR(idx, step, macro)
 #define LOOP_UNROLLING_3(idx, step, macro) LOOP_UNROLLING_2(idx, step, macro); UNROLL_INCR(idx, step, macro)

--- a/src/core/GPUTarget.cpp
+++ b/src/core/GPUTarget.cpp
@@ -68,6 +68,9 @@ GPUTarget get_gpu_target(const std::string &full_name, const std::string &base_n
         {"G620", GPUTarget::G620},            //
         {"G720", GPUTarget::G720},            //
         {"Immortalis-G720", GPUTarget::G720}, //
+        {"G1-Pro", GPUTarget::G1},            //
+        {"G1-Premium", GPUTarget::G1},        //
+        {"G1-Ultra", GPUTarget::G1},
 
     };
     // Try full name with variant.
@@ -104,26 +107,34 @@ GPUTarget get_gpu_target(const std::string &full_name, const std::string &base_n
 const std::string &string_from_target(GPUTarget target)
 {
     static std::map<GPUTarget, const std::string> gpu_target_map = {
-        {GPUTarget::MIDGARD, "midgard"},  {GPUTarget::BIFROST, "bifrost"}, {GPUTarget::VALHALL, "valhall"},
-        {GPUTarget::FIFTHGEN, "5th Gen"},
+        {GPUTarget::MIDGARD, "midgard"}, {GPUTarget::BIFROST, "bifrost"},
+        {GPUTarget::VALHALL, "valhall"}, {GPUTarget::FIFTHGEN, "5th Gen"},
 
-        {GPUTarget::T600, "t600"},        {GPUTarget::T700, "t700"},       {GPUTarget::T800, "t800"},
-        {GPUTarget::G71, "g71"},          {GPUTarget::G72, "g72"},         {GPUTarget::G51, "g51"},
-        {GPUTarget::G51BIG, "g51big"},    {GPUTarget::G51LIT, "g51lit"},   {GPUTarget::G31, "g31"},
-        {GPUTarget::G76, "g76"},          {GPUTarget::G52, "g52"},         {GPUTarget::G52LIT, "g52lit"},
-        {GPUTarget::G77, "g77"},          {GPUTarget::G57, "g57"},         {GPUTarget::G78, "g78"},
-        {GPUTarget::G68, "g68"},          {GPUTarget::G78AE, "g78ae"},     {GPUTarget::G710, "g710"},
-        {GPUTarget::G610, "g610"},        {GPUTarget::G510, "g510"},       {GPUTarget::G310, "g310"},
-        {GPUTarget::G715, "g715"},        {GPUTarget::G615, "g615"},       {GPUTarget::G720, "g720"},
-        {GPUTarget::G620, "g620"}};
+        {GPUTarget::T600, "t600"},       {GPUTarget::T700, "t700"},
+        {GPUTarget::T800, "t800"},       {GPUTarget::G71, "g71"},
+        {GPUTarget::G72, "g72"},         {GPUTarget::G51, "g51"},
+        {GPUTarget::G51BIG, "g51big"},   {GPUTarget::G51LIT, "g51lit"},
+        {GPUTarget::G31, "g31"},         {GPUTarget::G76, "g76"},
+        {GPUTarget::G52, "g52"},         {GPUTarget::G52LIT, "g52lit"},
+        {GPUTarget::G77, "g77"},         {GPUTarget::G57, "g57"},
+        {GPUTarget::G78, "g78"},         {GPUTarget::G68, "g68"},
+        {GPUTarget::G78AE, "g78ae"},     {GPUTarget::G710, "g710"},
+        {GPUTarget::G610, "g610"},       {GPUTarget::G510, "g510"},
+        {GPUTarget::G310, "g310"},       {GPUTarget::G715, "g715"},
+        {GPUTarget::G615, "g615"},       {GPUTarget::G720, "g720"},
+        {GPUTarget::G620, "g620"},       {GPUTarget::G1, "g1"}};
 
     return gpu_target_map[target];
 }
 
 GPUTarget get_target_from_name(const std::string &device_name)
 {
-    std::regex mali_regex(R"(Mali-(([A-Za-z]+\d*)\w*))");
-    std::regex immortalis_regex(R"(Immortalis-(([A-Za-z]+\d*)\w*))");
+    /* Below regex matches format:
+    Mali-[at least one letter][optional numbers]['-' or arbitrary characters] */
+    std::regex mali_regex(R"(Mali-(([A-Za-z]+\d*)[\w-]*))");
+    /* Below regex matches format:
+    Immortalis-[at least one letter][optional numbers]['-' or arbitrary characters] */
+    std::regex immortalis_regex(R"(Immortalis-(([A-Za-z]+\d*)[\w-]*))");
 
     std::smatch name_parts_mali;
     std::smatch name_parts_immortalis;
@@ -144,13 +155,13 @@ GPUTarget get_target_from_name(const std::string &device_name)
 
     if (found_mali)
     {
-        full_name = name_parts_mali.str(1);
-        base_name = name_parts_mali.str(2);
+        full_name = name_parts_mali.str(1); // Contains the string after Mali (e.g. "G51LIT")
+        base_name = name_parts_mali.str(2); // Contains just the G followed by just the numbers (e.g. "G51").
     }
     else
     {
-        full_name = name_parts_immortalis.str(1);
-        base_name = name_parts_immortalis.str(2);
+        full_name = name_parts_immortalis.str(1); // Contains the string after Immportalis
+        base_name = name_parts_immortalis.str(2); // Contains just the G followed by just the numbers
     }
 
     const auto gpu_target = get_gpu_target(full_name, base_name);

--- a/src/gpu/cl/ClKernelLibrary.cpp
+++ b/src/gpu/cl/ClKernelLibrary.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2024 Arm Limited.
+ * Copyright (c) 2016-2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -264,6 +264,8 @@ const std::map<std::string, std::string> ClKernelLibrary::_kernel_program_map = 
     {"gemm_mv_quantized", "common/gemv.cl"},
     {"gemm_mm_native", "common/gemm.cl"},
     {"gemm_mm_reshaped_only_rhs_nt_mmul", "common/gemm_reshaped_only_rhs_mmul.cl"},
+    {"gemm_mm_reshaped_only_rhs_nt_mmul_fp16", "common/gemm_reshaped_only_rhs_mmul.cl"},
+    {"gemm_mm_reshaped_only_rhs_nt_mmul_texture_fp16", "common/gemm_reshaped_only_rhs_mmul.cl"},
     {"gemm_mm_reshaped_only_rhs_nt_mmul_texture", "common/gemm_reshaped_only_rhs_mmul.cl"},
     {"gemm_mm_reshaped_lhs_nt_rhs_t", "common/gemm.cl"},
     {"gemm_mm_reshaped_lhs_nt_rhs_t_texture", "common/gemm.cl"},

--- a/src/gpu/cl/kernels/gemm/ClGemmHelpers.h
+++ b/src/gpu/cl/kernels/gemm/ClGemmHelpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 Arm Limited.
+ * Copyright (c) 2019-2023, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef ARM_COMPUTE_CL_GEMM_HELPERS_H
-#define ARM_COMPUTE_CL_GEMM_HELPERS_H
+#ifndef ACL_SRC_GPU_CL_KERNELS_GEMM_CLGEMMHELPERS_H
+#define ACL_SRC_GPU_CL_KERNELS_GEMM_CLGEMMHELPERS_H
 
 #include "arm_compute/core/TensorInfo.h"
 #include "arm_compute/core/Types.h"
@@ -105,7 +105,7 @@ void update_padding_for_cl_image(ITensorInfo *tensor);
  */
 Status validate_image2d_support_on_rhs(const ITensorInfo &tensor_reshaped_info, const GEMMRHSMatrixInfo &rhs_info);
 
-/** Determine if the MMUL kernels should be preferred
+/** Determine if the FP32 MMUL kernels should be preferred
  *
  * @param[in]      m         Number of rows of the LHS matrix
  * @param[in]      n         Number of columns of the RHS matrix
@@ -117,13 +117,33 @@ Status validate_image2d_support_on_rhs(const ITensorInfo &tensor_reshaped_info, 
  *
  * @return true if MMUL kernel is preferred over kernels w/o MMUL, false otherwise
  */
-bool is_mmul_kernel_preferred(const unsigned int m,
-                              const unsigned int n,
-                              const unsigned int k,
-                              const unsigned int b,
-                              const DataType     data_type,
-                              unsigned int      &best_m0,
-                              unsigned int      &best_n0);
+bool is_mmul_kernel_preferred_fp32_acc(const unsigned int m,
+                                       const unsigned int n,
+                                       const unsigned int k,
+                                       const unsigned int b,
+                                       const DataType     data_type,
+                                       unsigned int      &best_m0,
+                                       unsigned int      &best_n0);
+
+/** Determine if the FP16 MMUL kernels should be preferred
+ *
+ * @param[in]      m         Number of rows of the LHS matrix
+ * @param[in]      n         Number of columns of the RHS matrix
+ * @param[in]      k         Number of columns of the LHS matrix, rows of the RHS matrix
+ * @param[in]      b         Batch size
+ * @param[in]      data_type Data type FP32/FP16
+ * @param[in, out] best_m0   Suggested M0 (number of rows of the output block) for the kernel
+ * @param[in, out] best_n0   Suggested N0 (number of columns of the output block) for the kernel
+ *
+ * @return true if MMUL kernel is preferred over kernels w/o MMUL, false otherwise
+ */
+bool is_mmul_kernel_preferred_fp16_acc(const unsigned int m,
+                                       const unsigned int n,
+                                       const unsigned int k,
+                                       const unsigned int b,
+                                       const DataType     data_type,
+                                       unsigned int      &best_m0,
+                                       unsigned int      &best_n0);
 
 /** Find the preferred configurations for the LHS and RHS tensor using the GeMMConfigsMatrix provided by the user
  *
@@ -141,4 +161,4 @@ find_lhs_rhs_info(const GeMMConfigsMatrix &configs, unsigned int m, unsigned int
 } // namespace kernels
 } // namespace opencl
 } // namespace arm_compute
-#endif /* ARM_COMPUTE_CL_GEMM_HELPERS_H */
+#endif // ACL_SRC_GPU_CL_KERNELS_GEMM_CLGEMMHELPERS_H

--- a/src/gpu/cl/kernels/gemm/reshaped_only_rhs/ClGemmDefaultConfigReshapedRhsOnlyValhall.h
+++ b/src/gpu/cl/kernels/gemm/reshaped_only_rhs/ClGemmDefaultConfigReshapedRhsOnlyValhall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 Arm Limited.
+ * Copyright (c) 2020-2023, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef ARM_COMPUTE_CL_GEMM_DEFAULT_CONFIG_RESHAPED_RHS_ONLY_VALHALL_H
-#define ARM_COMPUTE_CL_GEMM_DEFAULT_CONFIG_RESHAPED_RHS_ONLY_VALHALL_H
+#ifndef ACL_SRC_GPU_CL_KERNELS_GEMM_RESHAPED_ONLY_RHS_CLGEMMDEFAULTCONFIGRESHAPEDRHSONLYVALHALL_H
+#define ACL_SRC_GPU_CL_KERNELS_GEMM_RESHAPED_ONLY_RHS_CLGEMMDEFAULTCONFIGRESHAPEDRHSONLYVALHALL_H
 
 #include "src/gpu/cl/kernels/gemm/IClGemmKernelConfig.h"
 
@@ -65,9 +65,11 @@ private:
     configure_G715_f32(unsigned int m, unsigned int n, unsigned int k, unsigned int b);
     std::pair<GEMMLHSMatrixInfo, GEMMRHSMatrixInfo>
     configure_G715_f16(unsigned int m, unsigned int n, unsigned int k, unsigned int b);
+    std::pair<GEMMLHSMatrixInfo, GEMMRHSMatrixInfo>
+    configure_G1_f16(unsigned int m, unsigned int n, unsigned int k, unsigned int b);
 };
 } // namespace gemm
 } // namespace kernels
 } // namespace opencl
 } // namespace arm_compute
-#endif /* ARM_COMPUTE_CL_GEMM_DEFAULT_CONFIG_RESHAPED_RHS_ONLY_VALHALL_H */
+#endif // ACL_SRC_GPU_CL_KERNELS_GEMM_RESHAPED_ONLY_RHS_CLGEMMDEFAULTCONFIGRESHAPEDRHSONLYVALHALL_H

--- a/src/runtime/CL/gemm/CLGEMMDefaultTypeValhall.h
+++ b/src/runtime/CL/gemm/CLGEMMDefaultTypeValhall.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023 Arm Limited.
+ * Copyright (c) 2020-2023, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef SRC_CLGEMMDEFAULTTYPEVALHALL_H
-#define SRC_CLGEMMDEFAULTTYPEVALHALL_H
+#ifndef ACL_SRC_RUNTIME_CL_GEMM_CLGEMMDEFAULTTYPEVALHALL_H
+#define ACL_SRC_RUNTIME_CL_GEMM_CLGEMMDEFAULTTYPEVALHALL_H
 
 #include "arm_compute/runtime/CL/ICLGEMMKernelSelection.h"
 
@@ -53,7 +53,8 @@ private:
     CLGEMMKernelType g710_f16(unsigned int m, unsigned int n, unsigned int k, unsigned int b, bool is_rhs_constant);
     CLGEMMKernelType g715_f32(unsigned int m, unsigned int n, unsigned int k, unsigned int b, bool is_rhs_constant);
     CLGEMMKernelType g715_f16(unsigned int m, unsigned int n, unsigned int k, unsigned int b, bool is_rhs_constant);
+    CLGEMMKernelType G1_f16(unsigned int m, unsigned int n, unsigned int k, unsigned int b, bool is_rhs_constant);
 };
 } // namespace cl_gemm
 } // namespace arm_compute
-#endif /* SRC_CLGEMMDEFAULTTYPEVALHALL_H */
+#endif // ACL_SRC_RUNTIME_CL_GEMM_CLGEMMDEFAULTTYPEVALHALL_H

--- a/tests/validation/CL/GEMMMatrixMultiplyReshapedOnlyRhsMMUL.cpp
+++ b/tests/validation/CL/GEMMMatrixMultiplyReshapedOnlyRhsMMUL.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Arm Limited.
+ * Copyright (c) 2022, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -68,11 +68,14 @@ const auto beta_values = framework::dataset::make("beta", {0.0f, -0.75f} );
 const auto m_values = framework::dataset::make("M", {49});
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", {257});
+const auto n_values              = framework::dataset::make("N", {257, 64, 48});
+const auto n_values_fp16         = framework::dataset::make("N", {79, 32, 80});
+const auto n_values_texture_fp16 = framework::dataset::make("N", {128, 96, 48});
 
 /** K values to test */
 /** The test case requires this to be multiple of 4*/
 const auto k_values = framework::dataset::make("K", {192});
+const auto k_values_fp16 = framework::dataset::make("K", {64});
 
 /** Batch size values to test */
 const auto b_values = framework::dataset::make("batch_size", {1, 2});
@@ -81,14 +84,17 @@ const auto b_values = framework::dataset::make("batch_size", {1, 2});
 const auto act_values = framework::dataset::make("Activation",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
-    ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::ELU),
+    ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::ELU)
 });
 
 /** M0 values to test - Precommit */
 const auto m0_values_precommit = framework::dataset::make("M0", { 1, 2, 4 });
+const auto m0_values_precommit_fp16 = framework::dataset::make("M0", { 1, 2, 3, 4, 8 });
 
 /** N0 values to test - Precommit */
-const auto n0_values_precommit = framework::dataset::make("N0", { 4, 8 });
+const auto n0_values_precommit              = framework::dataset::make("N0", { 4, 8 });
+const auto n0_values_precommit_fp16         = framework::dataset::make("N0", { 2, 4, 8, 16 });
+const auto n0_values_precommit_texture_fp16 = framework::dataset::make("N0", { 4, 8 });
 
 /** K0 values to test - Precommit */
 const auto k0_values_precommit = framework::dataset::make("K0", { 1 });
@@ -103,20 +109,19 @@ TEST_SUITE(GEMMMatrixMultiplyReshapedOnlyRhsMMUL)
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<float>, framework::DatasetMode::ALL,
-                combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(
-                                                                   m_values,
-                                                                   n_values),
-                                                                   k_values),
-                                                                   b_values),
-                                                                   m0_values_precommit),
-                                                                   n0_values_precommit),
-                                                                   k0_values_precommit),
-                                                                   framework::dataset::make("ExportToCLImage", false)),
-                                                                   framework::dataset::make("DataType", DataType::F32)),
-                                                                   a_values),
-                                                                   beta_values),
-                                                                   broadcast_bias_values),
-                                                                   act_values))
+                combine(m_values,
+                        n_values,
+                        k_values,
+                        b_values,
+                        m0_values_precommit,
+                        n0_values_precommit,
+                        k0_values_precommit,
+                        framework::dataset::make("ExportToCLImage", false),
+                        framework::dataset::make("DataType", DataType::F32),
+                        a_values,
+                        beta_values,
+                        broadcast_bias_values,
+                        act_values))
 {
     // Validate output
     if(validate_result)
@@ -134,20 +139,19 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<half>, framework::DatasetMode::ALL,
-                combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(
-                                                                   m_values,
-                                                                   n_values),
-                                                                   k_values),
-                                                                   b_values),
-                                                                   m0_values_precommit),
-                                                                   n0_values_precommit),
-                                                                   k0_values_precommit),
-                                                                   framework::dataset::make("ExportToCLImage", false)),
-                                                                   framework::dataset::make("DataType", DataType::F16)),
-                                                                   a_values),
-                                                                   beta_values),
-                                                                   broadcast_bias_values),
-                                                                   act_values))
+                combine(m_values,
+                        n_values_fp16,
+                        k_values_fp16,
+                        b_values,
+                        m0_values_precommit_fp16,
+                        n0_values_precommit_fp16,
+                        k0_values_precommit,
+                        framework::dataset::make("ExportToCLImage", false),
+                        framework::dataset::make("DataType", DataType::F16),
+                        a_values,
+                        beta_values,
+                        broadcast_bias_values,
+                        act_values))
 {
     // Validate output
     if(validate_result)
@@ -165,20 +169,19 @@ TEST_SUITE_END() // FP16
 TEST_SUITE(ExportToCLImage)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<float>, framework::DatasetMode::ALL,
-                combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(
-                                                                   m_values,
-                                                                   n_values),
-                                                                   k_values),
-                                                                   b_values),
-                                                                   m0_values_precommit),
-                                                                   n0_values_precommit),
-                                                                   k0_values_precommit),
-                                                                   framework::dataset::make("ExportToCLImage", true)),
-                                                                   framework::dataset::make("DataType", DataType::F32)),
-                                                                   a_values),
-                                                                   beta_values),
-                                                                   broadcast_bias_values),
-                                                                   act_values))
+                combine(m_values,
+                        n_values,
+                        k_values,
+                        b_values,
+                        m0_values_precommit,
+                        n0_values_precommit,
+                        k0_values_precommit,
+                        framework::dataset::make("ExportToCLImage", true),
+                        framework::dataset::make("DataType", DataType::F32),
+                        a_values,
+                        beta_values,
+                        broadcast_bias_values,
+                        act_values))
 {
     // Validate output
     if(validate_result)
@@ -196,20 +199,19 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<half>, framework::DatasetMode::ALL,
-                combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(combine(
-                                                                   m_values,
-                                                                   n_values),
-                                                                   k_values),
-                                                                   b_values),
-                                                                   m0_values_precommit),
-                                                                   n0_values_precommit),
-                                                                   k0_values_precommit),
-                                                                   framework::dataset::make("ExportToCLImage", true)),
-                                                                   framework::dataset::make("DataType", DataType::F16)),
-                                                                   a_values),
-                                                                   beta_values),
-                                                                   broadcast_bias_values),
-                                                                   act_values))
+                combine(m_values,
+                        n_values_fp16,
+                        k_values_fp16,
+                        b_values,
+                        m0_values_precommit_fp16,
+                        n0_values_precommit_texture_fp16,
+                        k0_values_precommit,
+                        framework::dataset::make("ExportToCLImage", true),
+                        framework::dataset::make("DataType", DataType::F16),
+                        a_values,
+                        beta_values,
+                        broadcast_bias_values,
+                        act_values))
 {
     // Validate output
     if(validate_result)

--- a/tests/validation/fixtures/GEMMFixture.h
+++ b/tests/validation/fixtures/GEMMFixture.h
@@ -1847,6 +1847,7 @@ protected:
     SimpleTensor<T> _reference{};
 };
 
+#ifdef ARM_COMPUTE_CL
 template <typename TensorType, typename AccessorType, typename T, typename ReshapeRHSOperatorType, typename GEMMOperatorType>
 class GEMMMatrixMultiplyReshapedOnlyRhsMMULValidationFixture : public framework::Fixture
 {
@@ -1919,19 +1920,13 @@ protected:
         ReshapeRHSOperatorType reshape_rhs;
         GEMMOperatorType       gemm;
 
-        validate_result = bool(reshape_rhs.validate(rhs.info(), rhs_reshaped.info(), rhs_info));
+        validate_result = arm_matrix_multiply_supported(CLKernelLibrary::get().get_device());
         if(!validate_result)
         {
             return nullptr;
         }
 
         reshape_rhs.configure(rhs.info(), rhs_reshaped.info(), rhs_info);
-
-        validate_result = bool(gemm.validate(lhs.info(), rhs_reshaped.info(), bias.info(), dst.info(), alpha, beta, lhs_info, rhs_info, kernel_info));
-        if(!validate_result)
-        {
-            return nullptr;
-        }
 
         gemm.configure(lhs.info(), rhs_reshaped.info(), bias.info(), dst.info(), alpha, beta, lhs_info, rhs_info, kernel_info);
 
@@ -2009,6 +2004,7 @@ protected:
     TensorType      _target{};
     SimpleTensor<T> _reference{};
 };
+#endif // ARM_COMPUTE_CL
 
 } // namespace validation
 } // namespace test

--- a/utils/TypePrinter.h
+++ b/utils/TypePrinter.h
@@ -2301,6 +2301,9 @@ inline ::std::ostream &operator<<(::std::ostream &os, const GPUTarget &gpu_targe
         case GPUTarget::G620:
             os << "G620";
             break;
+        case GPUTarget::G1:
+            os << "G1";
+            break;
         default:
             ARM_COMPUTE_ERROR("NOT_SUPPORTED!");
     }
@@ -2548,6 +2551,10 @@ inline std::string to_string(CLGEMMKernelType val)
         case CLGEMMKernelType::RESHAPED_ONLY_RHS:
         {
             return "Reshaped_Only_RHS";
+        }
+        case CLGEMMKernelType::RESHAPED_ONLY_RHS_MMUL:
+        {
+            return "Reshaped_Only_RHS_MMUL";
         }
         case CLGEMMKernelType::RESHAPED:
         {


### PR DESCRIPTION
This patch introduces a GEMM routine that is optimized for Arm(R) Mali(TM)-G1

Resolves: [COMPMID-8311], [COMPMID-8312]


Change-Id: I84e685f0314da9af1c3fbb50d83e68b355727770