### PR TITLE
Do only one iteration of newton-raphson refinement for FP16 inv

### DIFF
--- a/src/core/NEON/NEMath.inl
+++ b/src/core/NEON/NEMath.inl
@@ -634,14 +634,12 @@ inline float16x4_t vinv_f16(float16x4_t x)
 {
     float16x4_t recip = vrecpe_f16(x);
     recip             = vmul_f16(vrecps_f16(x, recip), recip);
-    recip             = vmul_f16(vrecps_f16(x, recip), recip);
     return recip;
 }
 
 inline float16x8_t vinvq_f16(float16x8_t x)
 {
     float16x8_t recip = vrecpeq_f16(x);
-    recip             = vmulq_f16(vrecpsq_f16(x, recip), recip);
     recip             = vmulq_f16(vrecpsq_f16(x, recip), recip);
     return recip;
 }

--- a/src/core/NEON/SVEMath.inl
+++ b/src/core/NEON/SVEMath.inl
@@ -82,7 +82,6 @@ inline svfloat16_t svinv_f16_z(svbool_t pg, svfloat16_t x)
 {
     auto recip = svrecpe_f16(x);
     recip      = svmul_f16_z(pg, svrecps_f16(x, recip), recip);
-    recip      = svmul_f16_z(pg, svrecps_f16(x, recip), recip);
     return recip;
 }
 


### PR DESCRIPTION
Do one iteration of newton-raphson refinement for FP16 inv
FP16 only has 10 explicitly stored bits of mantissa, so one
iteration of refinement should be precise enough. Numerical
results showed both one iteration and two iterations of
newton-raphson refinement had worst ULP being 1.