### PR TITLE
fix: Missing output type validation in CpuGemmDirectConv2d

### DIFF
--- a/src/cpu/operators/CpuGemmDirectConv2d.cpp
+++ b/src/cpu/operators/CpuGemmDirectConv2d.cpp
@@ -202,6 +202,8 @@ Status CpuGemmDirectConv2d::validate(const ITensorInfo *src,
         ARM_COMPUTE_RETURN_ERROR_ON(biases->num_dimensions() > 1);
     }
 
+    ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_DATA_TYPES(src, dst);
+
     cpu::AsmGemmInfo asm_info = init_assembly_metadata(info, false);
     ARM_COMPUTE_RETURN_ON_ERROR(cpu::CpuGemmAssemblyDispatch::validate(src, weights, biases, dst, asm_info));
     return Status{};


### PR DESCRIPTION
CpuGemmDirectConv2d should validate the output data type.

Partially Resolves: ARMCL-1199

Change-Id: Icdab0856027f60ad50f9a87a4c82144de9d248ef