### PR TITLE
refactor: Flatten nested concat usage in validation/NEON.

### DIFF
--- a/tests/framework/datasets/JoinDataset.h
+++ b/tests/framework/datasets/JoinDataset.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 Arm Limited.
+ * Copyright (c) 2017-2018, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -21,13 +21,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#ifndef ARM_COMPUTE_TEST_DATASET_JOIN
-#define ARM_COMPUTE_TEST_DATASET_JOIN
+#ifndef ACL_TESTS_FRAMEWORK_DATASETS_JOINDATASET_H
+#define ACL_TESTS_FRAMEWORK_DATASETS_JOINDATASET_H
 
 #include "Dataset.h"
 
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 namespace arm_compute
@@ -161,8 +162,19 @@ JoinDataset<T, U> concat(T &&dataset1, U &&dataset2)
 {
     return JoinDataset<T, U>(std::forward<T>(dataset1), std::forward<U>(dataset2));
 }
+
+template <typename T, typename U, typename V, typename... Rest>
+auto concat(T &&dataset1, U &&dataset2, V &&dataset3, Rest &&... rest)
+    -> decltype(concat(concat(std::forward<T>(dataset1), std::forward<U>(dataset2)),
+                       std::forward<V>(dataset3),
+                       std::forward<Rest>(rest)...))
+{
+    return concat(concat(std::forward<T>(dataset1), std::forward<U>(dataset2)),
+                  std::forward<V>(dataset3),
+                  std::forward<Rest>(rest)...);
+}
 } // namespace dataset
 } // namespace framework
 } // namespace test
 } // namespace arm_compute
-#endif /* ARM_COMPUTE_TEST_DATASET_JOIN */
+#endif // ACL_TESTS_FRAMEWORK_DATASETS_JOINDATASET_H

--- a/tests/validation/NEON/ActivationLayer.cpp
+++ b/tests/validation/NEON/ActivationLayer.cpp
@@ -59,10 +59,10 @@ RelativeTolerance<float> tolerance_float_sqrt(0.0001f);
 constexpr AbsoluteTolerance<int16_t> tolerance_qsymm16(1);
 
 const auto NeonActivationFunctionsDataset = concat(datasets::ActivationFunctions(),
-                                                   framework::dataset::make("ActivationFunction", { ActivationLayerInfo::ActivationFunction::HARD_SWISH, ActivationLayerInfo::ActivationFunction::SWISH }));
+                                                   make("ActivationFunction", { ActivationLayerInfo::ActivationFunction::HARD_SWISH, ActivationLayerInfo::ActivationFunction::SWISH }));
 
 /** Input data sets. */
-const auto ActivationDataset = combine(framework::dataset::make("InPlace", { false, true }), NeonActivationFunctionsDataset, framework::dataset::make("AlphaBeta", { 0.5f, 1.f }));
+const auto ActivationDataset = combine(make("InPlace", { false, true }), NeonActivationFunctionsDataset, make("AlphaBeta", { 0.5f, 1.f }));
 const auto ActivationDatasetForPaddingAfterConfigure = combine(
     make("InPlace", { false, true }),
     NeonActivationFunctionsDataset,
@@ -163,19 +163,19 @@ TEST_CASE(ActivationAPI, framework::DatasetMode::ALL)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
+    make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+    make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                           }),
-    framework::dataset::make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
+    make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                  ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                  ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                }),
-    framework::dataset::make("Expected", { false, true, false})
+    make("Expected", { false, true, false})
     ),
     input_info, output_info, act_info, expected)
 {
@@ -199,7 +199,7 @@ TEST_CASE(SqrtBoundaryValue, framework::DatasetMode::ALL)
     test_float_sqrt_boundary_value<half>();
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, NEActivationLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), ActivationDataset,
-                                                                                                      framework::dataset::make("DataType",
+                                                                                                      make("DataType",
                                                                                                               DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -294,7 +294,7 @@ template <typename T>
 using NEActivationLayerWithPaddingQuantizedFixture = ActivationWithPaddingValidationQuantizedFixture<Tensor, Accessor, NEActivationLayer, T>;
 
 /** Input data sets. */
-const auto QuantizedActivationFunctionsDataset = framework::dataset::make("ActivationFunction",
+const auto QuantizedActivationFunctionsDataset = make("ActivationFunction",
 {
     ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU,
     ActivationLayerInfo::ActivationFunction::RELU,
@@ -307,9 +307,9 @@ const auto QuantizedActivationFunctionsDataset = framework::dataset::make("Activ
 #endif
 });
 
-const auto QuantizedActivationDataset = combine(framework::dataset::make("InPlace", { false }),
-                                                        concat(QuantizedActivationFunctionsDataset, framework::dataset::make("ActivationFunction", ActivationLayerInfo::ActivationFunction::HARD_SWISH)),
-                                                framework::dataset::make("AlphaBeta", { 0.5f, 1.f }));
+const auto QuantizedActivationDataset = combine(make("InPlace", { false }),
+                                                        concat(QuantizedActivationFunctionsDataset, make("ActivationFunction", ActivationLayerInfo::ActivationFunction::HARD_SWISH)),
+                                                make("AlphaBeta", { 0.5f, 1.f }));
 const auto QuantizedActivationDatasetForPaddingAfterConfigure = combine(
     make("InPlace", { false }),
     concat(QuantizedActivationFunctionsDataset,
@@ -321,9 +321,9 @@ const auto QuantizedActivationDatasetForPaddingAfterConfigure = combine(
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEActivationLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), QuantizedActivationDataset,
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::QASYMM8),
-                                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
+                                                                                                                  make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, helper::tolerance_qasymm8(_function));
@@ -343,9 +343,9 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEActivationLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), QuantizedActivationDataset,
-                                                                                                                 framework::dataset::make("DataType",
+                                                                                                                 make("DataType",
                                                                                                                          DataType::QASYMM8_SIGNED),
-                                                                                                                 framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10.0f) })))
+                                                                                                                 make("QuantizationInfo", { QuantizationInfo(0.5f, 10.0f) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, helper::tolerance_qasymm8(_function));
@@ -364,14 +364,14 @@ FIXTURE_DATA_TEST_CASE(PaddingAfterConfigure, NEActivationLayerWithPaddingQuanti
 TEST_SUITE_END() // QASYMM8_SIGNED
 
 /** Input data sets. */
-const auto Int16QuantizedActivationFunctionsDataset = framework::dataset::make("ActivationFunction",
+const auto Int16QuantizedActivationFunctionsDataset = make("ActivationFunction",
 {
     ActivationLayerInfo::ActivationFunction::LOGISTIC,
     ActivationLayerInfo::ActivationFunction::TANH,
     ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU,
 });
-const auto Int16QuantizedActivationDataset = combine(framework::dataset::make("InPlace", { false }), Int16QuantizedActivationFunctionsDataset,
-                                                     framework::dataset::make("AlphaBeta", { 0.5f, 1.f }));
+const auto Int16QuantizedActivationDataset = combine(make("InPlace", { false }), Int16QuantizedActivationFunctionsDataset,
+                                                     make("AlphaBeta", { 0.5f, 1.f }));
 
 const auto Int16QuantizedActivationDatasetForPaddingAfterConfigure = combine(
     make("InPlace", { false }),
@@ -381,9 +381,9 @@ const auto Int16QuantizedActivationDatasetForPaddingAfterConfigure = combine(
 
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEActivationLayerQuantizedFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), Int16QuantizedActivationDataset,
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::QSYMM16),
-                                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 32768.f, 0.f) })))
+                                                                                                                  make("QuantizationInfo", { QuantizationInfo(1.f / 32768.f, 0.f) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qsymm16);

--- a/tests/validation/NEON/AddMulAdd.cpp
+++ b/tests/validation/NEON/AddMulAdd.cpp
@@ -42,13 +42,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_fp32(0.001f);     /**< Tolerance for floating point tests */
 const AbsoluteTolerance<half>      tolerance_fp16(half(0.1f)); /**< Tolerance for 16-bit floating point tests */
 constexpr AbsoluteTolerance<float> tolerance_quant(1);         /**< Tolerance for quantized tests */
 
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -59,30 +61,30 @@ const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo
 });
 
 // QASYMM8 test quantizations
-const auto qasymm8_input1_qinfo_set = framework::dataset::make("Input1QInfo", { QuantizationInfo(0.1, 10) }); // Representable Range: [-1, 24.5]
-const auto qasymm8_input2_qinfo_set = framework::dataset::make("Input2QInfo", { QuantizationInfo(0.2, 60) }); // Representable Range: [-12, 39]
-const auto qasymm8_bn_mul_qinfo_set = framework::dataset::make("BnMulInfo", { QuantizationInfo(0.001, 55) }); // Representable Range: [-0.11, 0.2]
-const auto qasymm8_bn_add_qinfo_set = framework::dataset::make("BnAddInfo", { QuantizationInfo(0.02, 20) });  // Representable Range: [-0.4, 4.7]
+const auto qasymm8_input1_qinfo_set = make("Input1QInfo", { QuantizationInfo(0.1, 10) }); // Representable Range: [-1, 24.5]
+const auto qasymm8_input2_qinfo_set = make("Input2QInfo", { QuantizationInfo(0.2, 60) }); // Representable Range: [-12, 39]
+const auto qasymm8_bn_mul_qinfo_set = make("BnMulInfo", { QuantizationInfo(0.001, 55) }); // Representable Range: [-0.11, 0.2]
+const auto qasymm8_bn_add_qinfo_set = make("BnAddInfo", { QuantizationInfo(0.02, 20) });  // Representable Range: [-0.4, 4.7]
 
 // Representable Range: [-9.36, 51.84], Expected F32 range: [-13, 63.5], leaving some space for saturation
-const auto qasymm8_add_output_qinfo_set = framework::dataset::make("AddOutputInfo", { QuantizationInfo(0.24, 39) });
+const auto qasymm8_add_output_qinfo_set = make("AddOutputInfo", { QuantizationInfo(0.24, 39) });
 
 // Representable Range: [-4.8, 10.5], Expected FP32 range: [-6.985, 12.7], leaving some space for saturation
 // This range also makes sense with the activation boundaries above, i.e. [-2, 8] for LU_BOUNDED_RELU and [0, 6] for BOUNDED_RELU
-const auto qasymm8_final_output_qinfo_set = framework::dataset::make("FinalOutputInfo", { QuantizationInfo(0.06, 80) });
+const auto qasymm8_final_output_qinfo_set = make("FinalOutputInfo", { QuantizationInfo(0.06, 80) });
 
 // QASYMM8_SIGNED test quantizations
-const auto qasymm8_signed_input1_qinfo_set = framework::dataset::make("Input1QInfo", { QuantizationInfo(0.1, 10) });  // Representable Range: [-13.8, 11.7]
-const auto qasymm8_signed_input2_qinfo_set = framework::dataset::make("Input2QInfo", { QuantizationInfo(0.2, -60) }); // Representable Range: [-13.6, 39.4]
-const auto qasymm8_signed_bn_mul_qinfo_set = framework::dataset::make("BnMulInfo", { QuantizationInfo(0.001, 55) });  // Representable Range: [-0.183, 0.072]
-const auto qasymm8_signed_bn_add_qinfo_set = framework::dataset::make("BnAddInfo", { QuantizationInfo(0.4, -120) });  // Representable Range: [-0.32, 9.08]
+const auto qasymm8_signed_input1_qinfo_set = make("Input1QInfo", { QuantizationInfo(0.1, 10) });  // Representable Range: [-13.8, 11.7]
+const auto qasymm8_signed_input2_qinfo_set = make("Input2QInfo", { QuantizationInfo(0.2, -60) }); // Representable Range: [-13.6, 39.4]
+const auto qasymm8_signed_bn_mul_qinfo_set = make("BnMulInfo", { QuantizationInfo(0.001, 55) });  // Representable Range: [-0.183, 0.072]
+const auto qasymm8_signed_bn_add_qinfo_set = make("BnAddInfo", { QuantizationInfo(0.4, -120) });  // Representable Range: [-0.32, 9.08]
 
 // Representable Range: [-21.36, 39.84], Expected F32 range: [-27.4, 51.1], leaving some space for saturation
-const auto qasymm8_signed_add_output_qinfo_set = framework::dataset::make("AddOutputInfo", { QuantizationInfo(0.24, -39) });
+const auto qasymm8_signed_add_output_qinfo_set = make("AddOutputInfo", { QuantizationInfo(0.24, -39) });
 
 // Representable Range: [-4.8, 10.5], Expected FP32 range: [-9.6713, 14.0942], leaving some space for saturation
 // This range also makes sense with the activation boundaries above, i.e. [-2, 8] for LU_BOUNDED_RELU and [0, 6] for BOUNDED_RELU
-const auto qasymm8_signed_final_output_qinfo_set = framework::dataset::make("FinalOutputInfo", { QuantizationInfo(0.06, -48) });
+const auto qasymm8_signed_final_output_qinfo_set = make("FinalOutputInfo", { QuantizationInfo(0.06, -48) });
 
 } // namespace
 
@@ -99,7 +101,7 @@ TEST_SUITE(Float)
 
 TEST_SUITE(F32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulAddFloatFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::F32),
+                                                                                                                    make("DataType", DataType::F32),
                                                                                                             ActivationFunctionsDataset))
 {
     // Validate outputs
@@ -109,15 +111,15 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulAddFloatFixture<float>, framework::Data
 
 // This test is to stress the case when there is no intermediate output required (i.e. nullptr)
 FIXTURE_DATA_TEST_CASE(RunSmallWithoutIntermOutput, NEAddMulAddFloatFixtureWoIntermOut<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ActivationInfo", { ActivationLayerInfo() })))
+                       make("DataType", DataType::F32),
+                       make("ActivationInfo", { ActivationLayerInfo() })))
 {
     // Validate outputs
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEAddMulAddFloatFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                                  framework::dataset::make("DataType", DataType::F32),
+                                                                                                                  make("DataType", DataType::F32),
                                                                                                           ActivationFunctionsDataset))
 {
     // Validate outputs
@@ -130,7 +132,7 @@ TEST_SUITE_END() // F32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(F16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulAddFloatFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                                                                   make("DataType", DataType::F16),
                                                                                                            ActivationFunctionsDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -146,7 +148,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulAddFloatFixture<half>, framework::Datas
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEAddMulAddFloatFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F16),
+                                                                                                                 make("DataType", DataType::F16),
                                                                                                          ActivationFunctionsDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -176,7 +178,7 @@ TEST_SUITE(Quantized)
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
+                                                                                                                       make("DataType", DataType::QASYMM8),
                                                                                                                        ActivationFunctionsDataset,
                                                                                                                        qasymm8_input1_qinfo_set,
                                                                                                                        qasymm8_input2_qinfo_set,
@@ -191,7 +193,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulQuantizedFixture<uint8_t>, framework::D
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEAddMulQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                                     framework::dataset::make("DataType", DataType::QASYMM8),
+                                                                                                                     make("DataType", DataType::QASYMM8),
                                                                                                                      ActivationFunctionsDataset,
                                                                                                                      qasymm8_input1_qinfo_set,
                                                                                                                      qasymm8_input2_qinfo_set,
@@ -208,7 +210,7 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                      framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                      make("DataType", DataType::QASYMM8_SIGNED),
                                                                                                                       ActivationFunctionsDataset,
                                                                                                                       qasymm8_signed_input1_qinfo_set,
                                                                                                                       qasymm8_signed_input2_qinfo_set,
@@ -223,7 +225,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEAddMulQuantizedFixture<int8_t>, framework::Da
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEAddMulQuantizedFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                    make("DataType", DataType::QASYMM8_SIGNED),
                                                                                                                     ActivationFunctionsDataset,
                                                                                                                     qasymm8_signed_input1_qinfo_set,
                                                                                                                     qasymm8_signed_input2_qinfo_set,

--- a/tests/validation/NEON/ArgMinMax.cpp
+++ b/tests/validation/NEON/ArgMinMax.cpp
@@ -43,13 +43,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-const auto OpsDataset   = framework::dataset::make("Operation", { ReductionOperation::ARG_IDX_MIN, ReductionOperation::ARG_IDX_MAX });
-const auto AxisDataset  = framework::dataset::make("Axis", { 0, 1, 2, 3 });
-const auto QInfoDataset = framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) });
+const auto OpsDataset   = make("Operation", { ReductionOperation::ARG_IDX_MIN, ReductionOperation::ARG_IDX_MAX });
+const auto AxisDataset  = make("Axis", { 0, 1, 2, 3 });
+const auto QInfoDataset = make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) });
 
-const auto ArgMinMaxSmallDatasetAxis0 = framework::dataset::make("Shape",
+const auto ArgMinMaxSmallDatasetAxis0 = make("Shape",
 {
     TensorShape{ 1U, 5U },
     TensorShape{ 2U, 3U },
@@ -70,19 +72,19 @@ TEST_SUITE(ArgMinMax)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
+        make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid output shape
                                                 TensorInfo(TensorShape(32U, 16U, 16U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 16U, 16U, 2U), 1, DataType::F32) // Invalid operation
         }),
-        framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
+        make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::S32),
                                                  TensorInfo(TensorShape(32U, 16U, 1U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Axis", { 4, 0, 2, 0 }),
-        framework::dataset::make("Operation", { ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::MEAN_SUM }),
-        framework::dataset::make("Expected", { false, false, true, false })
+        make("Axis", { 4, 0, 2, 0 }),
+        make("Operation", { ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::MEAN_SUM }),
+        make("Expected", { false, false, true, false })
         ),
         input_info, output_info, axis, operation, expected)
 {
@@ -107,9 +109,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallAxis0,
                        NEArgMinMaxValidationFixture_S32_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDatasetAxis0,
-                                                       framework::dataset::make("DataTypeIn", DataType::S32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
-                                       framework::dataset::make("Axis", { 0 }),
+                                                       make("DataTypeIn", DataType::S32),
+                                               make("DataTypeOut", DataType::S32),
+                                       make("Axis", { 0 }),
                                OpsDataset))
 {
     // Validate output
@@ -120,8 +122,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEArgMinMaxValidationFixture_S32_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset(),
-                                                       framework::dataset::make("DataTypeIn", DataType::S32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::S32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -132,8 +134,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEArgMinMaxValidationFixture_S32_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset(),
-                                                       framework::dataset::make("DataTypeIn", DataType::S32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::S32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -150,8 +152,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEArgMinMaxValidationFixture_F16_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset(),
-                                                       framework::dataset::make("DataTypeIn", DataType::F16),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F16),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -171,8 +173,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEArgMinMaxValidationFixture_F16_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset(),
-                                                       framework::dataset::make("DataTypeIn", DataType::F16),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F16),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -195,8 +197,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEArgMinMaxValidationFixture_F32_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset(),
-                                                       framework::dataset::make("DataTypeIn", DataType::F32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -209,8 +211,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall_F32_S64,
                        NEArgMinMaxValidationFixture_F32_S64,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset(),
-                                                       framework::dataset::make("DataTypeIn", DataType::F32),
-                                               framework::dataset::make("DataTypeOut", DataType::S64),
+                                                       make("DataTypeIn", DataType::F32),
+                                               make("DataTypeOut", DataType::S64),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -223,8 +225,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEArgMinMaxValidationFixture_F32_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset(),
-                                                       framework::dataset::make("DataTypeIn", DataType::F32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -245,8 +247,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEArgMinMaxQuantizedValidationFixture_U8_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset(),
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))
@@ -258,8 +260,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEArgMinMaxQuantizedValidationFixture_U8_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset(),
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))
@@ -274,8 +276,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEArgMinMaxQuantizedValidationFixture_S8_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset(),
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8_SIGNED),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8_SIGNED),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))
@@ -287,8 +289,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEArgMinMaxQuantizedValidationFixture_S8_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset(),
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8_SIGNED),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8_SIGNED),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))

--- a/tests/validation/NEON/ArithmeticAddition.cpp
+++ b/tests/validation/NEON/ArithmeticAddition.cpp
@@ -53,8 +53,8 @@ constexpr AbsoluteTolerance<float> tolerance_quant(1); /**< Tolerance value for 
 #else                                                  // !defined(__aarch64__) || defined(ENABLE_SVE)
 constexpr AbsoluteTolerance<float> tolerance_quant(1);
 #endif                                                 // !defined(__aarch64__) || defined(ENABLE_SVE)
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -66,22 +66,22 @@ using NEArithmeticAdditionFixture = ArithmeticAdditionValidationFixture<Tensor, 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8), // Unsupported broadcast
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8), // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),// Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false})
+               make("Expected", { true, false, false, false})
                ),
                input1_info, input2_info, output_info, expected)
 {
@@ -92,32 +92,33 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
     ARM_COMPUTE_EXPECT(bool(s) == expected, framework::LogLevel::ERRORS);
 }
 
-DATA_TEST_CASE(KernelSelection, framework::DatasetMode::ALL, concat(concat(
-                combine(framework::dataset::make("CpuExt", std::string("NEON")),
-                       framework::dataset::make("DataType", { DataType::F32,
-                                                              DataType::F16,
-                                                              DataType::U8,
-                                                              DataType::S16,
-                                                              DataType::S32,
-                                                              DataType::QASYMM8,
-                                                              DataType::QASYMM8_SIGNED,
-                                                              DataType::QSYMM16
-                                                            }),
-                        framework::dataset::make("CanUseFixedpoint", {true, false})),
-                combine(framework::dataset::make("CpuExt", std::string("SVE")),
-                        framework::dataset::make("DataType", { DataType::F32,
-                                                               DataType::F16,
-                                                               DataType::U8,
-                                                               DataType::S16,
-                                                               DataType::S32
-                                                             }),
-                        framework::dataset::make("CanUseFixedpoint", {true, false}))),
-                combine(framework::dataset::make("CpuExt", std::string("SVE2")),
-                        framework::dataset::make("DataType", { DataType::QASYMM8,
-                                                               DataType::QASYMM8_SIGNED,
-                                                               DataType::QSYMM16
-                                                             }),
-                        framework::dataset::make("CanUseFixedpoint", {true, false}))),
+DATA_TEST_CASE(KernelSelection, framework::DatasetMode::ALL, concat(
+                combine(make("CpuExt", std::string("NEON")),
+                       make("DataType", { DataType::F32,
+                                              DataType::F16,
+                                              DataType::U8,
+                                              DataType::S16,
+                                              DataType::S32,
+                                              DataType::QASYMM8,
+                                              DataType::QASYMM8_SIGNED,
+                                              DataType::QSYMM16
+                                            }),
+                        make("CanUseFixedpoint", {true, false})),
+                combine(make("CpuExt", std::string("SVE")),
+                        make("DataType", { DataType::F32,
+                                               DataType::F16,
+                                               DataType::U8,
+                                               DataType::S16,
+                                               DataType::S32
+                                             }),
+                        make("CanUseFixedpoint", {true, false})),
+                combine(make("CpuExt", std::string("SVE2")),
+                        make("DataType", { DataType::QASYMM8,
+                                               DataType::QASYMM8_SIGNED,
+                                               DataType::QSYMM16
+                                             }),
+                        make("CanUseFixedpoint", {true, false}))),
+
                cpu_ext, data_type, can_use_fixedpoint)
 {
     using namespace cpu::kernels;
@@ -169,9 +170,9 @@ TEST_CASE(NoPaddingAdded, framework::DatasetMode::PRECOMMIT)
 
 TEST_SUITE(Integer)
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                   DataType::U8),
-                                                                                                                  framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                  make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                   OutOfPlaceDataSet))
 {
     // Validate output
@@ -180,18 +181,18 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<uint8_t>, framework
 TEST_SUITE_END() // U8
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                   DataType::S16),
-                                                                                                                  framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                  make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                   OutOfPlaceDataSet))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticAdditionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticAdditionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                         DataType::S16),
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                 OutOfPlaceDataSet))
 {
     // Validate output
@@ -200,9 +201,9 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticAdditionFixture<int16_t>, framework
 TEST_SUITE_END() // S16
 
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                     DataType::S32),
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                             OutOfPlaceDataSet))
 {
     // Validate output
@@ -214,8 +215,8 @@ TEST_SUITE_END() // Integer
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(F16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16),
-                                                                                                                 framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::F16),
+                                                                                                                 make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                          OutOfPlaceDataSet))
 {
     if(CPUInfo::get().has_fp16())
@@ -233,18 +234,18 @@ TEST_SUITE_END() // F16
 #endif           /* ARM_COMPUTE_ENABLE_FP16 */
 
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticAdditionFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                         DataType::F32),
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                 OutOfPlaceDataSet))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticAdditionFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticAdditionFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                       DataType::F32),
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                               OutOfPlaceDataSet))
 {
     // Validate output
@@ -255,8 +256,8 @@ template <typename T>
 using NEArithmeticAdditionBroadcastFixture = ArithmeticAdditionBroadcastValidationFixture<Tensor, Accessor, NEArithmeticAddition, T>;
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticAdditionBroadcastFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -264,8 +265,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticAdditionBroadcastFixture<f
 }
 
 FIXTURE_DATA_TEST_CASE(RunLargeBroadcast, NEArithmeticAdditionBroadcastFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -285,11 +286,11 @@ TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEArithmeticAdditionQuantizedFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::QASYMM8),
-                                                               framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                       combine(datasets::SmallShapes(), make("DataType", DataType::QASYMM8),
+                                                               make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                OutOfPlaceDataSet))
 {
     // Validate output
@@ -344,11 +345,11 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticAdditionQuantizedBroadcastFixture<int8_t>, framework::DatasetMode::ALL, combine(
-                           datasets::SmallShapesBroadcast(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(0.45f, 20) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(0.55f, 10) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(0.5f, 5) }),
+                           datasets::SmallShapesBroadcast(), make("DataType", DataType::QASYMM8_SIGNED),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(0.45f, 20) }),
+                       make("Src1QInfo", { QuantizationInfo(0.55f, 10) }),
+                       make("OutQInfo", { QuantizationInfo(0.5f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -360,11 +361,11 @@ TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEArithmeticAdditionQuantizedFixture<int16_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::QSYMM16),
-                                                               framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                       combine(datasets::SmallShapes(), make("DataType", DataType::QSYMM16),
+                                                               make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                                OutOfPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/NEON/ArithmeticSubtraction.cpp
+++ b/tests/validation/NEON/ArithmeticSubtraction.cpp
@@ -57,15 +57,15 @@ constexpr AbsoluteTolerance<float> tolerance_qasymm8(1); /**< Tolerance value fo
 constexpr AbsoluteTolerance<int16_t> tolerance_qsymm16(1); /**< Tolerance value for comparing reference's output against implementation's output for quantized data types */
 
 // Quantization Infomation DataSet
-const auto ArithmeticSubtractionQuantizationInfoDataset = combine(framework::dataset::make("QuantizationInfoIn1", { QuantizationInfo(10, 120) }),
-                                                                          framework::dataset::make("QuantizationInfoIn2", { QuantizationInfo(20, 110) }),
-                                                                  framework::dataset::make("QuantizationInfoOut", { QuantizationInfo(15, 125) }));
-const auto ArithmeticSubtractionQuantizationInfoSignedDataset = combine(framework::dataset::make("QuantizationInfoIn1", { QuantizationInfo(0.5f, 10) }),
-                                                                                framework::dataset::make("QuantizationInfoIn2", { QuantizationInfo(0.5f, 20) }),
-                                                                        framework::dataset::make("QuantizationInfoOut", { QuantizationInfo(0.5f, 50) }));
-const auto ArithmeticSubtractionQuantizationInfoSignedInPlaceDataset = combine(framework::dataset::make("QuantizationInfoIn1", { QuantizationInfo(0.8f, 10) }),
-                                                                                       framework::dataset::make("QuantizationInfoIn2", { QuantizationInfo(0.8f, 10) }),
-                                                                               framework::dataset::make("QuantizationInfoOut", { QuantizationInfo(0.8f, 10) }));
+const auto ArithmeticSubtractionQuantizationInfoDataset = combine(make("QuantizationInfoIn1", { QuantizationInfo(10, 120) }),
+                                                                          make("QuantizationInfoIn2", { QuantizationInfo(20, 110) }),
+                                                                  make("QuantizationInfoOut", { QuantizationInfo(15, 125) }));
+const auto ArithmeticSubtractionQuantizationInfoSignedDataset = combine(make("QuantizationInfoIn1", { QuantizationInfo(0.5f, 10) }),
+                                                                                make("QuantizationInfoIn2", { QuantizationInfo(0.5f, 20) }),
+                                                                        make("QuantizationInfoOut", { QuantizationInfo(0.5f, 50) }));
+const auto ArithmeticSubtractionQuantizationInfoSignedInPlaceDataset = combine(make("QuantizationInfoIn1", { QuantizationInfo(0.8f, 10) }),
+                                                                                       make("QuantizationInfoIn2", { QuantizationInfo(0.8f, 10) }),
+                                                                               make("QuantizationInfoOut", { QuantizationInfo(0.8f, 10) }));
 const auto ArithmeticSubtractionQuantizationInfo16bitSymmetric =
     combine(
         make("QuantizationInfoIn1", { QuantizationInfo(0.003f, 0) }),
@@ -74,8 +74,8 @@ const auto ArithmeticSubtractionQuantizationInfo16bitSymmetric =
                                       QuantizationInfo(0.002f, 0) /* for more saturation */ })
     );
 
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 
 void validate_data_types(DataType input1_dtype, DataType input2_dtype, DataType output_dtype)
 {
@@ -120,31 +120,31 @@ using NEArithmeticSubtractionBroadcastFixture = ArithmeticSubtractionBroadcastVa
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                  TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::QASYMM8), // Mismatching types
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8), // Invalid convert policy
         }),
-        framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
         }),
-        framework::dataset::make("ConvertPolicy",{ ConvertPolicy::SATURATE,
+        make("ConvertPolicy",{ ConvertPolicy::SATURATE,
                                                    ConvertPolicy::SATURATE,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
         }),
-        framework::dataset::make("Expected", { true, false, false, false, false})
+        make("Expected", { true, false, false, false, false})
         ),
         input1_info, input2_info, output_info, policy, expected)
 {
@@ -218,9 +218,9 @@ DATA_TEST_CASE(ValidateAllDataTypes, framework::DatasetMode::ALL,
 
 
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                      DataType::U8),
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      OutOfPlaceDataSet))
 {
     // Validate output
@@ -247,9 +247,9 @@ using NEArithmeticSubtractionQuantizedBroadcastFixture = ArithmeticSubtractionVa
 
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionQASYMM8Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionQASYMM8Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                      DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                                                                                                                      ArithmeticSubtractionQuantizationInfoDataset,
                                                                                                              OutOfPlaceDataSet))
 {
@@ -271,8 +271,8 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionQASYMM8SignedFixture, framework::DatasetMode::ALL, combine(
-                                                                                                                       datasets::SmallShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                                                                                       datasets::SmallShapes(), make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                                                                                                                    ArithmeticSubtractionQuantizationInfoSignedDataset,
                                                                                                                    OutOfPlaceDataSet))
 {
@@ -281,8 +281,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionQASYMM8SignedFixture, fr
 }
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticSubtractionQuantizedBroadcastFixture<int8_t>, framework::DatasetMode::ALL, combine(
                            datasets::SmallShapesBroadcast(),
-                           framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                           make("DataType", DataType::QASYMM8_SIGNED),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        ArithmeticSubtractionQuantizationInfoSignedDataset,
                        OutOfPlaceDataSet))
 {
@@ -291,8 +291,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticSubtractionQuantizedBroadc
 }
 FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInPlace, NEArithmeticSubtractionQuantizedBroadcastFixture<int8_t>, framework::DatasetMode::ALL, combine(
                            datasets::TinyShapesBroadcastInplace(),
-                           framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                           make("DataType", DataType::QASYMM8_SIGNED),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        ArithmeticSubtractionQuantizationInfoSignedInPlaceDataset,
                        InPlaceDataSet))
 {
@@ -328,9 +328,9 @@ TEST_SUITE_END() // QSYMM16
 TEST_SUITE_END() // Quantized
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                      DataType::S16),
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      OutOfPlaceDataSet))
 {
     // Validate output
@@ -348,9 +348,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticSubtractionBroadcastFixtur
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                    DataType::S16),
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    OutOfPlaceDataSet))
 {
     // Validate output
@@ -359,9 +359,9 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<int16_t>, framew
 TEST_SUITE_END() // S16
 
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                      DataType::S32),
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      OutOfPlaceDataSet))
 {
     // Validate output
@@ -379,9 +379,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticSubtractionBroadcastFixtur
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                    DataType::S32),
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    OutOfPlaceDataSet))
 {
     // Validate output
@@ -392,9 +392,9 @@ TEST_SUITE_END() // S32
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(F16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                     DataType::F16),
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                             OutOfPlaceDataSet))
 {
     if(CPUInfo::get().has_fp16())
@@ -412,18 +412,18 @@ TEST_SUITE_END() // F16
 #endif           /* ARM_COMPUTE_ENABLE_FP16 */
 
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEArithmeticSubtractionFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                    DataType::F32),
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    InPlaceDataSet))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                  DataType::F32),
-                                                                                                                 framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                 make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                  OutOfPlaceDataSet))
 {
     // Validate output
@@ -431,8 +431,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEArithmeticSubtractionFixture<float>, framewor
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticSubtractionBroadcastFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -440,8 +440,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEArithmeticSubtractionBroadcastFixtur
 }
 
 FIXTURE_DATA_TEST_CASE(RunLargeBroadcast, NEArithmeticSubtractionBroadcastFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        OutOfPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/NEON/BatchConcatenateLayer.cpp
+++ b/tests/validation/NEON/BatchConcatenateLayer.cpp
@@ -39,31 +39,33 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(BatchConcatenateLayer)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32), // Mismatching data type input/output
+        make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32), // Mismatching data type input/output
                                                   TensorInfo(TensorShape(20U, 27U, 4U, 4U), 1, DataType::F32), // Mismatching x dimension
                                                   TensorInfo(TensorShape(23U, 26U, 4U, 3U), 1, DataType::F32), // Mismatching y dim
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 3U), 1, DataType::F32), // Mismatching z dim
                                                   TensorInfo(TensorShape(16U, 27U, 3U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32),
+        make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 3U, 3U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 3U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F16),
+        make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F16),
                                                   TensorInfo(TensorShape(23U, 12U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 20U, 4U, 3U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 3U, 12U), 1, DataType::F32)
         }),
-        framework::dataset::make("Expected", { false, false, false, false, true })
+        make("Expected", { false, false, false, false, true })
         ),
         input_info1, input_info2, output_info,expected)
 {
@@ -91,9 +93,9 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchConcatenateLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::F16),
-                                                                                                                  framework::dataset::make("Axis", 3)))
+                                                                                                                  make("Axis", 3)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -106,9 +108,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchConcatenateLayerFixture<half>, framework
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                         DataType::F16),
-                                                                                                                framework::dataset::make("Axis", 3)))
+                                                                                                                make("Axis", 3)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -126,16 +128,16 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                   framework::dataset::make("DataType",
+                                                                                                                   make("DataType",
                                                                                                                            DataType::F32),
-                                                                                                                   framework::dataset::make("Axis", 3)))
+                                                                                                                   make("Axis", 3)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                  DataType::F32),
-                                                                                                                 framework::dataset::make("Axis", 3)))
+                                                                                                                 make("Axis", 3)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -146,9 +148,9 @@ TEST_SUITE_END()
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("Axis", 3)))
+                                                                                                                     make("Axis", 3)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -156,9 +158,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchConcatenateLayerFixture<uint8_t>, framew
 TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchConcatenateLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                    framework::dataset::make("DataType",
+                                                                                                                    make("DataType",
                                                                                                                             DataType::QASYMM8_SIGNED),
-                                                                                                                    framework::dataset::make("Axis", 3)))
+                                                                                                                    make("Axis", 3)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/BatchNormalizationLayer.cpp
+++ b/tests/validation/NEON/BatchNormalizationLayer.cpp
@@ -46,6 +46,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 #ifndef ARM_COMPUTE_ADDRESS_SANITIZER_BUILD
@@ -56,16 +58,16 @@ constexpr AbsoluteTolerance<float> abs_tolerance_f32(0.0001f); /**< Tolerance va
 constexpr AbsoluteTolerance<float> abs_tolerance_f16(0.015f); /**< Tolerance value for comparing reference's output against implementation's output for DataType::F16 */
 #endif                                                       // ARM_COMPUTE_ENABLE_FP16
 
-const auto act_infos = framework::dataset::make("ActivationInfo",
+const auto act_infos = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 6.f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 8.f, 2.f),
 });
-const auto common_fusion_dataset = combine(framework::dataset::make("UseBias", { false, true }),
-                                                           framework::dataset::make("UseBeta", { false, true }),
-                                                   framework::dataset::make("UseGamma", { false, true }),
-                                           framework::dataset::make("Epsilon", { 0.001f }));
+const auto common_fusion_dataset = combine(make("UseBias", { false, true }),
+                                                           make("UseBeta", { false, true }),
+                                                   make("UseGamma", { false, true }),
+                                           make("Epsilon", { 0.001f }));
 } // namespace
 
 TEST_SUITE(NEON)
@@ -77,31 +79,31 @@ using NEBatchNormalizationLayerFixture = BatchNormalizationLayerValidationFixtur
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
+               make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Invalid mean/var/beta/gamma shape
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Fused activation's a < b
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
+               make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F16),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(5U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                    }),
-               framework::dataset::make("ActivationLayerInfo",{ ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
+               make("ActivationLayerInfo",{ ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 6.f),
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 6.f),
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 6.f),
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 2.f, 6.f),
                                                    }),
-               framework::dataset::make("Expected", { true, false, false, false, false})
+               make("Expected", { true, false, false, false, false})
                ),
                input_info, output_info, mvbg_info, act_info, expected)
 {
@@ -120,20 +122,20 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RandomSmall, NEBatchNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomBatchNormalizationLayerDataset(),framework::dataset::make("UseBeta", { false, true }),
-                                                                                                                                framework::dataset::make("UseGamma", { false, true }),
+FIXTURE_DATA_TEST_CASE(RandomSmall, NEBatchNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomBatchNormalizationLayerDataset(),make("UseBeta", { false, true }),
+                                                                                                                                make("UseGamma", { false, true }),
                                                                                                                         act_infos,
-                                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                        make("DataType", DataType::F32),
+                                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, abs_tolerance_f32, 0);
 }
-FIXTURE_DATA_TEST_CASE(RandomLarge, NEBatchNormalizationLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomBatchNormalizationLayerDataset(),framework::dataset::make("UseBeta", { false, true }),
-                                                                                                                              framework::dataset::make("UseGamma", { false, true }),
+FIXTURE_DATA_TEST_CASE(RandomLarge, NEBatchNormalizationLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomBatchNormalizationLayerDataset(),make("UseBeta", { false, true }),
+                                                                                                                              make("UseGamma", { false, true }),
                                                                                                                       act_infos,
-                                                                                                                      framework::dataset::make("DataType", DataType::F32),
-                                                                                                                      framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                      make("DataType", DataType::F32),
+                                                                                                                      make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, abs_tolerance_f32, 0);
@@ -142,11 +144,11 @@ TEST_SUITE_END() // F32
 
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RandomSmall, NEBatchNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomBatchNormalizationLayerDataset(),framework::dataset::make("UseBeta", { false, true }),
-                                                                                                                               framework::dataset::make("UseGamma", { false, true }),
-                                                                                                                       framework::dataset::make("ActivationInfo", ActivationLayerInfo()),
-                                                                                                                       framework::dataset::make("DataType", DataType::F16),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+FIXTURE_DATA_TEST_CASE(RandomSmall, NEBatchNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomBatchNormalizationLayerDataset(),make("UseBeta", { false, true }),
+                                                                                                                               make("UseGamma", { false, true }),
+                                                                                                                       make("ActivationInfo", ActivationLayerInfo()),
+                                                                                                                       make("DataType", DataType::F16),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -160,11 +162,11 @@ FIXTURE_DATA_TEST_CASE(RandomSmall, NEBatchNormalizationLayerFixture<half>, fram
     }
 }
 
-FIXTURE_DATA_TEST_CASE(RandomLarge, NEBatchNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::LargeRandomBatchNormalizationLayerDataset(),framework::dataset::make("UseBeta", { false, true }),
-                                                                                                                               framework::dataset::make("UseGamma", { false, true }),
-                                                                                                                       framework::dataset::make("ActivationInfo", ActivationLayerInfo()),
-                                                                                                                       framework::dataset::make("DataType", DataType::F16),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+FIXTURE_DATA_TEST_CASE(RandomLarge, NEBatchNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::LargeRandomBatchNormalizationLayerDataset(),make("UseBeta", { false, true }),
+                                                                                                                               make("UseGamma", { false, true }),
+                                                                                                                       make("ActivationInfo", ActivationLayerInfo()),
+                                                                                                                       make("DataType", DataType::F16),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -191,17 +193,17 @@ using NEBatchNormalizationLayerFusionFixture = BatchNormalizationLayerFusionVali
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Weights", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),      // Valid
+               make("Weights", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),      // Valid
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F16),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 1U), 1, DataType::F32),    // Invalid mean/var/beta/gamma shape
                                                      }),
-               framework::dataset::make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
+               make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F16),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(5U), 1, DataType::F32),
                                                    }),
-               framework::dataset::make("Expected", { true, false, false, false})
+               make("Expected", { true, false, false, false})
                ),
                weights_info, mvbg_info, expected)
 {
@@ -227,8 +229,8 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchNormalizationLayerFusionFixture<float>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallConvolutionLayerDataset(), common_fusion_dataset,
-                                       framework::dataset::make("DataType", DataType::F32),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                       make("DataType", DataType::F32),
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, rel_tolerance_f32, 0.f, abs_tolerance_f32);

--- a/tests/validation/NEON/BatchToSpaceLayer.cpp
+++ b/tests/validation/NEON/BatchToSpaceLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(BatchToSpaceLayer)
 
@@ -50,7 +52,7 @@ using NEBatchToSpaceLayerFixture = BatchToSpaceLayerValidationFixture<Tensor, Ac
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
+               make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Supported: blockx != blocky && blockx > blocky
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Supported: blockx != blocky && blocky > blockx
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),     // Invalid: Mismatching data types
@@ -61,12 +63,12 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Supported: correct tensor shape with cropping
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Invalid tensor shape with cropping
                                                      }),
-               framework::dataset::make("BlockShapeX", { 2, 4, 2, 2, 2, 2, 2, 2, 2, 2 }),
-               framework::dataset::make("BlockShapeY", { 2, 2, 4, 2, -2, 2, 2, 2, 2, 2 }),
-               framework::dataset::make("CropInfo", {
+               make("BlockShapeX", { 2, 4, 2, 2, 2, 2, 2, 2, 2, 2 }),
+               make("BlockShapeY", { 2, 2, 4, 2, -2, 2, 2, 2, 2, 2 }),
+               make("CropInfo", {
                 CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{3, 2, 1, 3}, CropInfo{3, 2, 1, 3}
                }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 16U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 32U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F16),
@@ -77,7 +79,7 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(27, 12U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, true, true, false, false, false, false, false, true, false})
+               make("Expected", { true, true, true, false, false, false, false, false, true, false})
                ),
                input_info, block_shape_x, block_shape_y, crop_info, output_info, expected)
 {
@@ -89,26 +91,26 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                        DataType::F32),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallWithCropping, NEBatchToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), framework::dataset::make("DataType",
+                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), make("DataType",
                                                                                                                        DataType::F32),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                      DataType::F32),
-                                                                                                             framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                             make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -116,25 +118,25 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchToSpaceLayerFixture<float>, framework::D
 TEST_SUITE_END()
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEBatchToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                       DataType::F16),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallWithCropping, NEBatchToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), framework::dataset::make("DataType",
+                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), make("DataType",
                                                                                                                        DataType::F16),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEBatchToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                     DataType::F16),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/BitwiseAnd.cpp
+++ b/tests/validation/NEON/BitwiseAnd.cpp
@@ -40,13 +40,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(BitwiseAnd)
 
 template <typename T>
 using NEBitwiseAndFixture = BitwiseAndValidationFixture<Tensor, Accessor, NEBitwiseAnd, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseAndFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseAndFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/NEON/BitwiseNot.cpp
+++ b/tests/validation/NEON/BitwiseNot.cpp
@@ -40,13 +40,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(BitwiseNot)
 
 template <typename T>
 using NEBitwiseNotFixture = BitwiseNotValidationFixture<Tensor, Accessor, NEBitwiseNot, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/NEON/BitwiseOr.cpp
+++ b/tests/validation/NEON/BitwiseOr.cpp
@@ -40,13 +40,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(BitwiseOr)
 
 template <typename T>
 using NEBitwiseOrFixture = BitwiseOrValidationFixture<Tensor, Accessor, NEBitwiseOr, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseOrFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseOrFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                    DataType::U8)))
 {
     // Validate output

--- a/tests/validation/NEON/BitwiseXor.cpp
+++ b/tests/validation/NEON/BitwiseXor.cpp
@@ -40,13 +40,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(BitwiseXor)
 
 template <typename T>
 using NEBitwiseXorFixture = BitwiseXorValidationFixture<Tensor, Accessor, NEBitwiseXor, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseXorFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEBitwiseXorFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/NEON/BoundingBoxTransform.cpp
+++ b/tests/validation/NEON/BoundingBoxTransform.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> relative_tolerance_f32(0.01f);
@@ -54,7 +56,7 @@ constexpr AbsoluteTolerance<uint16_t> tolerance_qasymm16(1);
 
 // *INDENT-OFF*
 // clang-format off
-const auto BboxInfoDataset = framework::dataset::make("BboxInfo", { BoundingBoxTransformInfo(20U, 20U, 2U, true),
+const auto BboxInfoDataset = make("BboxInfo", { BoundingBoxTransformInfo(20U, 20U, 2U, true),
                                                                     BoundingBoxTransformInfo(128U, 128U, 4U, true),
                                                                     BoundingBoxTransformInfo(800U, 600U, 1U, false),
                                                                     BoundingBoxTransformInfo(800U, 600U, 2U, true, { { 1.0, 0.5, 1.5, 2.0 } }),
@@ -62,7 +64,7 @@ const auto BboxInfoDataset = framework::dataset::make("BboxInfo", { BoundingBoxT
                                                                     BoundingBoxTransformInfo(800U, 600U, 4U, false, { { 1.0, 0.5, 1.5, 2.0 } }, true)
                                                                   });
 
-const auto DeltaDataset = framework::dataset::make("DeltasShape", { TensorShape(36U, 1U),
+const auto DeltaDataset = make("DeltasShape", { TensorShape(36U, 1U),
                                                                     TensorShape(36U, 2U),
                                                                     TensorShape(36U, 2U),
                                                                     TensorShape(40U, 1U),
@@ -80,31 +82,31 @@ TEST_SUITE(BBoxTransform)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("BoxesInfo", { TensorInfo(TensorShape(4U, 128U), 1, DataType::F32),
+               make("BoxesInfo", { TensorInfo(TensorShape(4U, 128U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 128U), 1, DataType::F32), // Wrong number of box fields
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F16), // Wrong data type
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F32), // Wrong number of classes
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F32),  // Deltas and predicted boxes have different dimensions
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F32)}),
                // Scaling is zero
-               framework::dataset::make("PredBoxesInfo",{ TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
+               make("PredBoxesInfo",{ TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(127U, 128U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 100U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 100U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 128U), 1, DataType::F32)}),
-               framework::dataset::make("DeltasInfo", { TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
+               make("DeltasInfo", { TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(127U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 100U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 128U), 1, DataType::F32)}),
-               framework::dataset::make("BoundingBoxTransofmInfo", { BoundingBoxTransformInfo(800.f, 600.f, 1.f),
+               make("BoundingBoxTransofmInfo", { BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 0.f)}),
-               framework::dataset::make("Expected", { true, false, false, false, false, false})
+               make("Expected", { true, false, false, false, false, false})
                ),
                boxes_info, pred_boxes_info, deltas_info, bbox_info, expected)
 {
@@ -119,7 +121,7 @@ using NEBoundingBoxTransformFixture = BoundingBoxTransformFixture<Tensor, Access
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(BoundingBox, NEBoundingBoxTransformFixture<float>, framework::DatasetMode::ALL,
-                       combine(DeltaDataset, BboxInfoDataset, framework::dataset::make("DataType", { DataType::F32 })))
+                       combine(DeltaDataset, BboxInfoDataset, make("DataType", { DataType::F32 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, relative_tolerance_f32, 0.f, absolute_tolerance_f32);
@@ -129,7 +131,7 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(BoundingBox, NEBoundingBoxTransformFixture<half>, framework::DatasetMode::ALL,
-                       combine(DeltaDataset, BboxInfoDataset, framework::dataset::make("DataType", { DataType::F16 })))
+                       combine(DeltaDataset, BboxInfoDataset, make("DataType", { DataType::F16 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -153,8 +155,8 @@ template <typename T>
 using NEBoundingBoxTransformQuantizedFixture = BoundingBoxTransformQuantizedFixture<Tensor, Accessor, NEBoundingBoxTransform, T>;
 
 FIXTURE_DATA_TEST_CASE(BoundingBox, NEBoundingBoxTransformQuantizedFixture<uint16_t>, framework::DatasetMode::ALL,
-                       combine(DeltaDataset, BboxInfoDataset, framework::dataset::make("DataType", { DataType::QASYMM16 }),
-                               framework::dataset::make("DeltasQuantInfo", { QuantizationInfo(0.125f, 0) })))
+                       combine(DeltaDataset, BboxInfoDataset, make("DataType", { DataType::QASYMM16 }),
+                               make("DeltasQuantInfo", { QuantizationInfo(0.125f, 0) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm16);

--- a/tests/validation/NEON/ChannelShuffle.cpp
+++ b/tests/validation/NEON/ChannelShuffle.cpp
@@ -40,29 +40,31 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(ChannelShuffle)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Invalid num groups
+               make("InputInfo", { TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Invalid num groups
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::U8),  // Mismatching data_type
                                                        TensorInfo(TensorShape(4U, 5U, 4U), 1, DataType::F32),  // Mismatching shapes
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Num groups == channels
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // (channels % num_groups) != 0
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Valid
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("NumGroups",{ 1, 2, 2, 4, 3, 2,
+               make("NumGroups",{ 1, 2, 2, 4, 3, 2,
                                                      }),
-               framework::dataset::make("Expected", { false, false, false, false, false, true})
+               make("Expected", { false, false, false, false, false, true})
                ),
                input_info, output_info, num_groups, expected)
 {
@@ -76,16 +78,16 @@ using NEChannelShuffleLayerFixture = ChannelShuffleLayerValidationFixture<Tensor
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEChannelShuffleLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomChannelShuffleLayerDataset(),
-                                                                                                                   framework::dataset::make("DataType", DataType::U8),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::U8),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEChannelShuffleLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomChannelShuffleLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType",
+                                                                                                                 make("DataType",
                                                                                                                          DataType::U8),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -96,9 +98,9 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEChannelShuffleLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomChannelShuffleLayerDataset(),
-                                                                                                                        framework::dataset::make("DataType",
+                                                                                                                        make("DataType",
                                                                                                                                 DataType::F16),
-                                                                                                                framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -112,9 +114,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEChannelShuffleLayerFixture<half>, framework::
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEChannelShuffleLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomChannelShuffleLayerDataset(),
-                                                                                                                      framework::dataset::make("DataType",
+                                                                                                                      make("DataType",
                                                                                                                               DataType::F16),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -132,17 +134,17 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEChannelShuffleLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomChannelShuffleLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType",
+                                                                                                                 make("DataType",
                                                                                                                          DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEChannelShuffleLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomChannelShuffleLayerDataset(),
-                                                                                                                       framework::dataset::make("DataType",
+                                                                                                                       make("DataType",
                                                                                                                                DataType::F32),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/Col2Im.cpp
+++ b/tests/validation/NEON/Col2Im.cpp
@@ -36,6 +36,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(Col2Im)
 
@@ -44,19 +46,19 @@ using CpuCol2Im = NESynthetizeFunction<cpu::kernels::CpuCol2ImKernel>;
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::S64),    // Unsupported data type
+               make("InputInfo", { TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::S64),    // Unsupported data type
                                                        TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::F32),    // Mismatching data type
                                                        TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::F32),    // Invalid output shape
                                                        TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(3U, 3U, 10U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("ConvolvedWidth", { 3, 3, 3, 3, 3 }),
-               framework::dataset::make("ConvolvedHeight", { 4, 4, 4, 4, 4 }),
-               framework::dataset::make("Expected", { false, false, false, true })
+               make("ConvolvedWidth", { 3, 3, 3, 3, 3 }),
+               make("ConvolvedHeight", { 4, 4, 4, 4, 4 }),
+               make("Expected", { false, false, false, true })
                ),
                input_info, output_info, convolved_width, convolved_height, expected)
 {

--- a/tests/validation/NEON/Comparisons.cpp
+++ b/tests/validation/NEON/Comparisons.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 const auto run_small_dataset           = combine(datasets::ComparisonOperations(), datasets::SmallShapes());
@@ -55,22 +57,22 @@ TEST_SUITE(Comparison)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Invalid output type
+        make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Invalid output type
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Mismatching input types
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Mismatching shapes
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
         }),
-        framework::dataset::make("Expected", { false, false, false, true})
+        make("Expected", { false, false, false, true})
         ),
         input1_info, input2_info, output_info, expected)
 {
@@ -90,7 +92,7 @@ TEST_SUITE(Bool)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEComparisonFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::U8)))
+                       combine(run_small_dataset, make("DataType", DataType::U8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -103,7 +105,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEComparisonFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_small_dataset, make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -119,7 +121,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEComparisonFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_large_dataset, make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -139,7 +141,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEComparisonFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_small_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -147,7 +149,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEComparisonFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_large_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -165,9 +167,9 @@ TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEComparisonQuantizedFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::QASYMM8),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) })))
+                       combine(run_small_dataset, make("DataType", DataType::QASYMM8),
+                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -177,9 +179,9 @@ TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast,
                        NEComparisonQuantizedBroadcastFixture<int8_t>,
                        framework::DatasetMode::ALL,
-                       combine(run_small_broadcast_dataset, framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1, -30) }),
-                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.3f, 2) })))
+                       combine(run_small_broadcast_dataset, make("DataType", DataType::QASYMM8_SIGNED),
+                                       make("QuantizationInfo", { QuantizationInfo(0.1, -30) }),
+                               make("QuantizationInfo", { QuantizationInfo(0.3f, 2) })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -188,9 +190,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast,
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEComparisonQuantizedFixture<int8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1, -30) }),
-                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.3f, 2) })))
+                       combine(run_small_dataset, make("DataType", DataType::QASYMM8_SIGNED),
+                                       make("QuantizationInfo", { QuantizationInfo(0.1, -30) }),
+                               make("QuantizationInfo", { QuantizationInfo(0.3f, 2) })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/ConvertFullyConnectedWeights.cpp
+++ b/tests/validation/NEON/ConvertFullyConnectedWeights.cpp
@@ -39,9 +39,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-auto params = combine(framework::dataset::make("WeightsWidth", { 16, 32, 64 }), framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+auto params = combine(make("WeightsWidth", { 16, 32, 64 }), make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 } // namespace
 
 TEST_SUITE(NEON)
@@ -50,27 +52,27 @@ TEST_SUITE(ConvertFullyConnectedWeights)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Mismatching data types
+    make("InputInfo", { TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Mismatching data types
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),     // Valid
                                             TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Mismatching shapes
                                             TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Wrong DataLayout
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 42U), 1, DataType::F16),
+    make("OutputInfo",{ TensorInfo(TensorShape(27U, 42U), 1, DataType::F16),
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),
                                           }),
-    framework::dataset::make("OriginalInput", { TensorShape(7U, 3U, 2U),
+    make("OriginalInput", { TensorShape(7U, 3U, 2U),
                                                 TensorShape(7U, 3U, 2U),
                                                 TensorShape(7U, 3U, 2U),
                                                 TensorShape(7U, 3U, 2U),
                                                }),
-    framework::dataset::make("DataLayout", { DataLayout::NCHW,
+    make("DataLayout", { DataLayout::NCHW,
                                              DataLayout::NCHW,
                                              DataLayout::NCHW,
                                              DataLayout::UNKNOWN,
                                                }),
-    framework::dataset::make("Expected", { false, true, false, false})
+    make("Expected", { false, true, false, false})
     ),
     input_info, output_info, original_input_shape, data_layout, expected)
 {
@@ -84,13 +86,13 @@ template <typename T>
 using NEConvertFullyConnectedWeightsFixture = ConvertFullyConnectedWeightsValidationFixture<Tensor, Accessor, NEConvertFullyConnectedWeights, T>;
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::ALL, combine(datasets::Small3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::ALL, combine(datasets::Small3DShapes(), params, make("DataType",
                                                                                                                     DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, make("DataType",
                                                                                                                         DataType::F32)))
 {
     // Validate output
@@ -100,7 +102,7 @@ TEST_SUITE_END() // FP32
 
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::ALL, combine(datasets::Small3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::ALL, combine(datasets::Small3DShapes(), params, make("DataType",
                                                                                                                    DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -114,7 +116,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEConvertFullyConnectedWeightsFixture<half>, fr
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, make("DataType",
                                                                                                                        DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -132,14 +134,14 @@ TEST_SUITE_END() // FP16
 #endif           /* ARM_COMPUTE_ENABLE_FP16 */
 
 TEST_SUITE(QASYMM8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEConvertFullyConnectedWeightsFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::Small3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEConvertFullyConnectedWeightsFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::Small3DShapes(), params, make("DataType",
                                                                                                                       DataType::QASYMM8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEConvertFullyConnectedWeightsFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8)))
 {
     // Validate output

--- a/tests/validation/NEON/Convolution3D.cpp
+++ b/tests/validation/NEON/Convolution3D.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 #ifdef ARM_COMPUTE_ENABLE_FP16
@@ -52,7 +54,7 @@ constexpr AbsoluteTolerance<float>   tolerance_fp32(0.001f);                    
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);                           /**< Tolerance for quantized tests */
 
 /** Activation function Dataset*/
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 0.5f)
@@ -60,18 +62,18 @@ const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo
 
 const auto data_precommit = combine(zip(
                                                                                     datasets::SmallDirectConv3DShapes(),
-                                                                                    framework::dataset::make("StrideX", { 1, 5, 8 }),
-                                                                                    framework::dataset::make("StrideY", { 1, 2, 3 }),
-                                                                                    framework::dataset::make("StrideZ", { 1, 2, 1 }),
-                                                                                    framework::dataset::make("PadX", { 0, 1, 2 }),
-                                                                                    framework::dataset::make("PadY", { 0, 2, 1 }),
-                                                                                    framework::dataset::make("PadZ", { 0, 3, 5 }),
-                                                                                    framework::dataset::make("KernelWidth", { 3, 5, 9 }),
-                                                                                    framework::dataset::make("KernelHeight", { 2, 1, 3 }),
-                                                                                    framework::dataset::make("KernelDepth", { 1, 2, 3 }),
-                                                                                    framework::dataset::make("NumKernels", { 2, 3, 8 })
+                                                                                    make("StrideX", { 1, 5, 8 }),
+                                                                                    make("StrideY", { 1, 2, 3 }),
+                                                                                    make("StrideZ", { 1, 2, 1 }),
+                                                                                    make("PadX", { 0, 1, 2 }),
+                                                                                    make("PadY", { 0, 2, 1 }),
+                                                                                    make("PadZ", { 0, 3, 5 }),
+                                                                                    make("KernelWidth", { 3, 5, 9 }),
+                                                                                    make("KernelHeight", { 2, 1, 3 }),
+                                                                                    make("KernelDepth", { 1, 2, 3 }),
+                                                                                    make("NumKernels", { 2, 3, 8 })
                                                 ),
-                                            framework::dataset::make("HasBias", { true, false }),
+                                            make("HasBias", { true, false }),
                                     ActivationFunctionsDataset);
 } // namespace
 
@@ -81,7 +83,7 @@ TEST_SUITE(Convolution3D)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U, 4U), 1U, DataType::F32, DataLayout::NDHWC), // Mismatching data type input/weights
+        make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U, 4U), 1U, DataType::F32, DataLayout::NDHWC), // Mismatching data type input/weights
                                                 TensorInfo(TensorShape(27U, 13U, 2U, 4U), 1U, DataType::F32, DataLayout::NDHWC), // Mismatching input feature maps
                                                 TensorInfo(TensorShape(27U, 13U, 2U, 4U), 1U, DataType::F32, DataLayout::NDHWC), // Invalid weights dimensions
                                                 TensorInfo(TensorShape(27U, 13U, 2U, 4U), 1U, DataType::F32, DataLayout::NHWC), // Invalid data layout
@@ -90,7 +92,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(27U, 13U, 2U, 4U), 1U, DataType::F32, DataLayout::NDHWC), // Invalid output size
                                                 TensorInfo(TensorShape(27U, 13U, 2U, 4U), 1U, DataType::U32, DataLayout::NDHWC), // Invalid data type
                                               }),
-        framework::dataset::make("WeightsInfo",{ TensorInfo(TensorShape(4U, 3U, 3U, 3U, 2U), 1U, DataType::F16),
+        make("WeightsInfo",{ TensorInfo(TensorShape(4U, 3U, 3U, 3U, 2U), 1U, DataType::F16),
                                                  TensorInfo(TensorShape(4U, 3U, 3U, 3U, 3U), 1U, DataType::F32),
                                                  TensorInfo(TensorShape(4U, 3U, 3U, 3U, 2U, 3U), 1U, DataType::F32),
                                                  TensorInfo(TensorShape(4U, 3U, 3U, 3U, 2U), 1U, DataType::F32),
@@ -99,7 +101,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                  TensorInfo(TensorShape(4U, 3U, 3U, 3U, 2U), 1U, DataType::F32),
                                                  TensorInfo(TensorShape(4U, 3U, 3U, 3U, 2U), 1U, DataType::U32),
                                               }),
-        framework::dataset::make("BiasesInfo",{ TensorInfo(TensorShape(4U), 1U, DataType::F32),
+        make("BiasesInfo",{ TensorInfo(TensorShape(4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1U, DataType::F32),
@@ -108,7 +110,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1U, DataType::F32),
                                               }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 4U), 1U, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1U, DataType::F32),
@@ -117,7 +119,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(26U, 11U, 4U), 1U, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1U, DataType::U32),
                                               }),
-        framework::dataset::make("Expected", { false, false, false, false, false, false, false, false})
+        make("Expected", { false, false, false, false, false, false, false, false})
         ),
         input_info, weights_info, biases_info, output_info, expected)
 {
@@ -134,8 +136,8 @@ using NEDirectConvolution3DFixture = DirectConvolution3DValidationFixture<Tensor
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectConvolution3DFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                                                                                                                 framework::dataset::make("DataType", DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NDHWC })))
+                                                                                                                 make("DataType", DataType::F32),
+                                                                                                                 make("DataLayout", { DataLayout::NDHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
@@ -145,8 +147,8 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectConvolution3DFixture<half>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                                                                                                                        framework::dataset::make("DataType", DataType::F16),
-                                                                                                                framework::dataset::make("DataLayout", { DataLayout::NDHWC })))
+                                                                                                                        make("DataType", DataType::F16),
+                                                                                                                make("DataLayout", { DataLayout::NDHWC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -171,29 +173,29 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectConvolution3DQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(zip(
-                                                                                                                   framework::dataset::make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
+                                                                                                                   make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
                                                                                                                            TensorShape(15U, 7U, 11U, 7U),
                                                                                                                            TensorShape(19U, 5U, 16U, 4U),
                                                                                                                            TensorShape(13U, 5U, 17U, 2U)
                                                                                                                                                           }),
-                                                                                                                   framework::dataset::make("StrideX", { 1, 3, 2, 1 }),
-                                                                                                                   framework::dataset::make("StrideY", { 2, 1, 3, 1 }),
-                                                                                                                   framework::dataset::make("StrideZ", { 3, 2, 1, 1 }),
-                                                                                                                   framework::dataset::make("PadX", { 0, 2, 1, 0 }),
-                                                                                                                   framework::dataset::make("PadY", { 1, 0, 2, 0 }),
-                                                                                                                   framework::dataset::make("PadZ", { 2, 1, 0, 0 }),
-                                                                                                                   framework::dataset::make("KernelWidth", { 3, 7, 5, 1 }),
-                                                                                                                   framework::dataset::make("KernelHeight", { 5, 3, 7, 1 }),
-                                                                                                                   framework::dataset::make("KernelDepth", { 7, 5, 3, 1 }),
-                                                                                                                   framework::dataset::make("NumKernels", { 5, 3, 1, 11 }),
-                                                                                                                   framework::dataset::make("HasBias", { true, true, true, false })
+                                                                                                                   make("StrideX", { 1, 3, 2, 1 }),
+                                                                                                                   make("StrideY", { 2, 1, 3, 1 }),
+                                                                                                                   make("StrideZ", { 3, 2, 1, 1 }),
+                                                                                                                   make("PadX", { 0, 2, 1, 0 }),
+                                                                                                                   make("PadY", { 1, 0, 2, 0 }),
+                                                                                                                   make("PadZ", { 2, 1, 0, 0 }),
+                                                                                                                   make("KernelWidth", { 3, 7, 5, 1 }),
+                                                                                                                   make("KernelHeight", { 5, 3, 7, 1 }),
+                                                                                                                   make("KernelDepth", { 7, 5, 3, 1 }),
+                                                                                                                   make("NumKernels", { 5, 3, 1, 11 }),
+                                                                                                                   make("HasBias", { true, true, true, false })
                                                                            ),
-                                                                       framework::dataset::make("Activation", ActivationLayerInfo()),
-                                                               framework::dataset::make("DataType", DataType::QASYMM8),
-                                                       framework::dataset::make("DataLayout", DataLayout::NDHWC),
-                                               framework::dataset::make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
-                                       framework::dataset::make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
-                               framework::dataset::make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
+                                                                       make("Activation", ActivationLayerInfo()),
+                                                               make("DataType", DataType::QASYMM8),
+                                                       make("DataLayout", DataLayout::NDHWC),
+                                               make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
+                                       make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
+                               make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
 {
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
@@ -203,29 +205,29 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectConvolution3DQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(zip(
-                                                                                                                   framework::dataset::make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
+                                                                                                                   make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
                                                                                                                            TensorShape(15U, 7U, 11U, 7U),
                                                                                                                            TensorShape(19U, 5U, 16U, 4U),
                                                                                                                            TensorShape(13U, 5U, 17U, 2U)
                                                                                                                                                           }),
-                                                                                                                   framework::dataset::make("StrideX", { 1, 3, 2, 1 }),
-                                                                                                                   framework::dataset::make("StrideY", { 2, 1, 3, 1 }),
-                                                                                                                   framework::dataset::make("StrideZ", { 3, 2, 1, 1 }),
-                                                                                                                   framework::dataset::make("PadX", { 0, 2, 1, 0 }),
-                                                                                                                   framework::dataset::make("PadY", { 1, 0, 2, 0 }),
-                                                                                                                   framework::dataset::make("PadZ", { 2, 1, 0, 0 }),
-                                                                                                                   framework::dataset::make("KernelWidth", { 3, 7, 5, 1 }),
-                                                                                                                   framework::dataset::make("KernelHeight", { 5, 3, 7, 1 }),
-                                                                                                                   framework::dataset::make("KernelDepth", { 7, 5, 3, 1 }),
-                                                                                                                   framework::dataset::make("NumKernels", { 5, 3, 1, 11 }),
-                                                                                                                   framework::dataset::make("HasBias", { true, true, true, false })
+                                                                                                                   make("StrideX", { 1, 3, 2, 1 }),
+                                                                                                                   make("StrideY", { 2, 1, 3, 1 }),
+                                                                                                                   make("StrideZ", { 3, 2, 1, 1 }),
+                                                                                                                   make("PadX", { 0, 2, 1, 0 }),
+                                                                                                                   make("PadY", { 1, 0, 2, 0 }),
+                                                                                                                   make("PadZ", { 2, 1, 0, 0 }),
+                                                                                                                   make("KernelWidth", { 3, 7, 5, 1 }),
+                                                                                                                   make("KernelHeight", { 5, 3, 7, 1 }),
+                                                                                                                   make("KernelDepth", { 7, 5, 3, 1 }),
+                                                                                                                   make("NumKernels", { 5, 3, 1, 11 }),
+                                                                                                                   make("HasBias", { true, true, true, false })
                                                                            ),
-                                                                       framework::dataset::make("Activation", ActivationLayerInfo()),
-                                                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                       framework::dataset::make("DataLayout", DataLayout::NDHWC),
-                                               framework::dataset::make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
-                                       framework::dataset::make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
-                               framework::dataset::make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
+                                                                       make("Activation", ActivationLayerInfo()),
+                                                               make("DataType", DataType::QASYMM8_SIGNED),
+                                                       make("DataLayout", DataLayout::NDHWC),
+                                               make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
+                                       make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
+                               make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
 {
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }

--- a/tests/validation/NEON/ConvolutionLayer.cpp
+++ b/tests/validation/NEON/ConvolutionLayer.cpp
@@ -313,10 +313,10 @@ FIXTURE_DATA_TEST_CASE(
     framework::DatasetMode::ALL,
     combine(
         datasets::SmallConvolutionLayerDataset(),
-        framework::dataset::make("ReshapeWeights", { true }),
-        framework::dataset::make("DataType",       { DataType::QASYMM8_SIGNED }),
-        framework::dataset::make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
-        framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+        make("ReshapeWeights", { true }),
+        make("DataType",       { DataType::QASYMM8_SIGNED }),
+        make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
+        make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
         ActivationFunctionsDataset
     )
 )
@@ -332,10 +332,10 @@ FIXTURE_DATA_TEST_CASE(
     framework::DatasetMode::NIGHTLY,
     combine(
         datasets::LargeConvolutionLayerDataset(),
-        framework::dataset::make("ReshapeWeights", { true }),
-        framework::dataset::make("DataType",       { DataType::QASYMM8_SIGNED }),
-        framework::dataset::make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
-        framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+        make("ReshapeWeights", { true }),
+        make("DataType",       { DataType::QASYMM8_SIGNED }),
+        make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
+        make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
         ActivationFunctionsDataset
     )
 )
@@ -933,28 +933,28 @@ using HasOptImplFixtureFastMath = HasOptImplFixture<ConvolutionClass, /*enable_f
 // UC2_1
 
 FIXTURE_DATA_TEST_CASE(UC2_1_CpuGemmConv2d, HasOptImplFixtureNoFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
 FIXTURE_DATA_TEST_CASE(UC2_1_NEGEMMConvolutionLayer, HasOptImplFixtureNoFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
 
 FIXTURE_DATA_TEST_CASE(UC2_1_CpuGemmConv2d_FastMath, HasOptImplFixtureFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
 
 FIXTURE_DATA_TEST_CASE(UC2_1_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo2 })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
@@ -963,16 +963,16 @@ FIXTURE_DATA_TEST_CASE(UC2_1_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureF
 // kernel that support that fixed format is found.
 
 FIXTURE_DATA_TEST_CASE(UC2_2_CpuGemmConv2d, HasOptImplFixtureNoFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo4 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo4 })))
 {
     ARM_COMPUTE_EXPECT(_kernel_found, framework::LogLevel::ERRORS);
     ARM_COMPUTE_EXPECT(_computed_weight_format == arm_compute::WeightFormat::OHWIo4, framework::LogLevel::ERRORS);
 }
 
 FIXTURE_DATA_TEST_CASE(UC2_2_NEGEMMConvolutionLayer, HasOptImplFixtureNoFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo4 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo4 })))
 {
     ARM_COMPUTE_EXPECT(_kernel_found, framework::LogLevel::ERRORS);
     ARM_COMPUTE_EXPECT(_computed_weight_format == arm_compute::WeightFormat::OHWIo4, framework::LogLevel::ERRORS);
@@ -983,8 +983,8 @@ FIXTURE_DATA_TEST_CASE(UC2_2_NEGEMMConvolutionLayer, HasOptImplFixtureNoFastMath
 // If other SVE length is used a kernel will fail to be found
 // This needs to be addressed in order to ensure it doesn't revert to FP32 kernels for systems with SVE length other than 256
 FIXTURE_DATA_TEST_CASE(UC2_2_CpuGemmConv2d_FastMath, HasOptImplFixtureFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo8i4_bf16 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo8i4_bf16 })))
 {
     if(Scheduler::get().cpu_info().has_bf16() && (arm_gemm::utils::get_vector_length<float>() == 8)){
         ARM_COMPUTE_EXPECT(_kernel_found, framework::LogLevel::ERRORS);
@@ -996,8 +996,8 @@ FIXTURE_DATA_TEST_CASE(UC2_2_CpuGemmConv2d_FastMath, HasOptImplFixtureFastMath<c
 }
 
 FIXTURE_DATA_TEST_CASE(UC2_2_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo8i4_bf16 })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::OHWIo8i4_bf16 })))
 {
     if(Scheduler::get().cpu_info().has_bf16() && (arm_gemm::utils::get_vector_length<float>() == 8)){
         ARM_COMPUTE_EXPECT(_kernel_found, framework::LogLevel::ERRORS);
@@ -1016,29 +1016,29 @@ FIXTURE_DATA_TEST_CASE(UC2_2_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureF
 // problem).
 
 FIXTURE_DATA_TEST_CASE(UC3_1_CpuGemmConv2d, HasOptImplFixtureNoFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::S32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::S32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
 
 FIXTURE_DATA_TEST_CASE(UC3_1_NEGEMMConvolutionLayer, HasOptImplFixtureNoFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::S32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::S32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
 
 FIXTURE_DATA_TEST_CASE(UC3_1_CpuGemmConv2d_FastMath, HasOptImplFixtureFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::S32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::S32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
 
 FIXTURE_DATA_TEST_CASE(UC3_1_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::S32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::S32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     ARM_COMPUTE_EXPECT(!_kernel_found, framework::LogLevel::ERRORS);
 }
@@ -1054,8 +1054,8 @@ FIXTURE_DATA_TEST_CASE(UC3_1_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureF
 // is replaced by OHWIo8 when running on 256-bit SVE.
 
 FIXTURE_DATA_TEST_CASE(UC3_2_CpuGemmConv2d, HasOptImplFixtureNoFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     ARM_COMPUTE_EXPECT(_kernel_found, framework::LogLevel::ERRORS);
     ARM_COMPUTE_EXPECT(_computed_weight_format != arm_compute::WeightFormat::ANY, framework::LogLevel::ERRORS);
@@ -1063,8 +1063,8 @@ FIXTURE_DATA_TEST_CASE(UC3_2_CpuGemmConv2d, HasOptImplFixtureNoFastMath<cpu::Cpu
 }
 
 FIXTURE_DATA_TEST_CASE(UC3_2_NEGEMMConvolutionLayer, HasOptImplFixtureNoFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     ARM_COMPUTE_EXPECT(_computed_weight_format != arm_compute::WeightFormat::ANY, framework::LogLevel::ERRORS);
     ARM_COMPUTE_EXPECT(_computed_weight_format != arm_compute::WeightFormat::UNSPECIFIED, framework::LogLevel::ERRORS);
@@ -1073,8 +1073,8 @@ FIXTURE_DATA_TEST_CASE(UC3_2_NEGEMMConvolutionLayer, HasOptImplFixtureNoFastMath
 #if defined(ARM_COMPUTE_ENABLE_BF16)
 
 FIXTURE_DATA_TEST_CASE(UC3_2_CpuGemmConv2d_FastMath, HasOptImplFixtureFastMath<cpu::CpuGemmConv2d>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     if(Scheduler::get().cpu_info().has_bf16()){
         ARM_COMPUTE_EXPECT(_kernel_found, framework::LogLevel::ERRORS);
@@ -1091,8 +1091,8 @@ FIXTURE_DATA_TEST_CASE(UC3_2_CpuGemmConv2d_FastMath, HasOptImplFixtureFastMath<c
 }
 
 FIXTURE_DATA_TEST_CASE(UC3_2_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureFastMath<NEGEMMConvolutionLayer>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
+                       combine(make("DataType", { DataType::F32 }),
+                               make("QueryWeightFormat", { arm_compute::WeightFormat::ANY })))
 {
     if(Scheduler::get().cpu_info().has_bf16()){
         ARM_COMPUTE_EXPECT(_kernel_found, framework::LogLevel::ERRORS);
@@ -1113,7 +1113,7 @@ FIXTURE_DATA_TEST_CASE(UC3_2_NEGEMMConvolutionLayer_FastMath, HasOptImplFixtureF
 namespace
 {
 using TestCaseType          = std::tuple<TensorShape, TensorShape, arm_compute::WeightFormat>;
-auto prepare_weights_shapes = framework::dataset::make("TensorShape",
+auto prepare_weights_shapes = make("TensorShape",
 {
     // OHWIo<interleave_by>i<block_by>
     //
@@ -1195,8 +1195,8 @@ using VarWidth = VariableWeightsFixture<cpu::CpuGemmConv2d, Tensor, Accessor, Sc
 
 FIXTURE_DATA_TEST_CASE(RunSmallFloat, VarWidth<float>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                               framework::dataset::make("ACL Scalar type", { DataType::F32 })))
+                                       make("DataLayout", { DataLayout::NHWC }),
+                               make("ACL Scalar type", { DataType::F32 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, rel_tolerance_f32, 0.f, float(abs_tolerance_f32));
@@ -1205,8 +1205,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallFloat, VarWidth<float>, framework::DatasetMode::A
 #if defined(ARM_COMPUTE_ENABLE_FP16)
 FIXTURE_DATA_TEST_CASE(RunSmallHalf, VarWidth<half>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                               framework::dataset::make("ACL Scalar type", { DataType::F16 })))
+                                       make("DataLayout", { DataLayout::NHWC }),
+                               make("ACL Scalar type", { DataType::F16 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -1227,8 +1227,8 @@ using VarWidthFastMath = VariableWeightsFixture<cpu::CpuGemmConv2d, Tensor, Acce
 
 FIXTURE_DATA_TEST_CASE(RunSmallFloatFastMath, VarWidthFastMath<float>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                               framework::dataset::make("ACL Scalar type", { DataType::F32 })))
+                                       make("DataLayout", { DataLayout::NHWC }),
+                               make("ACL Scalar type", { DataType::F32 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, rel_tolerance_f32, 0.f, float(abs_tolerance_f32));
@@ -1244,8 +1244,8 @@ using NEGEMMVarWidth = VariableWeightsFixtureNEInterface<NEGEMMConvolutionLayer,
 
 FIXTURE_DATA_TEST_CASE(NEGEMMRunSmallFloat, NEGEMMVarWidth<float>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                               framework::dataset::make("ACL Scalar type", { DataType::F32 })))
+                                       make("DataLayout", { DataLayout::NHWC }),
+                               make("ACL Scalar type", { DataType::F32 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, rel_tolerance_f32, 0.f, float(abs_tolerance_f32));
@@ -1254,8 +1254,8 @@ FIXTURE_DATA_TEST_CASE(NEGEMMRunSmallFloat, NEGEMMVarWidth<float>, framework::Da
 #if defined(ARM_COMPUTE_ENABLE_FP16)
 FIXTURE_DATA_TEST_CASE(NEGEMMRunSmallHalf, NEGEMMVarWidth<half>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                               framework::dataset::make("ACL Scalar type", { DataType::F16 })))
+                                       make("DataLayout", { DataLayout::NHWC }),
+                               make("ACL Scalar type", { DataType::F16 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -1276,8 +1276,8 @@ using NEGEMMVarWidthFastMath = VariableWeightsFixtureNEInterface<NEGEMMConvoluti
 
 FIXTURE_DATA_TEST_CASE(NEGEMMRunSmallFloatFastMath, NEGEMMVarWidthFastMath<float>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                               framework::dataset::make("ACL Scalar type", { DataType::F32 })))
+                                       make("DataLayout", { DataLayout::NHWC }),
+                               make("ACL Scalar type", { DataType::F32 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, rel_tolerance_f32, 0.f, float(abs_tolerance_f32));
@@ -1396,9 +1396,9 @@ TEST_SUITE(Float)
 #if defined(ARM_COMPUTE_ENABLE_BF16)
 TEST_SUITE(BFLOAT16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                    framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                    framework::dataset::make("DataType", Scheduler::get().cpu_info().has_bf16() ? DataType::BFLOAT16 : DataType::F32),
-                                                                                                                    framework::dataset::make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                    make("ReshapeWeights", { true }),
+                                                                                                                    make("DataType", Scheduler::get().cpu_info().has_bf16() ? DataType::BFLOAT16 : DataType::F32),
+                                                                                                                    make("DataLayout", { DataLayout::NHWC }),
                                                                                                             ActivationFunctionsDataset))
 {
     // Validate output
@@ -1410,9 +1410,9 @@ TEST_SUITE_END() // BFLOAT16
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                   framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                   framework::dataset::make("DataType", DataType::F16),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW }),
+                                                                                                                   make("ReshapeWeights", { true }),
+                                                                                                                   make("DataType", DataType::F16),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW }),
                                                                                                            ActivationFunctionsDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -1431,9 +1431,9 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                    framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                    framework::dataset::make("DataType", DataType::F32),
-                                                                                                                    framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                    make("ReshapeWeights", { true }),
+                                                                                                                    make("DataType", DataType::F32),
+                                                                                                                    make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                                                                             ActivationFunctionsDataset))
 {
     // Validate output
@@ -1441,15 +1441,15 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerFixture<float>, framework
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEGEMMConvolutionLayerMixedDataLayoutFixture<float>, framework::DatasetMode::ALL,
                        combine(
-                                                                                           framework::dataset::make("Input", TensorShape(23U, 27U, 5U)),
-                                                                                           framework::dataset::make("Weights", TensorShape(3U, 3U, 5U, 2U)),
-                                                                                       framework::dataset::make("Bias", TensorShape(2U)),
-                                                                               framework::dataset::make("Output", TensorShape(11U, 25U, 2U)),
-                                                                       framework::dataset::make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
-                                                               framework::dataset::make("Dilation", Size2D(1, 1)),
-                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                               framework::dataset::make("DataType", DataType::F32),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                           make("Input", TensorShape(23U, 27U, 5U)),
+                                                                                           make("Weights", TensorShape(3U, 3U, 5U, 2U)),
+                                                                                       make("Bias", TensorShape(2U)),
+                                                                               make("Output", TensorShape(11U, 25U, 2U)),
+                                                                       make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
+                                                               make("Dilation", Size2D(1, 1)),
+                                                       make("ReshapeWeights", { true }),
+                                               make("DataType", DataType::F32),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                ActivationFunctionsDataset))
 {
     // Validate output
@@ -1462,9 +1462,9 @@ FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEGEMMConvolutionLayerMixedDataLayout
  * We only need to test the padded weight path here on a single floating data type and a single layout, because the fallback path is agnostic of them
  */
 FIXTURE_DATA_TEST_CASE(RunPaddedWeights, NEGEMMConvolutionLayerPaddedWeightsFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                    framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                    framework::dataset::make("DataType", DataType::F32),
-                                                                                                                    framework::dataset::make("DataLayout", { DataLayout::NHWC })
+                                                                                                                    make("ReshapeWeights", { true }),
+                                                                                                                    make("DataType", DataType::F32),
+                                                                                                                    make("DataLayout", { DataLayout::NHWC })
                                                                                                             ))
 {
     // Validate output
@@ -1475,9 +1475,9 @@ FIXTURE_DATA_TEST_CASE(RunPaddedWeights, NEGEMMConvolutionLayerPaddedWeightsFixt
 // and weight dimensions larger than 7
 FIXTURE_DATA_TEST_CASE(RunVeryLarge, NEGEMMConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY,
     combine(datasets::VeryLargeConvolutionLayerDataset(),
-        framework::dataset::make("ReshapeWeights", { true }),
-        framework::dataset::make("DataType", DataType::F32),
-        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+        make("ReshapeWeights", { true }),
+        make("DataType", DataType::F32),
+        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
         NoActivation))
 {
     // Validate output
@@ -1502,7 +1502,7 @@ using NEGEMMConvolutionLayerQuantizedMixedSignFixture = ConvolutionValidationQua
 template <typename T>
 using NEGEMMConvolutionLayerQuantizedPerChannelFixture = ConvolutionValidationQuantizedPerChannelFixture<Tensor, Accessor, NEConvolutionLayer, T, int8_t>;
 
-const auto QuantizedActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto QuantizedActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -1519,10 +1519,10 @@ TEST_SUITE(Quantized)
 TEST_SUITE(UpdateStaticQuantInfoAfterConfigure)
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerForUpdatedStaticQuantInfoAfterConfigureFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                      framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                      framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                      framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                      framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(0.01f, -10) }),
+                                                                                                                      make("ReshapeWeights", { true }),
+                                                                                                                      make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                      make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                      make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(0.01f, -10) }),
                                                                                                                       QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1532,10 +1532,10 @@ TEST_SUITE_END() // QASYMM8_SIGNED
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerForUpdatedStaticQuantInfoAfterConfigureFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                       framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                       make("ReshapeWeights", { true }),
+                                                                                                                       make("DataType", DataType::QASYMM8),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                       make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
                                                                                                                        QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1547,10 +1547,10 @@ TEST_SUITE_END() // UpdateStaticQuantInfoAfterConfigure
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                       framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                       make("ReshapeWeights", { true }),
+                                                                                                                       make("DataType", DataType::QASYMM8),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                       make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
                                                                                                                        QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1559,16 +1559,16 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerQuantizedFixture<uint8_t>
 
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEGEMMConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(
-                                                                                                   framework::dataset::make("Input", TensorShape(23U, 27U, 5U)),
-                                                                                                   framework::dataset::make("Weights", TensorShape(3U, 3U, 5U, 2U)),
-                                                                                               framework::dataset::make("Bias", TensorShape(2U)),
-                                                                                       framework::dataset::make("Output", TensorShape(11U, 25U, 2U)),
-                                                                               framework::dataset::make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
-                                                                       framework::dataset::make("Dilation", Size2D(1, 1)),
-                                                               framework::dataset::make("ReshapeWeights", { true }),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                   make("Input", TensorShape(23U, 27U, 5U)),
+                                                                                                   make("Weights", TensorShape(3U, 3U, 5U, 2U)),
+                                                                                               make("Bias", TensorShape(2U)),
+                                                                                       make("Output", TensorShape(11U, 25U, 2U)),
+                                                                               make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
+                                                                       make("Dilation", Size2D(1, 1)),
+                                                               make("ReshapeWeights", { true }),
+                                                       make("DataType", DataType::QASYMM8),
+                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
                                QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1587,10 +1587,10 @@ FIXTURE_DATA_TEST_CASE(
     framework::DatasetMode::ALL,
     combine(
         datasets::SmallConvolutionLayerDataset(),
-        framework::dataset::make("ReshapeWeights", { true }),
-        framework::dataset::make("DataType",       { DataType::QASYMM8_SIGNED }),
-        framework::dataset::make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
-        framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+        make("ReshapeWeights", { true }),
+        make("DataType",       { DataType::QASYMM8_SIGNED }),
+        make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
+        make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
         ActivationFunctionsDataset
     )
 )
@@ -1605,10 +1605,10 @@ FIXTURE_DATA_TEST_CASE(
     framework::DatasetMode::NIGHTLY,
     combine(
         datasets::LargeConvolutionLayerDataset(),
-        framework::dataset::make("ReshapeWeights", { true }),
-        framework::dataset::make("DataType",       { DataType::QASYMM8_SIGNED }),
-        framework::dataset::make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
-        framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+        make("ReshapeWeights", { true }),
+        make("DataType",       { DataType::QASYMM8_SIGNED }),
+        make("DataLayout",     { DataLayout::NCHW, DataLayout::NHWC }),
+        make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
         ActivationFunctionsDataset
     )
 )
@@ -1618,10 +1618,10 @@ FIXTURE_DATA_TEST_CASE(
 #endif // #ifdef __aarch64__
 
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                      framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                      framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                      framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                      framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(0.01f, -10) }),
+                                                                                                                      make("ReshapeWeights", { true }),
+                                                                                                                      make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                      make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                      make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(0.01f, -10) }),
                                                                                                                       QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1629,16 +1629,16 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerQuantizedFixture<int8_t>,
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEGEMMConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL,
                        combine(
-                                                                                                   framework::dataset::make("Input", TensorShape(23U, 27U, 5U)),
-                                                                                                   framework::dataset::make("Weights", TensorShape(3U, 3U, 5U, 2U)),
-                                                                                               framework::dataset::make("Bias", TensorShape(2U)),
-                                                                                       framework::dataset::make("Output", TensorShape(11U, 25U, 2U)),
-                                                                               framework::dataset::make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
-                                                                       framework::dataset::make("Dilation", Size2D(1, 1)),
-                                                               framework::dataset::make("ReshapeWeights", { true }),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                   make("Input", TensorShape(23U, 27U, 5U)),
+                                                                                                   make("Weights", TensorShape(3U, 3U, 5U, 2U)),
+                                                                                               make("Bias", TensorShape(2U)),
+                                                                                       make("Output", TensorShape(11U, 25U, 2U)),
+                                                                               make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
+                                                                       make("Dilation", Size2D(1, 1)),
+                                                               make("ReshapeWeights", { true }),
+                                                       make("DataType", DataType::QASYMM8_SIGNED),
+                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("QuantizationInfoIfActivationEnabled", { QuantizationInfo(2.f / 255.f, 10) }),
                                QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1652,13 +1652,13 @@ FIXTURE_DATA_TEST_CASE(
     NEGEMMConvolutionLayerQuantizedMixedSignFixture,
     framework::DatasetMode::ALL,
     combine(datasets::SmallConvolutionLayerDataset(),
-                                                            framework::dataset::make("ReshapeWeights", {true}),
-                                                    framework::dataset::make("DataType", DataType::QASYMM8),
-                                            framework::dataset::make("WeightsDataType", DataType::QASYMM8_SIGNED),
-                                    framework::dataset::make("DataLayout", {DataLayout::NCHW, DataLayout::NHWC}),
-                            framework::dataset::make("QuantizationInfoIfActivationEnabled",
+                                                            make("ReshapeWeights", {true}),
+                                                    make("DataType", DataType::QASYMM8),
+                                            make("WeightsDataType", DataType::QASYMM8_SIGNED),
+                                    make("DataLayout", {DataLayout::NCHW, DataLayout::NHWC}),
+                            make("QuantizationInfoIfActivationEnabled",
 {QuantizationInfo(2.f / 255.f, 10)}),
-framework::dataset::make("WeightQuantizationInfoIfActivationEnabled",
+make("WeightQuantizationInfoIfActivationEnabled",
 {QuantizationInfo(2.f / 255.f, 10)}),
 QuantizedActivationFunctionsDataset))
 {
@@ -1670,18 +1670,18 @@ FIXTURE_DATA_TEST_CASE(
     NEGEMMConvolutionLayerQuantizedMixedSignFixture,
     framework::DatasetMode::ALL,
     combine(
-        framework::dataset::make("Input", TensorShape(23U, 27U, 5U)),
-        framework::dataset::make("Weights", TensorShape(3U, 3U, 5U, 2U)),
-        framework::dataset::make("Bias", TensorShape(2U)),
-        framework::dataset::make("Output", TensorShape(11U, 25U, 2U)),
-        framework::dataset::make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
-        framework::dataset::make("Dilation", Size2D(1, 1)),
-        framework::dataset::make("ReshapeWeights", {true}),
-        framework::dataset::make("DataType", DataType::QASYMM8),
-        framework::dataset::make("WeightsDataType", DataType::QASYMM8_SIGNED),
-        framework::dataset::make("DataLayout", {DataLayout::NCHW, DataLayout::NHWC}),
-        framework::dataset::make("QuantizationInfoIfActivationEnabled", {QuantizationInfo(2.f / 255.f, 10)}),
-        framework::dataset::make("WeightQuantizationInfoIfActivationEnabled", {QuantizationInfo(2.f / 255.f, 10)}),
+        make("Input", TensorShape(23U, 27U, 5U)),
+        make("Weights", TensorShape(3U, 3U, 5U, 2U)),
+        make("Bias", TensorShape(2U)),
+        make("Output", TensorShape(11U, 25U, 2U)),
+        make("PadStrideInfo", PadStrideInfo(2, 1, 0, 0)),
+        make("Dilation", Size2D(1, 1)),
+        make("ReshapeWeights", {true}),
+        make("DataType", DataType::QASYMM8),
+        make("WeightsDataType", DataType::QASYMM8_SIGNED),
+        make("DataLayout", {DataLayout::NCHW, DataLayout::NHWC}),
+        make("QuantizationInfoIfActivationEnabled", {QuantizationInfo(2.f / 255.f, 10)}),
+        make("WeightQuantizationInfoIfActivationEnabled", {QuantizationInfo(2.f / 255.f, 10)}),
         QuantizedActivationFunctionsDataset)
     )
 {
@@ -1693,24 +1693,24 @@ TEST_SUITE_END() // QASYMM8_MIXED
 TEST_SUITE(QSYMM8_PER_CHANNEL)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMConvolutionLayerQuantizedPerChannelFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                               framework::dataset::make("DataType", { DataType::QASYMM8 }),
-                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                       make("ReshapeWeights", { true }),
+                                                               make("DataType", { DataType::QASYMM8 }),
+                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                QuantizationData,
                                        QuantizedActivationFunctionsDataset,
-                               framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                               make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallSigned, NEGEMMConvolutionLayerQuantizedPerChannelFixture<int8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                               framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED }),
-                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                       make("ReshapeWeights", { true }),
+                                                               make("DataType", { DataType::QASYMM8_SIGNED }),
+                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                QuantizationData,
                                        QuantizedActivationFunctionsDataset,
-                               framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                               make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -1841,9 +1841,9 @@ TEST_CASE(MultipleExecutionWithConfigure, framework::DatasetMode::ALL)
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectGEMMConv2dLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                     framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                     framework::dataset::make("DataType", DataType::F32),
-                                                                                                                     framework::dataset::make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                     make("ReshapeWeights", { true }),
+                                                                                                                     make("DataType", DataType::F32),
+                                                                                                                     make("DataLayout", { DataLayout::NHWC }),
                                                                                                              ActivationFunctionsDataset))
 {
     // Validate output
@@ -1859,7 +1859,7 @@ using NEDirectGEMMConv2dLayerQuantizedFixture = ConvolutionValidationQuantizedFi
 template <typename T>
 using NEDirectGEMMConv2dLayerQuantizedPerChannelFixture = ConvolutionValidationQuantizedPerChannelFixture<Tensor, Accessor, NEGEMMConv2d, T, int8_t>;
 
-const auto QuantizedActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto QuantizedActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -1868,10 +1868,10 @@ const auto QuantizedActivationFunctionsDataset = framework::dataset::make("Activ
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectGEMMConv2dLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                        framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                        framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                        framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                        make("ReshapeWeights", { true }),
+                                                                                                                        make("DataType", DataType::QASYMM8),
+                                                                                                                        make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                        make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
                                                                                                                         QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1881,10 +1881,10 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectGEMMConv2dLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallConvolutionLayerDataset(),
-                                                                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.01f, -10) }),
+                                                                                                                       make("ReshapeWeights", { true }),
+                                                                                                                       make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                       make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(0.01f, -10) }),
                                                                                                                        QuantizedActivationFunctionsDataset))
 {
     // Validate output
@@ -1895,12 +1895,12 @@ TEST_SUITE_END() // QASYMM8_SIGNED
 TEST_SUITE(QSYMM8_PER_CHANNEL)
 FIXTURE_DATA_TEST_CASE(RunSmallSigned, NEDirectGEMMConv2dLayerQuantizedPerChannelFixture<int8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallConvolutionLayerDataset(),
-                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                               framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED }),
-                                                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
+                                                                       make("ReshapeWeights", { true }),
+                                                               make("DataType", { DataType::QASYMM8_SIGNED }),
+                                                       make("DataLayout", { DataLayout::NHWC }),
                                                QuantizationData,
                                        QuantizedActivationFunctionsDataset,
-                               framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                               make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/NEON/Copy.cpp
+++ b/tests/validation/NEON/Copy.cpp
@@ -38,6 +38,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(Copy)
 
@@ -47,15 +49,15 @@ using NECopyFixture = CopyFixture<Tensor, Accessor, NECopy, T>;
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Invalid data type combination
+               make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Invalid data type combination
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Mismatching shapes
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(32U, 11U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                      }),
-               framework::dataset::make("Expected", { false, false, true})
+               make("Expected", { false, false, true})
                ),
                input_info, output_info, expected)
 {
@@ -65,7 +67,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
 // *INDENT-ON*
 TEST_SUITE(FixedSeed)
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<float>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<float>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), make("DataType",
                                                                                             DataType::F32)))
 {
     // Validate output
@@ -74,7 +76,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<float>, framework::DatasetMode::A
 TEST_SUITE_END() // F32
 
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<uint8_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<uint8_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), make("DataType",
                                                                                               DataType::U8)))
 {
     // Validate output
@@ -83,7 +85,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<uint8_t>, framework::DatasetMode:
 TEST_SUITE_END() // U8
 
 TEST_SUITE(U16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<uint16_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NECopyFixture<uint16_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), make("DataType",
                                                                                                DataType::U16)))
 {
     // Validate output

--- a/tests/validation/NEON/CropResize.cpp
+++ b/tests/validation/NEON/CropResize.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(CropResize)
 
@@ -51,35 +53,35 @@ using NECropResizeFixture = CropResizeFixture<Tensor, Accessor, NECropResize, T>
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32),
+               make("InputInfo", { TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid box_ind shape.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid output shape.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid output data type.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid output shape.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid boxes shape.
                                                      }),
-               framework::dataset::make("BoxesInfo",{  TensorInfo(TensorShape(4, 20), 1, DataType::F32),
+               make("BoxesInfo",{  TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(3, 20), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("BoxIndInfo",{ TensorInfo(TensorShape(20), 1, DataType::S32),
+               make("BoxIndInfo",{ TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(10), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 10U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(5U, 5, 5, 20U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false, false, false})
+               make("Expected", { true, false, false, false, false, false})
                ),
                input, boxes, box_ind, output, expected)
 {
@@ -98,8 +100,8 @@ TEST_SUITE(F16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NECropResizeFixture<half>,
                        framework::DatasetMode::ALL,
-                       combine(datasets::SmallCropResizeDataset(),framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallCropResizeDataset(),make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -119,8 +121,8 @@ TEST_SUITE(F32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NECropResizeFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(datasets::SmallCropResizeDataset(),framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallCropResizeDataset(),make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32, 0.01);
@@ -132,8 +134,8 @@ TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NECropResizeFixture<uint8_t>,
                        framework::DatasetMode::ALL,
-                       combine(datasets::SmallCropResizeDataset(),framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::U8)))
+                       combine(datasets::SmallCropResizeDataset(),make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::U8)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32, 0.01);
@@ -144,8 +146,8 @@ TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NECropResizeFixture<uint16_t>,
                        framework::DatasetMode::ALL,
-                       combine(datasets::SmallCropResizeDataset(),framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::U16)))
+                       combine(datasets::SmallCropResizeDataset(),make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::U16)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32, 0.01);
@@ -156,8 +158,8 @@ TEST_SUITE(S16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NECropResizeFixture<int16_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallCropResizeDataset(),framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::S16)))
+                       combine(datasets::SmallCropResizeDataset(),make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::S16)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32, 0.01);
@@ -168,8 +170,8 @@ TEST_SUITE(U32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NECropResizeFixture<uint32_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallCropResizeDataset(),framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::U32)))
+                       combine(datasets::SmallCropResizeDataset(),make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::U32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32, 0.01);
@@ -180,8 +182,8 @@ TEST_SUITE(S32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NECropResizeFixture<int32_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallCropResizeDataset(),framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::S32)))
+                       combine(datasets::SmallCropResizeDataset(),make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::S32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32, 0.01);

--- a/tests/validation/NEON/DeconvolutionLayer.cpp
+++ b/tests/validation/NEON/DeconvolutionLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_fp32(0.001f);    /**< Tolerance for floating point tests */
@@ -51,73 +53,73 @@ constexpr float                           tolerance_num_fp16 = 0.02f;           
 #endif                                                                            /* ARM_COMPUTE_ENABLE_FP16*/
 constexpr float tolerance_num_quant = 0.07f;                                      /**< Tolerance number for quantized types */
 
-const auto data4x4 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 4) * framework::dataset::make("StrideY", 1, 4) * framework::dataset::make("PadX", 0, 3)
-                     * framework::dataset::make("PadY", 0, 3) * framework::dataset::make("NumKernels",
+const auto data4x4 = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 4) * make("StrideY", 1, 4) * make("PadX", 0, 3)
+                     * make("PadY", 0, 3) * make("NumKernels",
 {
     3
 });
 
-const auto data3x3 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 4) * framework::dataset::make("StrideY", 1, 4) * framework::dataset::make("PadX", 0, 2)
-                     * framework::dataset::make("PadY", 0, 2) * framework::dataset::make("NumKernels",
+const auto data3x3 = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 4) * make("StrideY", 1, 4) * make("PadX", 0, 2)
+                     * make("PadY", 0, 2) * make("NumKernels",
 {
     3
 });
 
-const auto data3x3_asymm = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 2) * framework::dataset::make("StrideY", 1, 2) * framework::dataset::make("PadLeft", 0, 1)
-                           * framework::dataset::make("PadRight", 0, 1) * framework::dataset::make("PadTop", 0, 1) * framework::dataset::make("PadBottom", 0, 1) * framework::dataset::make("NumKernels",
+const auto data3x3_asymm = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 2) * make("StrideY", 1, 2) * make("PadLeft", 0, 1)
+                           * make("PadRight", 0, 1) * make("PadTop", 0, 1) * make("PadBottom", 0, 1) * make("NumKernels",
 {
     3
 });
 
-const auto data9x9_small_asymm = framework::dataset::make("InputShape", TensorShape
+const auto data9x9_small_asymm = make("InputShape", TensorShape
 {
     10U, 10U, 1U, 1U
 })
-*framework::dataset::make("StrideX", 2) *framework::dataset::make("StrideY", 2) *framework::dataset::make("PadLeft", 3) *framework::dataset::make("PadRight", 4) *framework::dataset::make("PadTop",
-        3)  *framework::dataset::make("PadBottom", 4) *framework::dataset::make("NumKernels", { 1 });
+*make("StrideX", 2) *make("StrideY", 2) *make("PadLeft", 3) *make("PadRight", 4) *make("PadTop",
+        3)  *make("PadBottom", 4) *make("NumKernels", { 1 });
 
-const auto data9x9_large_asymm = framework::dataset::make("InputShape", TensorShape
+const auto data9x9_large_asymm = make("InputShape", TensorShape
 {
     640U, 360U, 56U, 1U
 })
-*framework::dataset::make("StrideX", 2) *framework::dataset::make("StrideY", 2) *framework::dataset::make("PadLeft", 3) *framework::dataset::make("PadRight", 4) *framework::dataset::make("PadTop",
-        3)  *framework::dataset::make("PadBottom", 4) *framework::dataset::make("NumKernels", { 1 });
+*make("StrideX", 2) *make("StrideY", 2) *make("PadLeft", 3) *make("PadRight", 4) *make("PadTop",
+        3)  *make("PadBottom", 4) *make("NumKernels", { 1 });
 
-const auto data3x3_precommit = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 2) * framework::dataset::make("StrideY", 1, 2) * framework::dataset::make("PadX", 0, 2)
-                               * framework::dataset::make("PadY", 0, 2) * framework::dataset::make("NumKernels",
+const auto data3x3_precommit = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 2) * make("StrideY", 1, 2) * make("PadX", 0, 2)
+                               * make("PadY", 0, 2) * make("NumKernels",
 {
     3
 });
 
-const auto data1x1 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 4) * framework::dataset::make("StrideY", 1, 4) * framework::dataset::make("PadX", 0, 1)
-                     * framework::dataset::make("PadY", 0, 1) * framework::dataset::make("NumKernels",
+const auto data1x1 = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 4) * make("StrideY", 1, 4) * make("PadX", 0, 1)
+                     * make("PadY", 0, 1) * make("NumKernels",
 {
     3
 });
 
-const auto data5x1 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 4) * framework::dataset::make("StrideY", 1, 4) * framework::dataset::make("PadX", 0, 1)
-                     * framework::dataset::make("PadY", 0, 1) * framework::dataset::make("NumKernels",
+const auto data5x1 = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 4) * make("StrideY", 1, 4) * make("PadX", 0, 1)
+                     * make("PadY", 0, 1) * make("NumKernels",
 {
     3
 });
 
-const auto data_layouts_dataset = framework::dataset::make("DataLayout",
+const auto data_layouts_dataset = make("DataLayout",
 {
     DataLayout::NCHW, DataLayout::NHWC
 });
 
-const auto add_bias_dataset = framework::dataset::make("AddBias",
+const auto add_bias_dataset = make("AddBias",
 {
     true, false
 });
 
-const auto input_qinfo_dataset = framework::dataset::make("InputQInfo",
+const auto input_qinfo_dataset = make("InputQInfo",
 {
     QuantizationInfo(1.f / 255.f, 0),
                      QuantizationInfo(2.f, 0),
 });
 
-const auto output_qinfo_dataset = framework::dataset::make("OutputQInfo",
+const auto output_qinfo_dataset = make("OutputQInfo",
 {
     QuantizationInfo(3.f / 255.f, 0),
                      QuantizationInfo(4.f, 0),
@@ -130,7 +132,7 @@ TEST_SUITE(DeconvolutionLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),   // Mismatching data type
+    make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),   // Mismatching data type
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),   // Invalid weights shape
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),   // Non supported data type
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),  // Invalid bias shape
@@ -140,7 +142,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(3U,26U,26U,1U), 1, DataType::F32),    // Negative padding
                                             TensorInfo(TensorShape(6U,6U,1U,1U), 1, DataType::F32),    // Negative and asymmetric padding
                                           }),
-    framework::dataset::make("WeightsInfo", { TensorInfo(TensorShape(3U, 3U, 2U, 2U), 1, DataType::F16),
+    make("WeightsInfo", { TensorInfo(TensorShape(3U, 3U, 2U, 2U), 1, DataType::F16),
                                             TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),
                                             TensorInfo(TensorShape(3U, 3U, 2U, 2U), 1, DataType::F16),
                                             TensorInfo(TensorShape(3U, 2U, 2U, 2U), 1, DataType::F32),
@@ -150,7 +152,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(1U,1U,26U,88U), 1, DataType::F32),
                                             TensorInfo(TensorShape(2U,2U,1U,1U), 1, DataType::F32),    // Negative and asymmetric padding
                                           }),
-    framework::dataset::make("BiasInfo",  { TensorInfo(TensorShape(1U), 1, DataType::F16),
+    make("BiasInfo",  { TensorInfo(TensorShape(1U), 1, DataType::F16),
                                             TensorInfo(TensorShape(1U), 1, DataType::F32),
                                             TensorInfo(TensorShape(1U), 1, DataType::F32),
                                             TensorInfo(TensorShape(25U, 11U), 1, DataType::F32),
@@ -160,7 +162,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(88U), 1, DataType::F32),
                                             TensorInfo(TensorShape(1U), 1, DataType::F32),
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
+    make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
                                             TensorInfo(TensorShape(25U, 10U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(13U, 13U, 2U), 1, DataType::F32),
@@ -170,7 +172,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(1U,78U,88U,1U), 1, DataType::F32),
                                             TensorInfo(TensorShape(15U,15U,1U,1U), 1, DataType::F32),
                                           }),
-    framework::dataset::make("PadStrideInfo", { PadStrideInfo(1, 1, 0, 0),
+    make("PadStrideInfo", { PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
@@ -180,7 +182,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 PadStrideInfo(2, 3, 3, 1),
                                                 PadStrideInfo(3, 3, 2, 0, 2, 0, arm_compute::DimensionRoundingType::FLOOR),
                                            }),
-    framework::dataset::make("Expected", { false, false, false, false, false, true,true, false, false })
+    make("Expected", { false, false, false, false, false, true,true, false, false })
     ),
     input_info, weights_info, bias_info, output_info, pad_info, expected)
 {
@@ -211,7 +213,7 @@ using NEDeconvolutionLayerFixture5x1 = DeconvolutionValidationFixture<Tensor, Ac
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture4x4<float>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture4x4<float>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType", DataType::F32),
                                                                                                                     data_layouts_dataset,
                                                                                                             add_bias_dataset))
 {
@@ -220,7 +222,7 @@ FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture4x4<float>, framework::Da
 }
 TEST_SUITE_END() // W4x4
 TEST_SUITE(W3x3)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, make("DataType",
                                                                                                                    DataType::F32),
                                                                                                                    data_layouts_dataset,
                                                                                                                    add_bias_dataset))
@@ -228,7 +230,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerFixture3x3<float>, framewor
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunAsymm, NEDeconvolutionLayerAsymmFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3_asymm, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunAsymm, NEDeconvolutionLayerAsymmFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3_asymm, make("DataType",
                                                                                                                       DataType::F32),
                                                                                                                       data_layouts_dataset,
                                                                                                                       add_bias_dataset))
@@ -236,7 +238,7 @@ FIXTURE_DATA_TEST_CASE(RunAsymm, NEDeconvolutionLayerAsymmFixture3x3<float>, fra
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3, make("DataType", DataType::F32),
                                                                                                                  data_layouts_dataset,
                                                                                                                  add_bias_dataset))
 {
@@ -245,7 +247,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerFixture3x3<float>, framewor
 }
 TEST_SUITE_END() // W3x3
 TEST_SUITE(W1x1)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture1x1<float>, framework::DatasetMode::NIGHTLY, combine(data1x1, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture1x1<float>, framework::DatasetMode::NIGHTLY, combine(data1x1, make("DataType", DataType::F32),
                                                                                                                     data_layouts_dataset,
                                                                                                             add_bias_dataset))
 {
@@ -254,25 +256,25 @@ FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture1x1<float>, framework::Da
 }
 TEST_SUITE_END() // W1x1
 TEST_SUITE(W9x9)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerAsymmFixture9x9<float>, framework::DatasetMode::ALL, combine(data9x9_small_asymm, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerAsymmFixture9x9<float>, framework::DatasetMode::ALL, combine(data9x9_small_asymm, make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                  framework::dataset::make("AddBias", { false })))
+                                                                                                                  make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                  make("AddBias", { false })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerAsymmFixture9x9<float>, framework::DatasetMode::NIGHTLY, combine(data9x9_large_asymm, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerAsymmFixture9x9<float>, framework::DatasetMode::NIGHTLY, combine(data9x9_large_asymm, make("DataType",
                                                                                                                       DataType::F32),
-                                                                                                                      framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                      framework::dataset::make("AddBias", { false })))
+                                                                                                                      make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                      make("AddBias", { false })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 TEST_SUITE_END() // W9x9
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture5x1<float>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture5x1<float>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType", DataType::F32),
                                                                                                                     data_layouts_dataset,
                                                                                                             add_bias_dataset))
 {
@@ -285,7 +287,7 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture4x4<half>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture4x4<half>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType", DataType::F16),
                                                                                                                    data_layouts_dataset,
                                                                                                            add_bias_dataset))
 {
@@ -302,7 +304,7 @@ FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture4x4<half>, framework::Dat
 }
 TEST_SUITE_END() // W4x4
 TEST_SUITE(W3x3)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, make("DataType",
                                                                                                                   DataType::F16),
                                                                                                                   data_layouts_dataset,
                                                                                                                   add_bias_dataset))
@@ -318,7 +320,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerFixture3x3<half>, framework
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::NIGHTLY, combine(data3x3, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::NIGHTLY, combine(data3x3, make("DataType", DataType::F16),
                                                                                                                         data_layouts_dataset,
                                                                                                                 add_bias_dataset))
 {
@@ -335,7 +337,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerFixture3x3<half>, framework
 }
 TEST_SUITE_END() // W3x3
 TEST_SUITE(W1x1)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture1x1<half>, framework::DatasetMode::NIGHTLY, combine(data1x1, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture1x1<half>, framework::DatasetMode::NIGHTLY, combine(data1x1, make("DataType", DataType::F16),
                                                                                                                    data_layouts_dataset,
                                                                                                            add_bias_dataset))
 {
@@ -352,7 +354,7 @@ FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture1x1<half>, framework::Dat
 }
 TEST_SUITE_END() // W1x1
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture5x1<half>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerFixture5x1<half>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType", DataType::F16),
                                                                                                                    data_layouts_dataset,
                                                                                                            add_bias_dataset))
 {
@@ -401,7 +403,7 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture4x4<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture4x4<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType",
                                                                                                                        DataType::QASYMM8),
                                                                                                                        data_layouts_dataset,
                                                                                                                        input_qinfo_dataset,
@@ -415,7 +417,7 @@ TEST_SUITE_END() // W4x4
 
 TEST_SUITE(W3x3)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerQuantizedFixture3x3<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
@@ -426,7 +428,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerQuantizedFixture3x3<uint8_t
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerQuantizedFixture3x3<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data3x3,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
@@ -439,7 +441,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerQuantizedFixture3x3<uint8_t
 TEST_SUITE_END() // W3x3
 
 TEST_SUITE(W1x1)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture1x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture1x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1, make("DataType",
                                                                                                                        DataType::QASYMM8),
                                                                                                                        data_layouts_dataset,
                                                                                                                        input_qinfo_dataset,
@@ -452,7 +454,7 @@ FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture1x1<uint8_t>, fr
 TEST_SUITE_END() // W1x1
 
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture5x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture5x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType",
                                                                                                                        DataType::QASYMM8),
                                                                                                                        data_layouts_dataset,
                                                                                                                        input_qinfo_dataset,
@@ -469,7 +471,7 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture4x4<int8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture4x4<int8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType",
                                                                                                                       DataType::QASYMM8_SIGNED),
                                                                                                                       data_layouts_dataset,
                                                                                                                       input_qinfo_dataset,
@@ -483,7 +485,7 @@ TEST_SUITE_END() // W4x4
 
 TEST_SUITE(W3x3)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerQuantizedFixture3x3<int8_t>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_qinfo_dataset,
@@ -494,7 +496,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDeconvolutionLayerQuantizedFixture3x3<int8_t>
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDeconvolutionLayerQuantizedFixture3x3<int8_t>, framework::DatasetMode::NIGHTLY, combine(data3x3,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_qinfo_dataset,
@@ -508,7 +510,7 @@ TEST_SUITE_END() // W3x3
 
 TEST_SUITE(W1x1)
 FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture1x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1,
-                                                                                                                      framework::dataset::make("DataType",
+                                                                                                                      make("DataType",
                                                                                                                               DataType::QASYMM8_SIGNED),
                                                                                                                       data_layouts_dataset,
                                                                                                                       input_qinfo_dataset,
@@ -521,7 +523,7 @@ FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture1x1<int8_t>, fra
 TEST_SUITE_END() // W1x1
 
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture5x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedFixture5x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType",
                                                                                                                       DataType::QASYMM8_SIGNED),
                                                                                                                       data_layouts_dataset,
                                                                                                                       input_qinfo_dataset,
@@ -535,19 +537,19 @@ TEST_SUITE_END() // W5x1
 
 TEST_SUITE_END() // QASYMM8_SIGNED
 
-const auto input_qinfo_per_channel_dataset = framework::dataset::make("InputQuantizationInfo",
+const auto input_qinfo_per_channel_dataset = make("InputQuantizationInfo",
 {
     QuantizationInfo(1.f / 255.f, 10)
 });
-const auto output_qinfo_per_channel_dataset = framework::dataset::make("OutputQuantizationInfo",
+const auto output_qinfo_per_channel_dataset = make("OutputQuantizationInfo",
 {
     QuantizationInfo(3.f / 255.f, 0)
 });
-const auto input_signed_qinfo_per_channel_dataset = framework::dataset::make("InputQuantizationInfo",
+const auto input_signed_qinfo_per_channel_dataset = make("InputQuantizationInfo",
 {
     QuantizationInfo(1.f / 255.f, -10)
 });
-const auto output_signed_qinfo_per_channel_dataset = framework::dataset::make("OutputQuantizationInfo",
+const auto output_signed_qinfo_per_channel_dataset = make("OutputQuantizationInfo",
 {
     QuantizationInfo(3.f / 255.f, 10)
 });
@@ -556,23 +558,23 @@ TEST_SUITE(QSYMM8_PER_CHANNEL)
 
 TEST_SUITE(W4x4)
 FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedPerChannelFixture4x4<uint8_t>, framework::DatasetMode::ALL, combine(data4x4,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_per_channel_dataset,
                        output_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunSigned, NEDeconvolutionLayerQuantizedPerChannelFixture4x4<int8_t>, framework::DatasetMode::ALL, combine(data4x4,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_per_channel_dataset,
                        output_signed_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
@@ -581,23 +583,23 @@ TEST_SUITE_END() // W4x4
 
 TEST_SUITE(W3x3)
 FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedPerChannelFixture3x3<uint8_t>, framework::DatasetMode::ALL, combine(data3x3,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_per_channel_dataset,
                        output_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunSigned, NEDeconvolutionLayerQuantizedPerChannelFixture3x3<int8_t>, framework::DatasetMode::ALL, combine(data3x3,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_per_channel_dataset,
                        output_signed_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
@@ -606,23 +608,23 @@ TEST_SUITE_END() // W3x3
 
 TEST_SUITE(W1x1)
 FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedPerChannelFixture1x1<uint8_t>, framework::DatasetMode::ALL, combine(data1x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_per_channel_dataset,
                        output_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunSigned, NEDeconvolutionLayerQuantizedPerChannelFixture1x1<int8_t>, framework::DatasetMode::ALL, combine(data1x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_per_channel_dataset,
                        output_signed_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
@@ -631,23 +633,23 @@ TEST_SUITE_END() // W1x1
 
 TEST_SUITE(W5x1)
 FIXTURE_DATA_TEST_CASE(Run, NEDeconvolutionLayerQuantizedPerChannelFixture5x1<uint8_t>, framework::DatasetMode::ALL, combine(data5x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_per_channel_dataset,
                        output_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunSigned, NEDeconvolutionLayerQuantizedPerChannelFixture5x1<int8_t>, framework::DatasetMode::ALL, combine(data5x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_per_channel_dataset,
                        output_signed_qinfo_per_channel_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_quantized, tolerance_num_quant);

--- a/tests/validation/NEON/DepthConcatenateLayer.cpp
+++ b/tests/validation/NEON/DepthConcatenateLayer.cpp
@@ -39,28 +39,30 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(DepthConcatenateLayer)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
+        make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
                                                   TensorInfo(TensorShape(24U, 27U, 4U), 1, DataType::F32), // Mismatching x dimension
                                                   TensorInfo(TensorShape(23U, 27U, 3U), 1, DataType::F32), // Mismatching total depth
                                                   TensorInfo(TensorShape(16U, 27U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 4U), 1, DataType::F32),
+        make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 9U), 1, DataType::F16),
+        make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 9U), 1, DataType::F16),
                                                   TensorInfo(TensorShape(25U, 12U, 9U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 8U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 12U), 1, DataType::F32)
         }),
-        framework::dataset::make("Expected", { false, false, false, true })
+        make("Expected", { false, false, false, true })
         ),
         input_info1, input_info2, output_info,expected)
 {
@@ -88,9 +90,9 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConcatenateLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::F16),
-                                                                                                                  framework::dataset::make("Axis", 2)))
+                                                                                                                  make("Axis", 2)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -103,9 +105,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConcatenateLayerFixture<half>, framework
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                         DataType::F16),
-                                                                                                                framework::dataset::make("Axis", 2)))
+                                                                                                                make("Axis", 2)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -123,16 +125,16 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                   framework::dataset::make("DataType",
+                                                                                                                   make("DataType",
                                                                                                                            DataType::F32),
-                                                                                                                   framework::dataset::make("Axis", 2)))
+                                                                                                                   make("Axis", 2)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                  DataType::F32),
-                                                                                                                 framework::dataset::make("Axis", 2)))
+                                                                                                                 make("Axis", 2)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -143,9 +145,9 @@ TEST_SUITE_END()
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("Axis", 2)))
+                                                                                                                     make("Axis", 2)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -153,9 +155,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConcatenateLayerFixture<uint8_t>, framew
 TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConcatenateLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                    framework::dataset::make("DataType",
+                                                                                                                    make("DataType",
                                                                                                                             DataType::QASYMM8_SIGNED),
-                                                                                                                    framework::dataset::make("Axis", 2)))
+                                                                                                                    make("Axis", 2)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/DepthConvertLayer.cpp
+++ b/tests/validation/NEON/DepthConvertLayer.cpp
@@ -41,36 +41,38 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Input data sets **/
-const auto DepthConvertLayerQASYMM8toF16Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::F16));
-const auto DepthConvertLayerQASYMM8toF32Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::F32));
-const auto DepthConvertLayerQASYMM8toS32Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::S32));
-const auto DepthConvertLayerU8toU16Dataset      = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::U16));
-const auto DepthConvertLayerU8toS16Dataset      = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::S16));
-const auto DepthConvertLayerU8toS32Dataset      = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::S32));
-const auto DepthConvertLayerU8toF16Dataset      = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::F16));
-const auto DepthConvertLayerU8toF32Dataset      = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::F32));
-const auto DepthConvertLayerU16toU8Dataset      = combine(framework::dataset::make("DataType", DataType::U16), framework::dataset::make("DataType", DataType::U8));
-const auto DepthConvertLayerU16toU32Dataset     = combine(framework::dataset::make("DataType", DataType::U16), framework::dataset::make("DataType", DataType::U32));
-const auto DepthConvertLayerS16toU8Dataset      = combine(framework::dataset::make("DataType", DataType::S16), framework::dataset::make("DataType", DataType::U8));
-const auto DepthConvertLayerS16toS32Dataset     = combine(framework::dataset::make("DataType", DataType::S16), framework::dataset::make("DataType", DataType::S32));
-const auto DepthConvertLayerF16toU8Dataset      = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::U8));
-const auto DepthConvertLayerF16toF32Dataset     = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F32));
-const auto DepthConvertLayerF16toS32Dataset     = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::S32));
-const auto DepthConvertLayerF32toF16Dataset     = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F16));
-const auto DepthConvertLayerF32toS32Dataset     = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::S32));
-const auto DepthConvertLayerF32toU8Dataset      = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::U8));
+const auto DepthConvertLayerQASYMM8toF16Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::F16));
+const auto DepthConvertLayerQASYMM8toF32Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::F32));
+const auto DepthConvertLayerQASYMM8toS32Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::S32));
+const auto DepthConvertLayerU8toU16Dataset      = combine(make("DataType", DataType::U8), make("DataType", DataType::U16));
+const auto DepthConvertLayerU8toS16Dataset      = combine(make("DataType", DataType::U8), make("DataType", DataType::S16));
+const auto DepthConvertLayerU8toS32Dataset      = combine(make("DataType", DataType::U8), make("DataType", DataType::S32));
+const auto DepthConvertLayerU8toF16Dataset      = combine(make("DataType", DataType::U8), make("DataType", DataType::F16));
+const auto DepthConvertLayerU8toF32Dataset      = combine(make("DataType", DataType::U8), make("DataType", DataType::F32));
+const auto DepthConvertLayerU16toU8Dataset      = combine(make("DataType", DataType::U16), make("DataType", DataType::U8));
+const auto DepthConvertLayerU16toU32Dataset     = combine(make("DataType", DataType::U16), make("DataType", DataType::U32));
+const auto DepthConvertLayerS16toU8Dataset      = combine(make("DataType", DataType::S16), make("DataType", DataType::U8));
+const auto DepthConvertLayerS16toS32Dataset     = combine(make("DataType", DataType::S16), make("DataType", DataType::S32));
+const auto DepthConvertLayerF16toU8Dataset      = combine(make("DataType", DataType::F16), make("DataType", DataType::U8));
+const auto DepthConvertLayerF16toF32Dataset     = combine(make("DataType", DataType::F16), make("DataType", DataType::F32));
+const auto DepthConvertLayerF16toS32Dataset     = combine(make("DataType", DataType::F16), make("DataType", DataType::S32));
+const auto DepthConvertLayerF32toF16Dataset     = combine(make("DataType", DataType::F32), make("DataType", DataType::F16));
+const auto DepthConvertLayerF32toS32Dataset     = combine(make("DataType", DataType::F32), make("DataType", DataType::S32));
+const auto DepthConvertLayerF32toU8Dataset      = combine(make("DataType", DataType::F32), make("DataType", DataType::U8));
 
-const auto DepthConvertLayerS32toF32Dataset     = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::F32));
-const auto DepthConvertLayerS32toQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::QASYMM8));
-const auto DepthConvertLayerS32toF16Dataset     = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::F16));
-const auto DepthConvertLayerS32toU8Dataset      = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::U8));
+const auto DepthConvertLayerS32toF32Dataset     = combine(make("DataType", DataType::S32), make("DataType", DataType::F32));
+const auto DepthConvertLayerS32toQASYMM8Dataset = combine(make("DataType", DataType::S32), make("DataType", DataType::QASYMM8));
+const auto DepthConvertLayerS32toF16Dataset     = combine(make("DataType", DataType::S32), make("DataType", DataType::F16));
+const auto DepthConvertLayerS32toU8Dataset      = combine(make("DataType", DataType::S32), make("DataType", DataType::U8));
 
-const auto DepthConvertLayerF16toQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::QASYMM8));
-const auto DepthConvertLayerF32toQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::QASYMM8));
-const auto DepthConvertLayerZeroShiftDataset    = framework::dataset::make("Shift", 0);
+const auto DepthConvertLayerF16toQASYMM8Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::QASYMM8));
+const auto DepthConvertLayerF32toQASYMM8Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::QASYMM8));
+const auto DepthConvertLayerZeroShiftDataset    = make("Shift", 0);
 
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);
 constexpr AbsoluteTolerance<int32_t> tolerance_one_int32(1);
@@ -85,18 +87,18 @@ TEST_SUITE(DepthConvertLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U16),  // Invalid data type combination
+               make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U16),  // Invalid data type combination
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),  // Invalid data type combination
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Mismatching shapes
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),  // Invalid shift
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),  // Valid
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                      }),
-               framework::dataset::make("Policy",{ ConvertPolicy::WRAP,
+               make("Policy",{ ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
@@ -104,9 +106,9 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                      }),
-               framework::dataset::make("Shift",{ 0, 0, 0, 1, 1, 1, 8, 1,
+               make("Shift",{ 0, 0, 0, 1, 1, 1, 8, 1,
                                                      }),
-               framework::dataset::make("Expected", { false, false, false, false, true})
+               make("Expected", { false, false, false, false, true})
                ),
                input_info, output_info, policy, shift, expected)
 {
@@ -141,18 +143,18 @@ using NEDepthConvertLayerQuantizedToS32Fixture = DepthConvertLayerValidationQuan
 TEST_SUITE(QASYMM8_to_F32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerQuantizedToF32Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        DepthConvertLayerQASYMM8toF32Dataset,
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        DepthConvertLayerZeroShiftDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerQuantizedToF32Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                        DepthConvertLayerQASYMM8toF32Dataset,
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        DepthConvertLayerZeroShiftDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -162,18 +164,18 @@ TEST_SUITE_END() // QASYMM8_to_F32
 TEST_SUITE(QASYMM8_to_S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerQuantizedToS32Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        DepthConvertLayerQASYMM8toS32Dataset,
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        DepthConvertLayerZeroShiftDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerQuantizedToS32Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                        DepthConvertLayerQASYMM8toS32Dataset,
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        DepthConvertLayerZeroShiftDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -182,7 +184,7 @@ TEST_SUITE_END() // QASYMM8_to_S32
 
 TEST_SUITE(U8_to_U16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU16Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toU16Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -190,7 +192,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU16Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToU16Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toU16Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -200,7 +202,7 @@ TEST_SUITE_END() // U8_to_U16
 
 TEST_SUITE(U8_to_S16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS16Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toS16Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -208,7 +210,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS16Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToS16Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toS16Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -217,7 +219,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToS16Fixture<uint8_t>, frame
 TEST_SUITE_END() // U8_to_S16
 TEST_SUITE(U8_to_S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS32Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toS32Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -225,7 +227,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS32Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToS32Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toS32Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -235,7 +237,7 @@ TEST_SUITE_END() // U8_to_S32
 
 TEST_SUITE(U8_to_F32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF32Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toF32Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -243,7 +245,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF32Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToF32Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toF32Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -254,7 +256,7 @@ TEST_SUITE_END() // U8_to_F32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(U8_to_F16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF16Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toF16Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -270,7 +272,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF16Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToF16Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toF16Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -289,14 +291,14 @@ TEST_SUITE_END() // U8_to_F36
 
 TEST_SUITE(U16_to_U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU8Fixture<uint16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU16toU8Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToU8Fixture<uint16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU16toU8Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -306,14 +308,14 @@ TEST_SUITE_END() // U16_to_U8
 
 TEST_SUITE(U16_to_U32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU32Fixture<uint16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU16toU32Dataset,
-                                                                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                        DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToU32Fixture<uint16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU16toU32Dataset,
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -323,14 +325,14 @@ TEST_SUITE_END() // U16_to_U32
 
 TEST_SUITE(S16_to_U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU8Fixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerS16toU8Dataset,
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToU8Fixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerS16toU8Dataset,
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -340,14 +342,14 @@ TEST_SUITE_END() // S16_to_U8
 
 TEST_SUITE(S16_to_S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS32Fixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerS16toS32Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToS32Fixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerS16toS32Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -359,9 +361,9 @@ TEST_SUITE_END() // S16_to_S32
 TEST_SUITE(F16_to_QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToQASYMM8Fixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                        DepthConvertLayerF16toQASYMM8Dataset,
-                                                                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                                                                                                                        DepthConvertLayerZeroShiftDataset,
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -376,9 +378,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToQASYMM8Fixture<half>, fram
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToQASYMM8Fixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                                                                                                                      DepthConvertLayerF16toQASYMM8Dataset,
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                                                                                                                      DepthConvertLayerZeroShiftDataset,
-                                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                                                                                                                     make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -395,7 +397,7 @@ TEST_SUITE_END() // F16_to_QASYMM8
 
 TEST_SUITE(F16_to_U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU8Fixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerF16toU8Dataset,
-                                                                                                                  framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                  make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                   DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -410,7 +412,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU8Fixture<half>, framework
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToU8Fixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerF16toU8Dataset,
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                 DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -428,7 +430,7 @@ TEST_SUITE_END() // F16_to_U8
 
 TEST_SUITE(F16_to_F32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF32Fixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerF16toF32Dataset,
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -443,7 +445,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF32Fixture<half>, framewor
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToF32Fixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerF16toF32Dataset,
-                                                                                                                 framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                 make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                  DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -461,7 +463,7 @@ TEST_SUITE_END() // F16_to_F32
 
 TEST_SUITE(F16_to_S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS32Fixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerF16toS32Dataset,
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -476,7 +478,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS32Fixture<half>, framewor
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToS32Fixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerF16toS32Dataset,
-                                                                                                                 framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                 make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                  DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -496,9 +498,9 @@ TEST_SUITE_END() // F16_to_S32
 TEST_SUITE(QASYMM8_to_F16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerQuantizedToF16Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        DepthConvertLayerQASYMM8toF16Dataset,
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        DepthConvertLayerZeroShiftDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -513,9 +515,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerQuantizedToF16Fixture<uint8_
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerQuantizedToF16Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                        DepthConvertLayerQASYMM8toF16Dataset,
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        DepthConvertLayerZeroShiftDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -532,7 +534,7 @@ TEST_SUITE_END() // QASYMM8_to_F16
 
 TEST_SUITE(F32_to_F16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF16Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerF32toF16Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -547,7 +549,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF16Fixture<float>, framewo
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToF16Fixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerF32toF16Dataset,
-                                                                                                                  framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                  make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                   DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -565,7 +567,7 @@ TEST_SUITE_END() // F32_to_F16
 
 TEST_SUITE(S32_to_F16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF16Fixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerS32toF16Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -580,7 +582,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF16Fixture<int32_t>, frame
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToF16Fixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerS32toF16Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -600,14 +602,14 @@ TEST_SUITE_END() // S32_to_F16
 
 TEST_SUITE(F32_to_S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToS32Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerF32toS32Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_one_int32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToS32Fixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerF32toS32Dataset,
-                                                                                                                  framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                  make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                   DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -617,14 +619,14 @@ TEST_SUITE_END() // F32_to_S32
 
 TEST_SUITE(F32_to_U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU8Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerF32toU8Dataset,
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_one_int32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToU8Fixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerF32toU8Dataset,
-                                                                                                                 framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                 make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                  DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -635,18 +637,18 @@ TEST_SUITE_END() // F32_to_U8
 TEST_SUITE(F32_to_QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToQASYMM8Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                         DepthConvertLayerF32toQASYMM8Dataset,
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                                                                                                                         DepthConvertLayerZeroShiftDataset,
-                                                                                                                        framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                                                                                                                        make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToQASYMM8Fixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                                                                                                                       DepthConvertLayerF32toQASYMM8Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                                                                                                                       DepthConvertLayerZeroShiftDataset,
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -655,14 +657,14 @@ TEST_SUITE_END() // F32_to_QASYMM8
 
 TEST_SUITE(S32_to_F32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToF32Fixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerS32toF32Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToF32Fixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerS32toF32Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -673,18 +675,18 @@ TEST_SUITE_END() // S32_to_F32
 TEST_SUITE(S32_to_QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToQASYMM8Fixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        DepthConvertLayerS32toQASYMM8Dataset,
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                        DepthConvertLayerZeroShiftDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToQASYMM8Fixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                                                                                                                         DepthConvertLayerS32toQASYMM8Dataset,
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE }),
                                                                                                                         DepthConvertLayerZeroShiftDataset,
-                                                                                                                        framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                                                                                                                        make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -693,14 +695,14 @@ TEST_SUITE_END() // S32_to_QASYMM8
 
 TEST_SUITE(S32_to_U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthConvertLayerToU8Fixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerS32toU8Dataset,
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthConvertLayerToU8Fixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerS32toU8Dataset,
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    DepthConvertLayerZeroShiftDataset))
 {
     // Validate output

--- a/tests/validation/NEON/DepthToSpaceLayer.cpp
+++ b/tests/validation/NEON/DepthToSpaceLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(DepthToSpaceLayer)
 
@@ -50,20 +52,20 @@ using NEDepthToSpaceLayerFixture = DepthToSpaceLayerValidationFixture<Tensor, Ac
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 4U, 4U), 1, DataType::F32),
+               make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 8U, 4U, 4U), 1, DataType::F32),   // block < 2
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),    // Negative block shape
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 4U, 4U), 1, DataType::F32), // Wrong tensor shape
                                                      }),
-               framework::dataset::make("BlockShape", { 2, 1, 2, 2, 2 }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 1U, 4U), 1, DataType::F32),
+               make("BlockShape", { 2, 1, 2, 2, 2 }),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 1U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 16U, 1U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 1U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false, false})
+               make("Expected", { true, false, false, false, false})
                ),
                input_info, block_shape, output_info, expected)
 {
@@ -75,16 +77,16 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                        DataType::F32),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                      DataType::F32),
-                                                                                                             framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                             make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -92,16 +94,16 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthToSpaceLayerFixture<float>, framework::D
 TEST_SUITE_END()
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEDepthToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                       DataType::F16),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDepthToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                     DataType::F16),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/DepthwiseConvolutionLayerNative.cpp
+++ b/tests/validation/NEON/DepthwiseConvolutionLayerNative.cpp
@@ -36,6 +36,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 using namespace arm_compute::misc::shape_calculator;
 
 // Create function for CpuDepthwiseConvolutionKernel
@@ -53,52 +55,52 @@ RelativeTolerance<float> rel_tolerance_f32(0.001f);
 constexpr float          abs_tolerance_f32(0.0001f);
 
 /** Width values to test - Precommit */
-const auto width_values_precommit = framework::dataset::make("width", { 17U } );
+const auto width_values_precommit = make("width", { 17U } );
 
 /** Width values to test - Nightly */
-const auto width_values_nightly = framework::dataset::make("width", { 53U, 47U } );
+const auto width_values_nightly = make("width", { 53U, 47U } );
 
 /** Height values to test - Precommit */
-const auto height_values_precommit = framework::dataset::make("height", { 19U } );
+const auto height_values_precommit = make("height", { 19U } );
 
 /** Height values to test - Nightly */
-const auto height_values_nightly = framework::dataset::make("height", { 39U, 43U } );
+const auto height_values_nightly = make("height", { 39U, 43U } );
 
 /** Channel values to test - Precommit */
-const auto channel_values_precommit = framework::dataset::make("channels", { 15U });
+const auto channel_values_precommit = make("channels", { 15U });
 
 /** Channel values to test - Nightly */
-const auto channel_values_nightly = framework::dataset::make("channels", { 33U, 19U });
+const auto channel_values_nightly = make("channels", { 33U, 19U });
 
 /** Batch values to test - Precommit */
-const auto batch_values_precommit = framework::dataset::make("batch", { 1U, 2U });
+const auto batch_values_precommit = make("batch", { 1U, 2U });
 
 /** Batch values to test - Nightly */
-const auto batch_values_nightly = framework::dataset::make("batch", { 1U, 3U });
+const auto batch_values_nightly = make("batch", { 1U, 3U });
 
 /** Kernel size values to test - Precommit */
-const auto kernel_sz_values_precommit = framework::dataset::make("kernel_size", { Size2D(1U, 1U), Size2D(1U, 3U) });
+const auto kernel_sz_values_precommit = make("kernel_size", { Size2D(1U, 1U), Size2D(1U, 3U) });
 
 /** Kernel size values to test - Nightly */
-const auto kernel_sz_values_nightly = framework::dataset::make("kernel_size", { Size2D(3U, 5U), Size2D(5U, 1U), Size2D(1U, 7U), Size2D(9U, 7U) });
+const auto kernel_sz_values_nightly = make("kernel_size", { Size2D(3U, 5U), Size2D(5U, 1U), Size2D(1U, 7U), Size2D(9U, 7U) });
 
 /** Depth multiplier values to test - All */
-const auto depth_multiplier_values = framework::dataset::make("depth_multiplier", { 1U, 3U });
+const auto depth_multiplier_values = make("depth_multiplier", { 1U, 3U });
 
 /** Dilation values to test - All */
-const auto dilation_values = framework::dataset::make("dilation", { Size2D(1U, 1U), Size2D(3U, 3U) });
+const auto dilation_values = make("dilation", { Size2D(1U, 1U), Size2D(3U, 3U) });
 
 /** Stride values to test - All */
-const auto stride_values = framework::dataset::make("stride", { Size2D(1U, 1U), Size2D(3U, 2U) });
+const auto stride_values = make("stride", { Size2D(1U, 1U), Size2D(3U, 2U) });
 
 /** Padding values to test - All */
-const auto padding_valid_values = framework::dataset::make("padding_valid", { true, false });
+const auto padding_valid_values = make("padding_valid", { true, false });
 
 /** Data type values to test - All */
-const auto data_type_values = framework::dataset::make("data_type", { DataType::F32 });
+const auto data_type_values = make("data_type", { DataType::F32 });
 
 /** Data layout values to test - All */
-const auto data_layout_values = framework::dataset::make("data_layout", { DataLayout::NHWC });
+const auto data_layout_values = make("data_layout", { DataLayout::NHWC });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -137,14 +139,14 @@ TEST_CASE(ValidateNoPadding, framework::DatasetMode::ALL)
 
 TEST_SUITE(KERNEL_SELECTION)
 DATA_TEST_CASE(KernelSelection_mul_and_add, framework::DatasetMode::ALL,
-               combine(framework::dataset::make("CpuExt", std::string("NEON")),
-                       framework::dataset::make("DataType", { DataType::F32,
+               combine(make("CpuExt", std::string("NEON")),
+                       make("DataType", { DataType::F32,
                                                               DataType::F16,
                                                               DataType::QASYMM8_SIGNED,
                                                               DataType::QASYMM8,
                                                               DataType::QSYMM8_PER_CHANNEL
                                                             }),
-                       framework::dataset::make("DataType_per_channel", { DataType::QASYMM8,
+                       make("DataType_per_channel", { DataType::QASYMM8,
                                                                           DataType::QASYMM8_SIGNED
                                                             })),
                 cpu_ext, data_type, data_type_per_channel)

--- a/tests/validation/NEON/DequantizationLayer.cpp
+++ b/tests/validation/NEON/DequantizationLayer.cpp
@@ -41,49 +41,51 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 #ifdef ARM_COMPUTE_ENABLE_FP16
-const auto data_types = framework::dataset::make("DataType", { DataType::F16, DataType::F32 });
+const auto data_types = make("DataType", { DataType::F16, DataType::F32 });
 #else  /* ARM_COMPUTE_ENABLE_FP16 */
-const auto data_types = framework::dataset::make("DataType", { DataType::F32 });
+const auto data_types = make("DataType", { DataType::F32 });
 #endif /* ARM_COMPUTE_ENABLE_FP16 */
 
 const auto dataset_quant_f32 = combine(datasets::SmallShapes(), datasets::QuantizedTypes(),
-                                               framework::dataset::make("DataType", DataType::F32),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                       make("DataType", DataType::F32),
+                                       make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_f16 = combine(datasets::SmallShapes(), datasets::QuantizedTypes(),
-                                               framework::dataset::make("DataType", DataType::F16),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                       make("DataType", DataType::F16),
+                                       make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_asymm_signed_f32 = combine(datasets::SmallShapes(),
-                                                                    framework::dataset::make("QuantizedTypes", { DataType::QASYMM8_SIGNED }),
-                                                            framework::dataset::make("DataType", DataType::F32),
-                                                    framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                                    make("QuantizedTypes", { DataType::QASYMM8_SIGNED }),
+                                                    make("DataType", DataType::F32),
+                                                    make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_asymm_signed_f16 = combine(datasets::SmallShapes(),
-                                                                    framework::dataset::make("QuantizedTypes", { DataType::QASYMM8_SIGNED }),
-                                                            framework::dataset::make("DataType", DataType::F16),
-                                                    framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                                    make("QuantizedTypes", { DataType::QASYMM8_SIGNED }),
+                                                    make("DataType", DataType::F16),
+                                                    make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_per_channel_f32 = combine(datasets::SmallShapes(), datasets::QuantizedPerChannelTypes(),
-                                                           framework::dataset::make("DataType", DataType::F32),
-                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                   make("DataType", DataType::F32),
+                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 const auto dataset_quant_per_channel_f16 = combine(datasets::SmallShapes(), datasets::QuantizedPerChannelTypes(),
-                                                           framework::dataset::make("DataType", DataType::F16),
-                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                   make("DataType", DataType::F16),
+                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 const auto dataset_quant_nightly_f32 = combine(datasets::LargeShapes(), datasets::QuantizedTypes(),
-                                                       framework::dataset::make("DataType", DataType::F32),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                               make("DataType", DataType::F32),
+                                               make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_nightly_f16 = combine(datasets::LargeShapes(), datasets::QuantizedTypes(),
-                                                       framework::dataset::make("DataType", DataType::F16),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                               make("DataType", DataType::F16),
+                                               make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_per_channel_nightly_f32 = combine(datasets::LargeShapes(), datasets::QuantizedPerChannelTypes(),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                           make("DataType", DataType::F32),
+                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 const auto dataset_quant_per_channel_nightly_f16 = combine(datasets::LargeShapes(), datasets::QuantizedPerChannelTypes(),
-                                                                   framework::dataset::make("DataType", DataType::F16),
-                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                                   make("DataType", DataType::F16),
+                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 
-const auto dataset_precommit_f16 = concat(concat(dataset_quant_f16, dataset_quant_per_channel_f16), dataset_quant_asymm_signed_f16);
-const auto dataset_precommit_f32 = concat(concat(dataset_quant_f32, dataset_quant_per_channel_f32), dataset_quant_asymm_signed_f32);
+const auto dataset_precommit_f16 = concat(dataset_quant_f16, dataset_quant_per_channel_f16, dataset_quant_asymm_signed_f16);
+const auto dataset_precommit_f32 = concat(dataset_quant_f32, dataset_quant_per_channel_f32, dataset_quant_asymm_signed_f32);
 const auto dataset_nightly_f16   = concat(dataset_quant_f16, dataset_quant_per_channel_f16);
 const auto dataset_nightly_f32   = concat(dataset_quant_f32, dataset_quant_per_channel_f32);
 
@@ -95,21 +97,21 @@ TEST_SUITE(DequantizationLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),      // Wrong input data type
+        make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),      // Wrong input data type
                                                 TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Wrong output data type
                                                 TensorInfo(TensorShape(16U, 16U, 2U, 5U), 1, DataType::QASYMM8),   // Missmatching shapes
                                                 TensorInfo(TensorShape(17U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Valid
                                                 TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Valid
                                                 TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8_SIGNED),  // Valid
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(17U, 16U, 16U, 5U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
         }),
-        framework::dataset::make("Expected", { false, false, false, true, true, true })
+        make("Expected", { false, false, false, true, true, true })
         ),
         input_info, output_info, expected)
 {

--- a/tests/validation/NEON/DetectionPostProcessLayer.cpp
+++ b/tests/validation/NEON/DetectionPostProcessLayer.cpp
@@ -39,6 +39,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 template <typename U, typename T>
@@ -184,56 +186,56 @@ TEST_SUITE(DetectionPostProcessLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("BoxEncodingsInfo", { TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
+        make("BoxEncodingsInfo", { TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 3U), 1, DataType::F32),  // Mismatching batch_size
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::S8), // Unsupported data type
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32), // Wrong Detection Info
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32), // Wrong boxes dimensions
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::QASYMM8)}),
         // Wrong score dimension
-        framework::dataset::make("ClassPredsInfo",{ TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
+        make("ClassPredsInfo",{ TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::QASYMM8)}),
-        framework::dataset::make("AnchorsInfo",{ TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
+        make("AnchorsInfo",{ TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::QASYMM8)}),
-        framework::dataset::make("OutputBoxInfo", { TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
+        make("OutputBoxInfo", { TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::S8),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U, 5U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32)}),
-        framework::dataset::make("OuputClassesInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
+        make("OuputClassesInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(6U, 1U), 1, DataType::F32)}),
-        framework::dataset::make("OutputScoresInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
+        make("OutputScoresInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(6U, 1U), 1, DataType::F32)}),
-        framework::dataset::make("NumDetectionsInfo",{ TensorInfo(TensorShape(1U), 1, DataType::F32),
+        make("NumDetectionsInfo",{ TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32)}),
-        framework::dataset::make("DetectionPostProcessLayerInfo",{ DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
+        make("DetectionPostProcessLayerInfo",{ DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 1.5f, 2, {0.0f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f})}),
-        framework::dataset::make("Expected", {true, false, false, false, false, false })
+        make("Expected", {true, false, false, false, false, false })
         ),
         box_encodings_info, classes_info, anchors_info, output_boxes_info, output_classes_info,output_scores_info, num_detection_info, detect_info, expected)
 {

--- a/tests/validation/NEON/DilatedConvolutionLayer.cpp
+++ b/tests/validation/NEON/DilatedConvolutionLayer.cpp
@@ -42,6 +42,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 const AbsoluteTolerance<float> tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for DataType::F32 */
@@ -53,7 +55,7 @@ constexpr float                           tolerance_num_f16 = 0.07f;            
 constexpr AbsoluteTolerance<int32_t> tolerance_qasymm8(1);                           /**< Tolerance value for comparing reference's output against implementation's output for quantized data types */
 
 /** CNN data types */
-const auto CNNDataTypes = framework::dataset::make("DataType",
+const auto CNNDataTypes = make("DataType",
 {
 #ifdef ARM_COMPUTE_ENABLE_FP16
     DataType::F16,
@@ -69,32 +71,32 @@ TEST_SUITE(DilatedConvolutionLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(ValidateConvolutionMethod, framework::DatasetMode::ALL, zip(
-                                          framework::dataset::make("InputInfo", { TensorInfo(TensorShape(8U, 8U, 2U), 1, DataType::F32),
+                                          make("InputInfo", { TensorInfo(TensorShape(8U, 8U, 2U), 1, DataType::F32),
                                                                                   TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32),
                                                                                   TensorInfo(TensorShape(3U, 3U, 2U, 1U), 1, DataType::F32),
                                                                                   TensorInfo(TensorShape(33U, 27U, 7U, 4U), 1, DataType::F32)
                                           }),
-                                          framework::dataset::make("WeightsInfo", { TensorInfo(TensorShape(3U, 3U, 5U, 21U), 1, DataType::F32),
+                                          make("WeightsInfo", { TensorInfo(TensorShape(3U, 3U, 5U, 21U), 1, DataType::F32),
                                                                                     TensorInfo(TensorShape(3U, 3U, 5U, 21U), 1, DataType::F32),
                                                                                     TensorInfo(TensorShape(3U, 3U, 5U, 21U), 1, DataType::F32),
                                                                                     TensorInfo(TensorShape(5U, 5U, 7U, 16U), 1, DataType::F16)
                                           }),
-                                          framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(6U, 6U, 1U), 1, DataType::F32),
+                                          make("OutputInfo", { TensorInfo(TensorShape(6U, 6U, 1U), 1, DataType::F32),
                                                                                    TensorInfo(TensorShape(21U, 25U, 21U, 4U), 1, DataType::F32),
                                                                                    TensorInfo(TensorShape(11U, 25U, 21U), 1, DataType::F32),
                                                                                    TensorInfo(TensorShape(11U, 12U, 16U, 4U), 1, DataType::F32)
                                           }),
-                                          framework::dataset::make("ConvInfo", { PadStrideInfo(1, 1, 0, 0),
+                                          make("ConvInfo", { PadStrideInfo(1, 1, 0, 0),
                                                                                  PadStrideInfo(1, 1, 0, 0),
                                                                                  PadStrideInfo(2, 1, 0, 0),
                                                                                  PadStrideInfo(3, 2, 1, 0)
                                           }),
-                                          framework::dataset::make("Dilation", { Size2D(1U, 2U),
+                                          make("Dilation", { Size2D(1U, 2U),
                                                                                  Size2D(2U, 1U),
                                                                                  Size2D(2U, 2U),
                                                                                  Size2D(3U, 3U)
                                           }),
-                                          framework::dataset::make("Expected", { ConvolutionMethod::GEMM, ConvolutionMethod::GEMM, ConvolutionMethod::GEMM, ConvolutionMethod::GEMM })
+                                          make("Expected", { ConvolutionMethod::GEMM, ConvolutionMethod::GEMM, ConvolutionMethod::GEMM, ConvolutionMethod::GEMM })
                                           ),
                input_info, weights_info, output_info, conv_info, dilation, expected)
 {
@@ -117,10 +119,10 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMDilatedConvolutionLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDilatedConvolutionLayerDataset(),
-                                                                                                                        framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                        framework::dataset::make("DataType", DataType::F16),
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                                                                                                        framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                                                                                        make("ReshapeWeights", { true }),
+                                                                                                                        make("DataType", DataType::F16),
+                                                                                                                        make("DataLayout", { DataLayout::NCHW }),
+                                                                                                                        make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -134,10 +136,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMDilatedConvolutionLayerFixture<half>, fra
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEGEMMDilatedConvolutionLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDilatedConvolutionLayerDataset(),
-                                                                                                                      framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                      framework::dataset::make("DataType", DataType::F16),
-                                                                                                                      framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                                                                                                      framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                                                                                      make("ReshapeWeights", { true }),
+                                                                                                                      make("DataType", DataType::F16),
+                                                                                                                      make("DataLayout", { DataLayout::NCHW }),
+                                                                                                                      make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -155,19 +157,19 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMDilatedConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDilatedConvolutionLayerDataset(),
-                       framework::dataset::make("ReshapeWeights", { true }),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                       framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                       make("ReshapeWeights", { true }),
+                       make("DataType", DataType::F32),
+                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                       make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEGEMMDilatedConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDilatedConvolutionLayerDataset(),
-                                                                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                       framework::dataset::make("DataType", DataType::F32),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                       framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                                                                                       make("ReshapeWeights", { true }),
+                                                                                                                       make("DataType", DataType::F32),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                       make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -187,22 +189,22 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEGEMMDilatedConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallDilatedConvolutionLayerDataset(),
-                                                               framework::dataset::make("ReshapeWeights", { true }),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                       framework::dataset::make("IgnoredQuantizationInfo", { QuantizationInfo() }),
-                               framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                               make("ReshapeWeights", { true }),
+                                                       make("DataType", DataType::QASYMM8),
+                                               make("DataLayout", { DataLayout::NCHW }),
+                                       make("IgnoredQuantizationInfo", { QuantizationInfo() }),
+                               make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEGEMMDilatedConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeDilatedConvolutionLayerDataset(),
-                                                               framework::dataset::make("ReshapeWeights", { true }),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                       framework::dataset::make("IgnoredQuantizationInfo", { QuantizationInfo() }),
-                               framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                               make("ReshapeWeights", { true }),
+                                                       make("DataType", DataType::QASYMM8),
+                                               make("DataLayout", { DataLayout::NCHW }),
+                                       make("IgnoredQuantizationInfo", { QuantizationInfo() }),
+                               make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/NEON/DirectConvolutionLayer.cpp
+++ b/tests/validation/NEON/DirectConvolutionLayer.cpp
@@ -55,40 +55,40 @@ constexpr float                           tolerance_num = 0.07f;                
 #endif                                                                               /* ARM_COMPUTE_ENABLE_FP16 */
 
 /** Direct convolution data set.for FP32 */
-const auto data_pad_f32 = concat(concat(combine(framework::dataset::make("PadX", { 0, 1 }),framework::dataset::make("PadY", { 0, 1 }),
-                                                        framework::dataset::make("KernelSize", 3)),
-                                        combine(framework::dataset::make("PadX", { 0, 2 }),framework::dataset::make("PadY", { 0, 2 }),
-                                                        framework::dataset::make("KernelSize", 3))),
-                                 combine(framework::dataset::make("PadX", { 0, 3 }),framework::dataset::make("PadY", { 0, 3 }),
-                                                 framework::dataset::make("KernelSize", 5)));
+const auto data_pad_f32 = concat(combine(make("PadX", { 0, 1 }),make("PadY", { 0, 1 }),
+                                         make("KernelSize", 3)),
+                                 combine(make("PadX", { 0, 2 }),make("PadY", { 0, 2 }),
+                                         make("KernelSize", 3)),
+                                 combine(make("PadX", { 0, 3 }),make("PadY", { 0, 3 }),
+                                         make("KernelSize", 5)));
 
 /** Direct convolution data set.for FP16 */
-const auto data_pad_f16 = concat(combine(framework::dataset::make("PadX", { 0, 1 }),framework::dataset::make("PadY", { 0, 1 }),
-                                                 framework::dataset::make("KernelSize", 3)),
-                                 combine(framework::dataset::make("PadX", { 0 }),framework::dataset::make("PadY", { 0 }),
-                                                 framework::dataset::make("KernelSize", 1)));
+const auto data_pad_f16 = concat(combine(make("PadX", { 0, 1 }),make("PadY", { 0, 1 }),
+                                                 make("KernelSize", 3)),
+                                 combine(make("PadX", { 0 }),make("PadY", { 0 }),
+                                                 make("KernelSize", 1)));
 
-const auto data_f32 = combine(datasets::SmallDirectConvolutionShapes(),framework::dataset::make("StrideX", { 1, 2, 3, 4 }),framework::dataset::make("StrideY", { 1, 2, 3, 4 }),
+const auto data_f32 = combine(datasets::SmallDirectConvolutionShapes(),make("StrideX", { 1, 2, 3, 4 }),make("StrideY", { 1, 2, 3, 4 }),
                                               data_pad_f32);
 
-const auto data_f16 = combine(datasets::SmallDirectConvolutionShapes(),framework::dataset::make("StrideX", { 1, 2, 3 }),framework::dataset::make("StrideY", { 1, 2, 3 }),
+const auto data_f16 = combine(datasets::SmallDirectConvolutionShapes(),make("StrideX", { 1, 2, 3 }),make("StrideY", { 1, 2, 3 }),
                                               data_pad_f16);
 
-const auto data_prec = combine(datasets::SmallDirectConvolutionShapes(),framework::dataset::make("StrideX", { 1 }),framework::dataset::make("StrideY", { 1 }),framework::dataset::make("PadX", { 1 }),framework::dataset::make("PadY", { 1 }),
-                                                               framework::dataset::make("KernelSize", 3));
+const auto data_prec = combine(datasets::SmallDirectConvolutionShapes(),make("StrideX", { 1 }),make("StrideY", { 1 }),make("PadX", { 1 }),make("PadY", { 1 }),
+                                                               make("KernelSize", 3));
 
-const auto data9x9 = combine(datasets::SmallDirectConvolutionShapes(),framework::dataset::make("StrideX", { 1, 2, 3 }),framework::dataset::make("StrideY", { 1, 2, 3 }),framework::dataset::make("PadX", { 0, 2 }),framework::dataset::make("PadY", { 0, 3 }),
-                                                             framework::dataset::make("KernelSize", 9));
+const auto data9x9 = combine(datasets::SmallDirectConvolutionShapes(),make("StrideX", { 1, 2, 3 }),make("StrideY", { 1, 2, 3 }),make("PadX", { 0, 2 }),make("PadY", { 0, 3 }),
+                                                             make("KernelSize", 9));
 
-const auto data8x8 = combine(datasets::SmallDirectConvolutionShapes(),framework::dataset::make("StrideX", { 1, 2, 3 }),framework::dataset::make("StrideY", { 1, 2, 3 }),framework::dataset::make("PadX", { 0 }),framework::dataset::make("PadY", { 0 }),
-                                                             framework::dataset::make("KernelSize", 8));
+const auto data8x8 = combine(datasets::SmallDirectConvolutionShapes(),make("StrideX", { 1, 2, 3 }),make("StrideY", { 1, 2, 3 }),make("PadX", { 0 }),make("PadY", { 0 }),
+                                                             make("KernelSize", 8));
 
-const auto data_f32_nightly = combine(data_f32, framework::dataset::make("NumKernels", { 1, 4, 5 }));
-const auto data_f16_nightly = combine(data_f16, framework::dataset::make("NumKernels", { 1, 4, 5 }));
+const auto data_f32_nightly = combine(data_f32, make("NumKernels", { 1, 4, 5 }));
+const auto data_f16_nightly = combine(data_f16, make("NumKernels", { 1, 4, 5 }));
 
-const auto data_precommit    = combine(data_prec, framework::dataset::make("NumKernels", { 1 }));
-const auto data_precommit9x9 = combine(data9x9, framework::dataset::make("NumKernels", { 4 }));
-const auto data_precommit8x8 = combine(data8x8, framework::dataset::make("NumKernels", { 4 }));
+const auto data_precommit    = combine(data_prec, make("NumKernels", { 1 }));
+const auto data_precommit9x9 = combine(data9x9, make("NumKernels", { 4 }));
+const auto data_precommit8x8 = combine(data8x8, make("NumKernels", { 4 }));
 
 /* The following tests is from real use-case that made DirectConvolution
  * overflows in terms of its tensor indexing. This test case is using
@@ -101,11 +101,11 @@ const auto data_precommit8x8 = combine(data8x8, framework::dataset::make("NumKer
  */
 constexpr AbsoluteTolerance<float> usecase_tolerance_fp32(0.05f);
 
-const auto data_nightly_usecase = combine(framework::dataset::make("InputShape", { TensorShape{ 3U, 800U, 800U } }),framework::dataset::make("StrideX", { 1 }),framework::dataset::make("StrideY", { 1 }),framework::dataset::make("PadX", { 4 }),framework::dataset::make("PadY", { 4 }),framework::dataset::make("KernelSize", 9),
-                                                                                  framework::dataset::make("NumKernels", { 16 }));
+const auto data_nightly_usecase = combine(make("InputShape", { TensorShape{ 3U, 800U, 800U } }),make("StrideX", { 1 }),make("StrideY", { 1 }),make("PadX", { 4 }),make("PadY", { 4 }),make("KernelSize", 9),
+                                                                                  make("NumKernels", { 16 }));
 
 /** Activation function Dataset*/
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 0.5f)
@@ -161,7 +161,7 @@ TEST_CASE(NoBias, framework::DatasetMode::PRECOMMIT)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid: Mismatching data type input/weights
+        make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid: Mismatching data type input/weights
                                                 TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid: Mismatching input feature maps
                                                 TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Unsupported kernel width
                                                 TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Unsupported non-rectangular weights dimensions
@@ -171,7 +171,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Unsupported biases dimensions
                                                 TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid output size
                                               }),
-        framework::dataset::make("WeightsInfo",{ TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F16),
+        make("WeightsInfo",{ TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F16),
                                                  TensorInfo(TensorShape(3U, 3U, 3U, 4U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(9U, 9U, 2U, 4U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(5U, 3U, 2U, 4U), 1, DataType::F32),
@@ -181,7 +181,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                  TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),
                                               }),
-        framework::dataset::make("BiasesInfo",{ TensorInfo(TensorShape(4U), 1, DataType::F32),
+        make("BiasesInfo",{ TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1, DataType::F32),
@@ -191,7 +191,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(4U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U), 1, DataType::F32),
                                               }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
@@ -201,7 +201,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(26U, 11U, 4U), 1, DataType::F32),
                                               }),
-        framework::dataset::make("ConvInfo",  { PadStrideInfo(1, 1, 0, 0),
+        make("ConvInfo",  { PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
@@ -211,7 +211,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
                                                }),
-        framework::dataset::make("ActivationInfo",
+        make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -223,7 +223,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
 }),
-        framework::dataset::make("Expected", { false, false, false, false, false, false, false, false, false })
+        make("Expected", { false, false, false, false, false, false, false, false, false })
         ),
         input_info, weights_info, biases_info, output_info, conv_info, act_info, expected)
 {
@@ -234,9 +234,9 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
 // *INDENT-ON*
 
 DATA_TEST_CASE(NoPaddingNHWCKernel, framework::DatasetMode::ALL, combine(data_precommit,
-                                                                                         framework::dataset::make("DataType", DataType::F32),
+                                                                                         make("DataType", DataType::F32),
                                                                                  ActivationFunctionsDataset,
-                                                                         framework::dataset::make("DataLayout", { DataLayout::NHWC })),
+                                                                         make("DataLayout", { DataLayout::NHWC })),
 
                shape, stride_x, stride_y, pad_x, pad_y, kernel_size, num_kernels, data_type, act_info, data_layout)
 {
@@ -319,52 +319,52 @@ TEST_SUITE_END() // FP16
 #endif           /* ARM_COMPUTE_ENABLE_FP16 */
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit, make("DataType",
                                                                                                                     DataType::F32),
                                                                                                                     ActivationFunctionsDataset,
-                                                                                                                    framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                    make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEDirectConvolutionLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                       framework::dataset::make("DataType", DataType::F32),
+                       make("DataType", DataType::F32),
                        ActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 
-FIXTURE_DATA_TEST_CASE(RunSmall8x8, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit8x8, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall8x8, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit8x8, make("DataType",
                                                                                                                        DataType::F32),
                                                                                                                        ActivationFunctionsDataset,
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 
-FIXTURE_DATA_TEST_CASE(RunSmall9x9, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit9x9, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall9x9, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit9x9, make("DataType",
                                                                                                                        DataType::F32),
                                                                                                                        ActivationFunctionsDataset,
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NHWC })))
+                                                                                                                       make("DataLayout", { DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(data_f32_nightly, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(data_f32_nightly, make("DataType",
                                                                                                                   DataType::F32),
                                                                                                                   ActivationFunctionsDataset,
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                  make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLargeUsecase, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(data_nightly_usecase, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLargeUsecase, NEDirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(data_nightly_usecase, make("DataType",
                        DataType::F32),
-                       framework::dataset::make("ActivationInfo", { ActivationLayerInfo() }),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC })))
+                       make("ActivationInfo", { ActivationLayerInfo() }),
+                       make("DataLayout", { DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, usecase_tolerance_fp32);

--- a/tests/validation/NEON/ElementwiseAbsoluteValue.cpp
+++ b/tests/validation/NEON/ElementwiseAbsoluteValue.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -66,7 +68,7 @@ using NEAbsLayerQuantizedFixture = AbsQuantizedValidationFixture<Tensor, Accesso
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -80,7 +82,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerFixture<half>, framework::DatasetMode
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEAbsLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEAbsLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -99,14 +101,14 @@ TEST_SUITE_END() // FP16
 #endif           // ARM_COMPUTE_ENABLE_FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                 DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEAbsLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEAbsLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output
@@ -117,14 +119,14 @@ TEST_SUITE_END() // Float
 
 TEST_SUITE(Integer)
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                   DataType::S32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEAbsLayerFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEAbsLayerFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                       DataType::S32)))
 {
     // Validate output
@@ -137,9 +139,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.2, -3) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InputQInfo", { QuantizationInfo(0.2, -3) }),
+                       make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -149,9 +151,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEAbsLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.075, 6) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("InputQInfo", { QuantizationInfo(0.075, 6) }),
+                       make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/NEON/ElementwiseDivision.cpp
+++ b/tests/validation/NEON/ElementwiseDivision.cpp
@@ -40,24 +40,26 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
 AbsoluteTolerance<int>   tolerance_zero_s32(0); // Tolerance for S32 division
 
 /** Input data sets **/
-const auto ElementwiseDivisionS32Dataset = combine(framework::dataset::make("DataType", DataType::S32),
-                                                           framework::dataset::make("DataType", DataType::S32),
-                                                   framework::dataset::make("DataType", DataType::S32));
+const auto ElementwiseDivisionS32Dataset = combine(make("DataType", DataType::S32),
+                                                           make("DataType", DataType::S32),
+                                                   make("DataType", DataType::S32));
 #ifdef ARM_COMPUTE_ENABLE_FP16
 RelativeTolerance<half> tolerance_fp16(static_cast<half>(0.01f));
-const auto              ElementwiseDivisionFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                                                 framework::dataset::make("DataType", DataType::F16));
+const auto              ElementwiseDivisionFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                                                 make("DataType", DataType::F16));
 #endif /* ARM_COMPUTE_ENABLE_FP16 */
-const auto ElementwiseDivisionFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                                    framework::dataset::make("DataType", DataType::F32));
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto ElementwiseDivisionFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                                    make("DataType", DataType::F32));
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -69,25 +71,25 @@ using NEElementwiseDivisionFixture = ArithmeticDivisionValidationFixture<Tensor,
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, true, true, false, false})
+               make("Expected", { true, true, true, false, false})
                ),
                input1_info, input2_info, output_info, expected)
 {

--- a/tests/validation/NEON/ElementwiseExpLayer.cpp
+++ b/tests/validation/NEON/ElementwiseExpLayer.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -68,7 +70,7 @@ using NEExpLayerQuantizedFixture = ExpQuantizedValidationFixture<Tensor, Accesso
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEExpLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEExpLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -82,7 +84,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEExpLayerFixture<half>, framework::DatasetMode
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEExpLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEExpLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -101,7 +103,7 @@ TEST_SUITE_END() // FP16
 #endif           // ARM_COMPUTE_ENABLE_FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEExpLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEExpLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                 DataType::F32)))
 {
     // Validate output
@@ -114,9 +116,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEExpLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.01, 0) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.003, 10) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InputQInfo", { QuantizationInfo(0.01, 0) }),
+                       make("OutputQInfo", { QuantizationInfo(0.003, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -126,9 +128,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEExpLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.02, -1) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.002, -2) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("InputQInfo", { QuantizationInfo(0.02, -1) }),
+                       make("OutputQInfo", { QuantizationInfo(0.002, -2) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/NEON/ElementwiseKernelSelection.cpp
+++ b/tests/validation/NEON/ElementwiseKernelSelection.cpp
@@ -35,17 +35,18 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(NEON)
 TEST_SUITE(KernelSelection)
 
 DATA_TEST_CASE(KernelSelection_elementwise_unary, framework::DatasetMode::ALL, concat(
-                   combine(framework::dataset::make("CpuExt", std::string("NEON")),
-                           framework::dataset::make("DataType", { DataType::F32,
+                   combine(make("CpuExt", std::string("NEON")),
+                           make("DataType", { DataType::F32,
                                                                   DataType::F16,
                                                                   DataType::S32
                                                                 })),
-                   combine(framework::dataset::make("CpuExt", std::string("SVE")),
-                           framework::dataset::make("DataType", { DataType::F32,
+                   combine(make("CpuExt", std::string("SVE")),
+                           make("DataType", { DataType::F32,
                                                                   DataType::F16,
                                                                   DataType::S32
                                                                 }))),
@@ -68,25 +69,26 @@ DATA_TEST_CASE(KernelSelection_elementwise_unary, framework::DatasetMode::ALL, c
     ARM_COMPUTE_EXPECT_EQUAL(expected, actual, framework::LogLevel::ERRORS);
 }
 
-DATA_TEST_CASE(KernelSelection_elementwise_arithmetic, framework::DatasetMode::ALL, concat(concat(
-                                                                                               combine(framework::dataset::make("CpuExt", std::string("NEON")),
-                                                                                                       framework::dataset::make("DataType", { DataType::F32,
-                                                                                                               DataType::F16,
-                                                                                                               DataType::S32,
-                                                                                                               DataType::S16,
-                                                                                                               DataType::QASYMM8,
-                                                                                                               DataType::QASYMM8_SIGNED
-                                                                                                                                            })),
-                                                                                               combine(framework::dataset::make("CpuExt", std::string("SVE")),
-                                                                                                       framework::dataset::make("DataType", { DataType::F32,
-                                                                                                               DataType::F16,
-                                                                                                               DataType::S32,
-                                                                                                               DataType::S16
-                                                                                                                                            }))),
-                                                                                           combine(framework::dataset::make("CpuExt", std::string("SVE2")),
-                                                                                                   framework::dataset::make("DataType", { DataType::QASYMM8,
-                                                                                                           DataType::QASYMM8_SIGNED
-                                                                                                                                        }))),
+DATA_TEST_CASE(KernelSelection_elementwise_arithmetic, framework::DatasetMode::ALL, concat(
+                                                                                           combine(make("CpuExt", std::string("NEON")),
+                                                                                                   make("DataType", { DataType::F32,
+                                                                                                                      DataType::F16,
+                                                                                                                      DataType::S32,
+                                                                                                                      DataType::S16,
+                                                                                                                      DataType::QASYMM8,
+                                                                                                                      DataType::QASYMM8_SIGNED,
+            })),
+                                                                                           combine(make("CpuExt", std::string("SVE")),
+                                                                                                   make("DataType", { DataType::F32,
+                                                                                                                      DataType::F16,
+                                                                                                                      DataType::S32,
+                                                                                                                      DataType::S16,
+            })),
+                                                                                           combine(make("CpuExt", std::string("SVE2")),
+                                                                                                   make("DataType", { DataType::QASYMM8,
+                                                                                                                      DataType::QASYMM8_SIGNED,
+        }))),
+
                cpu_ext, data_type)
 {
     using namespace cpu::kernels;
@@ -109,27 +111,28 @@ DATA_TEST_CASE(KernelSelection_elementwise_arithmetic, framework::DatasetMode::A
     ARM_COMPUTE_EXPECT_EQUAL(expected, actual, framework::LogLevel::ERRORS);
 }
 
-DATA_TEST_CASE(KernelSelection_elementwise_comparison, framework::DatasetMode::ALL, concat(concat(
-                                                                                               combine(framework::dataset::make("CpuExt", std::string("NEON")),
-                                                                                                       framework::dataset::make("DataType", { DataType::F32,
-                                                                                                               DataType::F16,
-                                                                                                               DataType::S32,
-                                                                                                               DataType::S16,
-                                                                                                               DataType::U8,
-                                                                                                               DataType::QASYMM8,
-                                                                                                               DataType::QASYMM8_SIGNED
-                                                                                                                                            })),
-                                                                                               combine(framework::dataset::make("CpuExt", std::string("SVE")),
-                                                                                                       framework::dataset::make("DataType", { DataType::F32,
-                                                                                                               DataType::F16,
-                                                                                                               DataType::S32,
-                                                                                                               DataType::S16,
-                                                                                                               DataType::U8
-                                                                                                                                            }))),
-                                                                                           combine(framework::dataset::make("CpuExt", std::string("SVE2")),
-                                                                                                   framework::dataset::make("DataType", { DataType::QASYMM8,
-                                                                                                           DataType::QASYMM8_SIGNED
-                                                                                                                                        }))),
+DATA_TEST_CASE(KernelSelection_elementwise_comparison, framework::DatasetMode::ALL, concat(
+                                                                                           combine(make("CpuExt", std::string("NEON")),
+                                                                                                   make("DataType", { DataType::F32,
+                                                                                                                      DataType::F16,
+                                                                                                                      DataType::S32,
+                                                                                                                      DataType::S16,
+                                                                                                                      DataType::U8,
+                                                                                                                      DataType::QASYMM8,
+                                                                                                                      DataType::QASYMM8_SIGNED,
+            })),
+                                                                                           combine(make("CpuExt", std::string("SVE")),
+                                                                                                   make("DataType", { DataType::F32,
+                                                                                                                      DataType::F16,
+                                                                                                                      DataType::S32,
+                                                                                                                      DataType::S16,
+                                                                                                                      DataType::U8,
+            })),
+                                                                                           combine(make("CpuExt", std::string("SVE2")),
+                                                                                                   make("DataType", { DataType::QASYMM8,
+                                                                                                                      DataType::QASYMM8_SIGNED,
+        }))),
+
                cpu_ext, data_type)
 {
     using namespace cpu::kernels;

--- a/tests/validation/NEON/ElementwiseLog.cpp
+++ b/tests/validation/NEON/ElementwiseLog.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -68,7 +70,7 @@ using NELogLayerQuantizedFixture = LogQuantizedValidationFixture<Tensor, Accesso
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NELogLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NELogLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -82,7 +84,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NELogLayerFixture<half>, framework::DatasetMode
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NELogLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NELogLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -101,14 +103,14 @@ TEST_SUITE_END() // FP16
 #endif           // ARM_COMPUTE_ENABLE_FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NELogLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NELogLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                 DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NELogLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NELogLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output
@@ -121,9 +123,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NELogLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(10.5, 0), QuantizationInfo(0.5, -10)  }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(5, 10) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InputQInfo", { QuantizationInfo(10.5, 0), QuantizationInfo(0.5, -10)  }),
+                       make("OutputQInfo", { QuantizationInfo(5, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -133,9 +135,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NELogLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.75, -128) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(12.5, -2) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("InputQInfo", { QuantizationInfo(0.75, -128) }),
+                       make("OutputQInfo", { QuantizationInfo(12.5, -2) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/NEON/ElementwiseMax.cpp
+++ b/tests/validation/NEON/ElementwiseMax.cpp
@@ -39,31 +39,33 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr RelativeTolerance<float>  tolerance_fp32(0.000001f);
 constexpr AbsoluteTolerance<int8_t> tolerance_qasymm8_signed(1);
 /** Input data sets **/
-const auto ElementwiseMaxQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                                  framework::dataset::make("DataType",
+const auto ElementwiseMaxQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                                  make("DataType",
                                                                            DataType::QASYMM8));
-const auto ElementwiseMaxQASYMM8SignedDataset = combine(framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                        framework::dataset::make("DataType",
+const auto ElementwiseMaxQASYMM8SignedDataset = combine(make("DataType", DataType::QASYMM8_SIGNED), make("DataType", DataType::QASYMM8_SIGNED),
+                                                        make("DataType",
                                                                                  DataType::QASYMM8_SIGNED));
 
 /** Input data sets **/
-const auto ElementwiseMaxS32Dataset = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType",
+const auto ElementwiseMaxS32Dataset = combine(make("DataType", DataType::S32), make("DataType", DataType::S32), make("DataType",
                                               DataType::S32));
-const auto ElementwiseMaxS16Dataset = combine(framework::dataset::make("DataType", { DataType::S16 }), framework::dataset::make("DataType", DataType::S16),
-                                              framework::dataset::make("DataType", DataType::S16));
+const auto ElementwiseMaxS16Dataset = combine(make("DataType", { DataType::S16 }), make("DataType", DataType::S16),
+                                              make("DataType", DataType::S16));
 #ifdef ARM_COMPUTE_ENABLE_FP16
-const auto ElementwiseMaxFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                               framework::dataset::make("DataType", DataType::F16));
+const auto ElementwiseMaxFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                               make("DataType", DataType::F16));
 #endif /* ARM_COMPUTE_ENABLE_FP16 */
-const auto ElementwiseMaxFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                               framework::dataset::make("DataType", DataType::F32));
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto ElementwiseMaxFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                               make("DataType", DataType::F32));
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -75,7 +77,7 @@ using NEElementwiseMaxFixture = ElementwiseMaxValidationFixture<Tensor, Accessor
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),            // Invalid data type combination
@@ -83,7 +85,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                         TensorInfo(TensorShape(8U, 8U, 3U), 1, DataType::QASYMM8_SIGNED),   // OK
                                                         TensorInfo(TensorShape(8U, 8U, 3U), 1, DataType::QASYMM8_SIGNED),   // Mismatching data types
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
@@ -91,7 +93,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(8U, 8U, 3U), 1, DataType::QASYMM8_SIGNED),
                                                        TensorInfo(TensorShape(8U, 8U, 3U), 1, DataType::QASYMM8),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
@@ -99,7 +101,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(8U, 8U, 3U), 1, DataType::QASYMM8_SIGNED),
                                                        TensorInfo(TensorShape(8U, 8U, 3U), 1, DataType::QASYMM8_SIGNED),
                                                      }),
-               framework::dataset::make("Expected", { true, true, true, false, false, true, false, false })
+               make("Expected", { true, true, true, false, false, true, false, false })
                ),
                input1_info, input2_info, output_info, expected)
 {
@@ -137,9 +139,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEElementwiseMaxQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                        ElementwiseMaxQASYMM8Dataset,
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                                                                                                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -152,9 +154,9 @@ using NEElementwiseMaxQuantizedBroadcastFixture = ElementwiseMaxQuantizedBroadca
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEElementwiseMaxQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapesBroadcast(),
                                                                ElementwiseMaxQASYMM8Dataset,
-                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                OutOfPlaceDataSet))
 {
     // Validate output
@@ -165,9 +167,9 @@ TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEElementwiseMaxQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                       ElementwiseMaxQASYMM8SignedDataset,
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(10.f, 20) }),
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f, 0) }),
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f, -27) }),
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(10.f, 20) }),
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(1.f, 0) }),
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(2.f, -27) }),
                                                                                                                       OutOfPlaceDataSet))
 {
     // Validate output
@@ -175,9 +177,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEElementwiseMaxQuantizedFixture<int8_t>, frame
 }
 FIXTURE_DATA_TEST_CASE(RunSmallInPlace, NEElementwiseMaxQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        ElementwiseMaxQASYMM8SignedDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(10.f, -20) }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(10.f, -20) }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(10.f, -20) }),
+                       make("QuantizationInfo", { QuantizationInfo(10.f, -20) }),
+                       make("QuantizationInfo", { QuantizationInfo(10.f, -20) }),
+                       make("QuantizationInfo", { QuantizationInfo(10.f, -20) }),
                        InPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/NEON/ElementwiseMin.cpp
+++ b/tests/validation/NEON/ElementwiseMin.cpp
@@ -39,31 +39,33 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr RelativeTolerance<float>  tolerance_fp32(0.000001f);
 constexpr AbsoluteTolerance<int8_t> tolerance_qasymm8_signed(1);
 /** Input data sets **/
-const auto ElementwiseMinQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                                  framework::dataset::make("DataType",
+const auto ElementwiseMinQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                                  make("DataType",
                                                                            DataType::QASYMM8));
 
-const auto ElementwiseMaxQASYMM8SignedDataset = combine(framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                        framework::dataset::make("DataType",
+const auto ElementwiseMaxQASYMM8SignedDataset = combine(make("DataType", DataType::QASYMM8_SIGNED), make("DataType", DataType::QASYMM8_SIGNED),
+                                                        make("DataType",
                                                                                  DataType::QASYMM8_SIGNED));
 
-const auto ElementwiseMinS32Dataset = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType",
+const auto ElementwiseMinS32Dataset = combine(make("DataType", DataType::S32), make("DataType", DataType::S32), make("DataType",
                                               DataType::S32));
-const auto ElementwiseMinS16Dataset = combine(framework::dataset::make("DataType", { DataType::S16 }), framework::dataset::make("DataType", DataType::S16),
-                                              framework::dataset::make("DataType", DataType::S16));
+const auto ElementwiseMinS16Dataset = combine(make("DataType", { DataType::S16 }), make("DataType", DataType::S16),
+                                              make("DataType", DataType::S16));
 #ifdef ARM_COMPUTE_ENABLE_FP16
-const auto ElementwiseMinFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                               framework::dataset::make("DataType", DataType::F16));
+const auto ElementwiseMinFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                               make("DataType", DataType::F16));
 #endif /* ARM_COMPUTE_ENABLE_FP16 */
-const auto ElementwiseMinFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                               framework::dataset::make("DataType", DataType::F32));
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto ElementwiseMinFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                               make("DataType", DataType::F32));
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -75,7 +77,7 @@ using NEElementwiseMinFixture = ElementwiseMinValidationFixture<Tensor, Accessor
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),                // Invalid data type combination
@@ -83,7 +85,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                         TensorInfo(TensorShape(4U, 4U, 2U), 1, DataType::QASYMM8_SIGNED),       // Ok
                                                         TensorInfo(TensorShape(4U, 4U, 2U), 1, DataType::QASYMM8_SIGNED),       // Mismatching types, cannot mix QASYMM8_SIGNED with QASYMM8
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
@@ -91,7 +93,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(4U, 4U, 2U), 1, DataType::QASYMM8_SIGNED),
                                                        TensorInfo(TensorShape(4U, 4U, 2U), 1, DataType::QASYMM8),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
@@ -99,7 +101,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(4U, 4U, 2U), 1, DataType::QASYMM8_SIGNED),
                                                        TensorInfo(TensorShape(4U, 4U, 2U), 1, DataType::QASYMM8_SIGNED),
                                                      }),
-               framework::dataset::make("Expected", { true, true, true, false,
+               make("Expected", { true, true, true, false,
                                                       false,true,false})
                                                       ),
                input1_info, input2_info, output_info, expected)
@@ -141,9 +143,9 @@ using NEElementwiseMinQuantizedBroadcastFixture = ElementwiseMinQuantizedBroadca
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEElementwiseMinQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapesBroadcast(),
                                                                ElementwiseMinQASYMM8Dataset,
-                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                OutOfPlaceDataSet))
 {
     // Validate output
@@ -152,9 +154,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEElementwiseMinQuantizedBroadcastFixt
 FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInPlace, NEElementwiseMinQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::TinyShapesBroadcastInplace(),
                                                                ElementwiseMinQASYMM8Dataset,
-                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) }),
-                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) }),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) }),
+                                                       make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) }),
+                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) }),
+                                       make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -162,9 +164,9 @@ FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInPlace, NEElementwiseMinQuantizedBroadca
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, NEElementwiseMinQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                        ElementwiseMinQASYMM8Dataset,
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                                                                                                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -175,9 +177,9 @@ TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEElementwiseMinQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                       ElementwiseMaxQASYMM8SignedDataset,
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(10.f, 20) }),
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f, 0) }),
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f, -27) }),
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(10.f, 20) }),
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(1.f, 0) }),
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(2.f, -27) }),
                                                                                                                       OutOfPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/NEON/ElementwiseNegation.cpp
+++ b/tests/validation/NEON/ElementwiseNegation.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -67,8 +69,8 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NENegLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                             framework::dataset::make("DataType", DataType::F16),
-                                                                                                     framework::dataset::make("InPlace", { true, false })))
+                                                                                                             make("DataType", DataType::F16),
+                                                                                                     make("InPlace", { true, false })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -82,8 +84,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NENegLayerFixture<half>, framework::DatasetMode
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NENegLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                           framework::dataset::make("DataType", DataType::F16),
-                                                                                                   framework::dataset::make("InPlace", { false })))
+                                                                                                           make("DataType", DataType::F16),
+                                                                                                   make("InPlace", { false })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -102,16 +104,16 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NENegLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                framework::dataset::make("InPlace", { true, false })))
+                                                                                                        make("DataType", DataType::F32),
+                                                                                                make("InPlace", { true, false })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NENegLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                            framework::dataset::make("DataType", DataType::F32),
-                                                                                                    framework::dataset::make("InPlace", { false })))
+                                                                                                            make("DataType", DataType::F32),
+                                                                                                    make("InPlace", { false })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
@@ -122,16 +124,16 @@ TEST_SUITE_END() // Float
 TEST_SUITE(Integer)
 TEST_SUITE(S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NENegLayerFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                          framework::dataset::make("DataType", DataType::S32),
-                                                                                                  framework::dataset::make("InPlace", { true, false })))
+                                                                                                          make("DataType", DataType::S32),
+                                                                                                  make("InPlace", { true, false })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NENegLayerFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                              framework::dataset::make("DataType", DataType::S32),
-                                                                                                      framework::dataset::make("InPlace", { false })))
+                                                                                                              make("DataType", DataType::S32),
+                                                                                                      make("InPlace", { false })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -143,9 +145,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NENegLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.2, -3) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InputQInfo", { QuantizationInfo(0.2, -3) }),
+                       make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -155,9 +157,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NENegLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.075, 6) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("InputQInfo", { QuantizationInfo(0.075, 6) }),
+                       make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/NEON/ElementwisePower.cpp
+++ b/tests/validation/NEON/ElementwisePower.cpp
@@ -40,19 +40,21 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.001f);
 /** Input data sets **/
 #ifdef ARM_COMPUTE_ENABLE_FP16
 RelativeTolerance<half> tolerance_fp16(static_cast<half>(0.01f));
-const auto              ElementwisePowerFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                                              framework::dataset::make("DataType", DataType::F16));
+const auto              ElementwisePowerFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                                              make("DataType", DataType::F16));
 #endif /* ARM_COMPUTE_ENABLE_FP16 */
-const auto ElementwisePowerFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                                 framework::dataset::make("DataType", DataType::F32));
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto ElementwisePowerFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                                 make("DataType", DataType::F32));
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -64,25 +66,25 @@ using NEElementwisePowerFixture = ElementwisePowerValidationFixture<Tensor, Acce
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, true, true, false, false})
+               make("Expected", { true, true, true, false, false})
                ),
                input1_info, input2_info, output_info, expected)
 {

--- a/tests/validation/NEON/ElementwiseRound.cpp
+++ b/tests/validation/NEON/ElementwiseRound.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(0);
@@ -57,7 +59,7 @@ using NERoundLayerQuantizedFixture = RoundQuantizedValidationFixture<Tensor, Acc
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NERoundLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NERoundLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                        DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -71,7 +73,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NERoundLayerFixture<half>, framework::DatasetMo
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NERoundLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NERoundLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -90,14 +92,14 @@ TEST_SUITE_END() // FP16
 #endif           // ARM_COMPUTE_ENABLE_FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NERoundLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NERoundLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                   DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NERoundLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NERoundLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output
@@ -110,9 +112,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERoundLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.2, -3) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InputQInfo", { QuantizationInfo(0.2, -3) }),
+                       make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -122,9 +124,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERoundLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.075, 6) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("InputQInfo", { QuantizationInfo(0.075, 6) }),
+                       make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/NEON/ElementwiseRsqrtLayer.cpp
+++ b/tests/validation/NEON/ElementwiseRsqrtLayer.cpp
@@ -77,7 +77,7 @@ using CpuRsqrtDynamicShapeQuantizedFixture = RsqrtDynamicShapeQuantizedValidatio
 TEST_SUITE(DynamicShape)
 TEST_SUITE(FP32)
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CpuRsqrtDynamicShapeFloatFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CpuRsqrtDynamicShapeFloatFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                           DataType::F32)))
 {
     // Validate output
@@ -110,7 +110,7 @@ using NERsqrtLayerQuantizedFixture = RsqrtQuantizedValidationFixture<Tensor, Acc
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NERsqrtLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NERsqrtLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                        DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -124,7 +124,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NERsqrtLayerFixture<half>, framework::DatasetMo
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NERsqrtLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NERsqrtLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -143,7 +143,7 @@ TEST_SUITE_END() // FP16
 #endif           // ARM_COMPUTE_ENABLE_FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NERsqrtLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NERsqrtLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                   DataType::F32)))
 {
     // Validate output
@@ -157,9 +157,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERsqrtLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(20, 0) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InputQInfo", { QuantizationInfo(20, 0) }),
+                       make("OutputQInfo", { QuantizationInfo(0.5, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -169,9 +169,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERsqrtLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(25, -128) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("InputQInfo", { QuantizationInfo(25, -128) }),
+                       make("OutputQInfo", { QuantizationInfo(0.1, -7) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/NEON/ElementwiseSin.cpp
+++ b/tests/validation/NEON/ElementwiseSin.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 AbsoluteTolerance<float> tolerance_fp32(0.00001f);
@@ -61,7 +63,7 @@ using NESinLayerQuantizedFixture = SinQuantizedValidationFixture<Tensor, Accesso
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NESinLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NESinLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -75,7 +77,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NESinLayerFixture<half>, framework::DatasetMode
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NESinLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NESinLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -94,14 +96,14 @@ TEST_SUITE_END() // FP16
 #endif           // ARM_COMPUTE_ENABLE_FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NESinLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NESinLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                 DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_fp32);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NESinLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NESinLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output
@@ -114,9 +116,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NESinLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.2, -3) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(200, 10) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InputQInfo", { QuantizationInfo(0.2, -3) }),
+                       make("OutputQInfo", { QuantizationInfo(200, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -126,9 +128,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NESinLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(
                        datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("InputQInfo", { QuantizationInfo(0.07, 6) }),
-                       framework::dataset::make("OutputQInfo", { QuantizationInfo(123, -7) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("InputQInfo", { QuantizationInfo(0.07, 6) }),
+                       make("OutputQInfo", { QuantizationInfo(123, -7) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/NEON/ElementwiseSquareDiff.cpp
+++ b/tests/validation/NEON/ElementwiseSquareDiff.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -48,28 +50,28 @@ RelativeTolerance<float> tolerance_fp16(0.01f);
 #endif /* ARM_COMPUTE_ENABLE_FP16 */
 
 /** Input data sets **/
-const auto ElementwiseSquaredDiffQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                                          framework::dataset::make("DataType",
+const auto ElementwiseSquaredDiffQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                                          make("DataType",
                                                                                    DataType::QASYMM8));
 
-const auto ElementwiseSquaredDiffQASYMM8SignedDataset = combine(framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                framework::dataset::make("DataType",
+const auto ElementwiseSquaredDiffQASYMM8SignedDataset = combine(make("DataType", DataType::QASYMM8_SIGNED), make("DataType", DataType::QASYMM8_SIGNED),
+                                                                make("DataType",
                                                                                          DataType::QASYMM8_SIGNED));
 
 /** Input data sets **/
-const auto ElementwiseSquaredDiffS32Dataset = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::S32),
-                                                      framework::dataset::make("DataType",
+const auto ElementwiseSquaredDiffS32Dataset = combine(make("DataType", DataType::S32), make("DataType", DataType::S32),
+                                                      make("DataType",
                                                                                DataType::S32));
-const auto ElementwiseSquaredDiffS16Dataset = combine(framework::dataset::make("DataType", { DataType::S16 }), framework::dataset::make("DataType", DataType::S16),
-                                                      framework::dataset::make("DataType", DataType::S16));
+const auto ElementwiseSquaredDiffS16Dataset = combine(make("DataType", { DataType::S16 }), make("DataType", DataType::S16),
+                                                      make("DataType", DataType::S16));
 #ifdef ARM_COMPUTE_ENABLE_FP16
-const auto ElementwiseSquaredDiffFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                                       framework::dataset::make("DataType", DataType::F16));
+const auto ElementwiseSquaredDiffFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                                       make("DataType", DataType::F16));
 #endif /* ARM_COMPUTE_ENABLE_FP16 */
-const auto ElementwiseSquaredDiffFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                                       framework::dataset::make("DataType", DataType::F32));
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto ElementwiseSquaredDiffFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                                       make("DataType", DataType::F32));
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -81,28 +83,28 @@ using NEElementwiseSquaredDiffFixture = ElementwiseSquaredDiffValidationFixture<
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                         TensorInfo(TensorShape(1U, 1U, 2U), 1, DataType::QASYMM8_SIGNED),     // Mismatching types
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 1U, 2U), 1, DataType::QASYMM8_SIGNED),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 1U, 2U), 1, DataType::QASYMM8, QuantizationInfo(0.3f,1)),
                                                      }),
-               framework::dataset::make("Expected", { true, true, true, false, false, false})
+               make("Expected", { true, true, true, false, false, false})
                ),
                input1_info, input2_info, output_info, expected)
 {
@@ -136,9 +138,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEElementwiseSquaredDiffQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        ElementwiseSquaredDiffQASYMM8Dataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                       make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                       make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -150,9 +152,9 @@ using NEElementwiseSquaredDiffQuantizedBroadcastFixture = ElementwiseSquaredDiff
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEElementwiseSquaredDiffQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapesBroadcast(),
                                                                ElementwiseSquaredDiffQASYMM8Dataset,
-                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                OutOfPlaceDataSet))
 {
     // Validate output
@@ -161,9 +163,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEElementwiseSquaredDiffQuantizedBroad
 FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInPlace, NEElementwiseSquaredDiffQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(datasets::TinyShapesBroadcastInplace(),
                                                                ElementwiseSquaredDiffQASYMM8Dataset,
-                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -174,9 +176,9 @@ TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEElementwiseSquaredDiffQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        ElementwiseSquaredDiffQASYMM8SignedDataset,
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f, 5) }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(.5f, 5) }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(.2f, 5) }),
+                       make("QuantizationInfo", { QuantizationInfo(1.f, 5) }),
+                       make("QuantizationInfo", { QuantizationInfo(.5f, 5) }),
+                       make("QuantizationInfo", { QuantizationInfo(.2f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/NEON/FFT.cpp
+++ b/tests/validation/NEON/FFT.cpp
@@ -40,10 +40,12 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-const auto data_types = framework::dataset::make("DataType", { DataType::F32 });
-const auto shapes_1d  = framework::dataset::make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 2U, 3U),
+const auto data_types = make("DataType", { DataType::F32 });
+const auto shapes_1d  = make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 2U, 3U),
                                                                   TensorShape(4U, 2U, 3U), TensorShape(5U, 2U, 3U),
                                                                   TensorShape(7U, 2U, 3U), TensorShape(8U, 2U, 3U),
                                                                   TensorShape(9U, 2U, 3U), TensorShape(25U, 2U, 3U),
@@ -52,14 +54,14 @@ const auto shapes_1d  = framework::dataset::make("TensorShape", { TensorShape(2U
                                                                   TensorShape(96U, 2U, 2U)
                                                                 });
 
-const auto shapes_2d = framework::dataset::make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 6U, 3U),
+const auto shapes_2d = make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 6U, 3U),
                                                                  TensorShape(4U, 5U, 3U), TensorShape(5U, 7U, 3U),
                                                                  TensorShape(7U, 25U, 3U), TensorShape(8U, 2U, 3U),
                                                                  TensorShape(9U, 16U, 3U), TensorShape(25U, 32U, 3U),
                                                                  TensorShape(192U, 128U, 2U)
                                                                });
 
-const auto ActivationFunctionsSmallDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsSmallDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 0.5f)
@@ -75,22 +77,22 @@ TEST_SUITE(FFT1D)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Mismatching data types
+        make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Mismatching data types
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Mismatching shapes
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 3, DataType::F32), // Invalid channels
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Unsupported axis
                                                 TensorInfo(TensorShape(11U, 13U, 2U), 2, DataType::F32), // Undecomposable FFT
                                                 TensorInfo(TensorShape(25U, 13U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F16),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F16),
                                                 TensorInfo(TensorShape(16U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(11U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 13U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("Axis", { 0, 0, 0, 2, 0, 0 }),
-        framework::dataset::make("Expected", { false, false, false, false, false, true })
+        make("Axis", { 0, 0, 0, 2, 0, 0 }),
+        make("Expected", { false, false, false, false, false, true })
         ),
         input_info, output_info, axis, expected)
 {
@@ -107,7 +109,7 @@ using NEFFT1DFixture = FFTValidationFixture<Tensor, Accessor, NEFFT1D, FFT1DInfo
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFFT1DFixture<float>, framework::DatasetMode::ALL, combine(shapes_1d, framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFFT1DFixture<float>, framework::DatasetMode::ALL, combine(shapes_1d, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32, tolerance_num);
@@ -120,19 +122,19 @@ TEST_SUITE(FFT2D)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32), // Mismatching data types
+        make("InputInfo", { TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32), // Mismatching data types
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32), // Mismatching shapes
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 3, DataType::F32), // Invalid channels
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Undecomposable FFT
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F16),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F16),
                                                 TensorInfo(TensorShape(16U, 25U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("Expected", { false, false, false, false, true })
+        make("Expected", { false, false, false, false, true })
         ),
                input_info, output_info, expected)
 {
@@ -147,7 +149,7 @@ using NEFFT2DFixture = FFTValidationFixture<Tensor, Accessor, NEFFT2D, FFT2DInfo
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFFT2DFixture<float>, framework::DatasetMode::ALL, combine(shapes_2d, framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFFT2DFixture<float>, framework::DatasetMode::ALL, combine(shapes_2d, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32, tolerance_num);
@@ -166,16 +168,16 @@ using NEFFTConvolutionLayerMixedDataLayoutFixture = FFTConvolutionValidationFixt
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEFFTConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallFFTConvolutionLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                 make("DataType", DataType::F32),
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                                                                                  ActivationFunctionsSmallDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEFFTConvolutionLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallFFTConvolutionLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                 make("DataType", DataType::F32),
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                                                                                  ActivationFunctionsSmallDataset))
 {
     // Validate output

--- a/tests/validation/NEON/Fill.cpp
+++ b/tests/validation/NEON/Fill.cpp
@@ -38,6 +38,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(Fill)
 
@@ -45,7 +47,7 @@ template <typename T>
 using NEFillFixture = FillFixture<Tensor, Accessor, NEFill, T>;
 
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::U8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::U8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -53,7 +55,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint8_t>, framework::DatasetMode:
 TEST_SUITE_END() // U8
 
 TEST_SUITE(S8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::S8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::S8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -61,7 +63,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int8_t>, framework::DatasetMode::
 TEST_SUITE_END() // S8
 
 TEST_SUITE(QASYMM8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::QASYMM8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -69,7 +71,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint8_t>, framework::DatasetMode:
 TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(U16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::U16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::U16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -77,7 +79,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint16_t>, framework::DatasetMode
 TEST_SUITE_END() // U16
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::S16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::S16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -85,7 +87,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int16_t>, framework::DatasetMode:
 TEST_SUITE_END() // S16
 
 TEST_SUITE(F16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -93,7 +95,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<half>, framework::DatasetMode::AL
 TEST_SUITE_END() // F16
 
 TEST_SUITE(U32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::U32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::U32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -101,7 +103,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<uint32_t>, framework::DatasetMode
 TEST_SUITE_END() // U32
 
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::S32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::S32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -109,7 +111,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<int32_t>, framework::DatasetMode:
 TEST_SUITE_END() // S32
 
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFillFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/FillBorder.cpp
+++ b/tests/validation/NEON/FillBorder.cpp
@@ -36,24 +36,26 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(FillBorder)
 
 // *INDENT-OFF*
 // clang-format off
-const auto PaddingSizesDataset = concat(concat(
-                                 framework::dataset::make("PaddingSize", PaddingSize{ 0 }),
-                                 framework::dataset::make("PaddingSize", PaddingSize{ 1, 0, 1, 2 })),
-                                 framework::dataset::make("PaddingSize", PaddingSize{ 10 }));
+const auto PaddingSizesDataset = concat(
+                                 make("PaddingSize", PaddingSize{ 0 }),
+                                 make("PaddingSize", PaddingSize{ 1, 0, 1, 2 }),
+                                 make("PaddingSize", PaddingSize{ 10 }));
 
-const auto BorderSizesDataset  = framework::dataset::make("BorderSize", 0, 6);
+const auto BorderSizesDataset  = make("BorderSize", 0, 6);
 
 DATA_TEST_CASE(FillBorder, framework::DatasetMode::ALL, combine(
                datasets::SmallShapes(),
                datasets::BorderModes(),
                BorderSizesDataset,
                PaddingSizesDataset,
-               framework::dataset::make("DataType", DataType::U8)),
+               make("DataType", DataType::U8)),
                shape, border_mode, size, padding, data_type)
 // clang-format on
 // *INDENT-ON*

--- a/tests/validation/NEON/Flatten.cpp
+++ b/tests/validation/NEON/Flatten.cpp
@@ -40,21 +40,23 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(FlattenLayer)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::U8),  // Mismatching data_type
+               make("InputInfo", { TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::U8),  // Mismatching data_type
                                                        TensorInfo(TensorShape(4U, 5U, 4U), 1, DataType::F32),  // Mismatching shapes
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Valid
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(64U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(64U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { false, false, true})
+               make("Expected", { false, false, true})
                ),
                input_info, output_info, expected)
 {
@@ -69,13 +71,13 @@ using NEFlattenLayerFixture = FlattenLayerValidationFixture<Tensor, Accessor, NE
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEFlattenLayerFixture<float>, framework::DatasetMode::ALL, combine(framework::dataset::concat(datasets::Small3DShapes(), datasets::Small4DShapes()),
-                                                                                                    framework::dataset::make("DataType", DataType::F32)))
+                                                                                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEFlattenLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(framework::dataset::concat(datasets::Large3DShapes(), datasets::Large4DShapes()),
-                                                                                                        framework::dataset::make("DataType", DataType::F32)))
+                                                                                                        make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -85,7 +87,7 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEFlattenLayerFixture<half>, framework::DatasetMode::ALL, combine(framework::dataset::concat(datasets::Small3DShapes(), datasets::Small4DShapes()),
-                                                                                                   framework::dataset::make("DataType", DataType::F16)))
+                                                                                                   make("DataType", DataType::F16)))
 {
     // Only validate if the cpu architecture supports FP16.
     if(CPUInfo::get().has_fp16())
@@ -100,7 +102,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFlattenLayerFixture<half>, framework::Dataset
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEFlattenLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(framework::dataset::concat(datasets::Large3DShapes(), datasets::Large4DShapes()),
-                                                                                                       framework::dataset::make("DataType", DataType::F16)))
+                                                                                                       make("DataType", DataType::F16)))
 {
     // Validate output
     if(CPUInfo::get().has_fp16())

--- a/tests/validation/NEON/Floor.cpp
+++ b/tests/validation/NEON/Floor.cpp
@@ -43,23 +43,25 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(Floor)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Wrong data type
+        make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Wrong data type
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Invalid data type combination
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Mismatching shapes
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("Expected", { false, false, false, true })
+        make("Expected", { false, false, false, true })
                                                           ),
                input_info, output_info, expected)
 {
@@ -69,8 +71,8 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
 
 
 DATA_TEST_CASE(KernelSelection, framework::DatasetMode::ALL,
-               combine(framework::dataset::make("CpuExt", std::string("NEON")),
-                       framework::dataset::make("DataType", { DataType::F32,
+               combine(make("CpuExt", std::string("NEON")),
+                       make("DataType", { DataType::F32,
                                                               DataType::F16,
                                                             })),
                cpu_ext, data_type)
@@ -99,7 +101,7 @@ using NEFloorFixture = FloorValidationFixture<Tensor, Accessor, NEFloor, T>;
 TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFloorFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFloorFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -112,7 +114,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFloorFixture<half>, framework::DatasetMode::P
         framework::ARM_COMPUTE_PRINT_INFO();
     }
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEFloorFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunLarge, NEFloorFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -129,12 +131,12 @@ TEST_SUITE_END() // FP16
 #endif           // ARM_COMPUTE_ENABLE_FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEFloorFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEFloorFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEFloorFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunLarge, NEFloorFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/FullyConnectedLayer.cpp
+++ b/tests/validation/NEON/FullyConnectedLayer.cpp
@@ -466,7 +466,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFullyConnectedLayerQuantizedFixture<uint8_t>,
 FIXTURE_DATA_TEST_CASE(RunLarge, NEFullyConnectedLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(
                            datasets::LargeFullyConnectedLayerDataset(),
                             FullyConnectedParameters,
-                           framework::dataset::make("DataType", DataType::QASYMM8),
+                           make("DataType", DataType::QASYMM8),
                        QuantizationData,
                        NoActivationFunctionDataset))
 {

--- a/tests/validation/NEON/FuseBatchNormalization.cpp
+++ b/tests/validation/NEON/FuseBatchNormalization.cpp
@@ -36,6 +36,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 AbsoluteTolerance<float> absolute_tolerance_f32(0.001f);
@@ -59,19 +61,19 @@ const auto shape_conv_values_precommit = concat(datasets::Small4DShapes(), datas
 const auto shape_conv_values_nightly = concat(datasets::Large4DShapes(), datasets::Large3DShapes());
 
 /** Data layout to test */
-const auto data_layout_values = framework::dataset::make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW });
+const auto data_layout_values = make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW });
 
 /** In-place flags to test */
-const auto in_place_values = framework::dataset::make("InPlace", { true, false });
+const auto in_place_values = make("InPlace", { true, false });
 
 /** With bias flags to test */
-const auto with_bias_values = framework::dataset::make("WithBias", { true, false });
+const auto with_bias_values = make("WithBias", { true, false });
 
 /** With gamma flags to test */
-const auto with_gamma_values = framework::dataset::make("WithGamma", { true, false });
+const auto with_gamma_values = make("WithGamma", { true, false });
 
 /** With beta flags to test */
-const auto with_beta_values = framework::dataset::make("WithBeta", { true, false });
+const auto with_beta_values = make("WithBeta", { true, false });
 
 TEST_SUITE(NEON)
 TEST_SUITE(FuseBatchNormalization)
@@ -81,7 +83,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationConvFixture<float>, framework::DatasetMode::PRECOMMIT,
                                         combine(
                                                         shape_conv_values_precommit,
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -96,7 +98,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationConvFixture<float>, fra
 FIXTURE_DATA_TEST_CASE(RunLarge, NEFuseBatchNormalizationConvFixture<float>, framework::DatasetMode::NIGHTLY,
                                         combine(
                                                         shape_conv_values_nightly,
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -113,7 +115,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationConvFixture<half>, framework::DatasetMode::PRECOMMIT,
                                         combine(
                                                         shape_conv_values_precommit,
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -136,7 +138,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationConvFixture<half>, fram
 FIXTURE_DATA_TEST_CASE(RunLarge, NEFuseBatchNormalizationConvFixture<half>, framework::DatasetMode::NIGHTLY,
                                         combine(
                                                         shape_conv_values_nightly,
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -165,7 +167,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationDWCFixture<float>, framework::DatasetMode::PRECOMMIT,
                                         combine(
                                                         datasets::Small3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -180,7 +182,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationDWCFixture<float>, fram
 FIXTURE_DATA_TEST_CASE(RunLarge, NEFuseBatchNormalizationDWCFixture<float>, framework::DatasetMode::NIGHTLY,
                                         combine(
                                                         datasets::Large3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -198,7 +200,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationDWCFixture<half>, framework::DatasetMode::PRECOMMIT,
                                         combine(
                                                         datasets::Small3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -221,7 +223,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEFuseBatchNormalizationDWCFixture<half>, frame
 FIXTURE_DATA_TEST_CASE(RunLarge, NEFuseBatchNormalizationDWCFixture<half>, framework::DatasetMode::NIGHTLY,
                                         combine(
                                                         datasets::Large3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,

--- a/tests/validation/NEON/Gather.cpp
+++ b/tests/validation/NEON/Gather.cpp
@@ -42,13 +42,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(Gather)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),
+        make("InputInfo", { TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),     // Invalid Indices data type
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),     // Invalid Indices dimensionality
@@ -57,7 +59,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),     // Invalid positive axis value
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F16),     // Invalid negative axis value
         }),
-        framework::dataset::make("IndicesInfo", {
+        make("IndicesInfo", {
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10U), 1, DataType::U8),
@@ -67,7 +69,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
         }),
-        framework::dataset::make("OutputInfo", {
+        make("OutputInfo", {
                                                 TensorInfo(TensorShape(27U, 10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10U, 27U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10U, 27U), 1, DataType::F32),
@@ -77,7 +79,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F16),
         }),
-        framework::dataset::make("Axis", {
+        make("Axis", {
                                             0,
                                             1,
                                             -2,
@@ -88,7 +90,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             2,
                                             -3,
         }),
-        framework::dataset::make("Expected", { true, true, false, false, false, false, false, false })
+        make("Expected", { true, true, false, false, false, false, false, false })
         ),
         input_info, indices_info, output_info, axis, expected)
 {
@@ -108,7 +110,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEGatherFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(gather_small_shapes, framework::dataset::make("DataType", DataType::F16)))
+                       combine(gather_small_shapes, make("DataType", DataType::F16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -117,7 +119,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEGatherFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -128,7 +130,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEGatherFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(gather_small_shapes, framework::dataset::make("DataType", DataType::F32)))
+                       combine(gather_small_shapes, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -137,7 +139,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEGatherFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -149,7 +151,7 @@ TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEGatherFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(gather_small_shapes, framework::dataset::make("DataType", DataType::U8)))
+                       combine(gather_small_shapes, make("DataType", DataType::U8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -158,7 +160,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEGatherFixture<uint8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::U8)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::U8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -169,7 +171,7 @@ TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEGatherFixture<uint16_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(gather_small_shapes, framework::dataset::make("DataType", DataType::U16)))
+                       combine(gather_small_shapes, make("DataType", DataType::U16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -178,7 +180,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEGatherFixture<uint16_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::U16)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::U16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/GenerateProposalsLayer.cpp
+++ b/tests/validation/NEON/GenerateProposalsLayer.cpp
@@ -42,6 +42,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 using NEComputeAllAnchors = NESynthetizeFunction<NEComputeAllAnchorsKernel>;
@@ -77,7 +79,7 @@ inline void fill_tensor(Accessor &&tensor, const std::vector<T> &v)
     }
 }
 
-const auto ComputeAllInfoDataset = framework::dataset::make("ComputeAllInfo",
+const auto ComputeAllInfoDataset = make("ComputeAllInfo",
 {
     ComputeAnchorsInfo(10U, 10U, 1. / 16.f),
     ComputeAnchorsInfo(100U, 1U, 1. / 2.f),
@@ -95,50 +97,50 @@ TEST_SUITE(GenerateProposals)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("scores", { TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F32),
+               make("scores", { TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F32),
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Mismatching types
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Wrong deltas (number of transformation non multiple of 4)
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Wrong anchors (number of values per roi != 5)
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Output tensor num_valid_proposals not scalar
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16)}),
                // num_valid_proposals not U32
-               framework::dataset::make("deltas",{ TensorInfo(TensorShape(100U, 100U, 36U), 1, DataType::F32),
+               make("deltas",{ TensorInfo(TensorShape(100U, 100U, 36U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 36U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32)}),
-               framework::dataset::make("anchors", { TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
+               make("anchors", { TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(5U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32)}),
-               framework::dataset::make("proposals", { TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
+               make("proposals", { TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32)}),
-               framework::dataset::make("scores_out", { TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
+               make("scores_out", { TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32)}),
-               framework::dataset::make("num_valid_proposals", { TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
+               make("num_valid_proposals", { TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 10U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::F16)}),
-               framework::dataset::make("generate_proposals_info", { GenerateProposalsInfo(10.f, 10.f, 1.f),
+               make("generate_proposals_info", { GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f)}),
-               framework::dataset::make("Expected", { true, false, false, false, false, false })
+               make("Expected", { true, false, false, false, false, false })
                ),
         scores, deltas, anchors, proposals, scores_out, num_valid_proposals, generate_proposals_info, expected)
 {
@@ -158,7 +160,7 @@ using NEComputeAllAnchorsFixture = ComputeAllAnchorsFixture<Tensor, Accessor, NE
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-DATA_TEST_CASE(IntegrationTestCaseAllAnchors, framework::DatasetMode::ALL, framework::dataset::make("DataType", { DataType::F32 }),
+DATA_TEST_CASE(IntegrationTestCaseAllAnchors, framework::DatasetMode::ALL, make("DataType", { DataType::F32 }),
                data_type)
 {
     const int values_per_roi = 4;
@@ -223,8 +225,8 @@ DATA_TEST_CASE(IntegrationTestCaseAllAnchors, framework::DatasetMode::ALL, frame
     validate(Accessor(all_anchors), anchors_expected);
 }
 
-DATA_TEST_CASE(IntegrationTestCaseGenerateProposals, framework::DatasetMode::ALL, combine(framework::dataset::make("DataType", { DataType::F32 }),
-                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })),
+DATA_TEST_CASE(IntegrationTestCaseGenerateProposals, framework::DatasetMode::ALL, combine(make("DataType", { DataType::F32 }),
+                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })),
                data_type, data_layout)
 {
     const int values_per_roi = 4;
@@ -381,7 +383,7 @@ DATA_TEST_CASE(IntegrationTestCaseGenerateProposals, framework::DatasetMode::ALL
 }
 
 FIXTURE_DATA_TEST_CASE(ComputeAllAnchors, NEComputeAllAnchorsFixture<float>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, framework::dataset::make("DataType", { DataType::F32 })))
+                       combine(make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, make("DataType", { DataType::F32 })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -390,7 +392,7 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(ComputeAllAnchors, NEComputeAllAnchorsFixture<half>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, framework::dataset::make("DataType", { DataType::F16 })))
+                       combine(make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, make("DataType", { DataType::F16 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -414,9 +416,9 @@ using NEComputeAllAnchorsQuantizedFixture = ComputeAllAnchorsQuantizedFixture<Te
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(ComputeAllAnchors, NEComputeAllAnchorsQuantizedFixture<int16_t>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset,
-                                       framework::dataset::make("DataType", { DataType::QSYMM16 }),
-                               framework::dataset::make("QuantInfo", { QuantizationInfo(0.125f, 0) })))
+                       combine(make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset,
+                                       make("DataType", { DataType::QSYMM16 }),
+                               make("QuantInfo", { QuantizationInfo(0.125f, 0) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qsymm16);

--- a/tests/validation/NEON/GlobalPoolingLayer.cpp
+++ b/tests/validation/NEON/GlobalPoolingLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Input data set for float data types */
@@ -58,9 +60,9 @@ using NEGlobalPoolingLayerFixture = GlobalPoolingLayerValidationFixture<Tensor, 
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunGlobalPooling, NEGlobalPoolingLayerFixture<float>, framework::DatasetMode::ALL, combine(GlobalPoolingLayerDataset, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunGlobalPooling, NEGlobalPoolingLayerFixture<float>, framework::DatasetMode::ALL, combine(GlobalPoolingLayerDataset, make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                                  framework::dataset::make("DataLayout", DataLayout::NCHW)))
+                                                                                                                  make("DataLayout", DataLayout::NCHW)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);

--- a/tests/validation/NEON/HeightConcatenateLayer.cpp
+++ b/tests/validation/NEON/HeightConcatenateLayer.cpp
@@ -39,32 +39,34 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(HeightConcatenateLayer)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo1", {  TensorInfo(TensorShape(23U, 15U, 5U), 1, DataType::F32), // Mismatching data type input/output
+        make("InputInfo1", {  TensorInfo(TensorShape(23U, 15U, 5U), 1, DataType::F32), // Mismatching data type input/output
                                                   TensorInfo(TensorShape(22U, 27U, 5U), 1, DataType::F32), // Mismatching y dimension
                                                   TensorInfo(TensorShape(11U, 25U, 5U), 1, DataType::F32), // Mismatching total height
                                                   TensorInfo(TensorShape(16U, 25U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(35U, 21U, 5U), 1, DataType::F32)
 
         }),
-        framework::dataset::make("InputInfo2", {  TensorInfo(TensorShape(23U, 15U, 4U), 1, DataType::F32),
+        make("InputInfo2", {  TensorInfo(TensorShape(23U, 15U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(22U, 127U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(11U, 26U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 25U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(35U, 10U, 5U), 1, DataType::F32)
         }),
-        framework::dataset::make("OutputInfo", {  TensorInfo(TensorShape(23U, 30U, 5U), 1, DataType::F16),
+        make("OutputInfo", {  TensorInfo(TensorShape(23U, 30U, 5U), 1, DataType::F16),
                                                   TensorInfo(TensorShape(22U, 12U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(11U, 7U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 50U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(35U, 31U, 5U), 1, DataType::F32)
         }),
-        framework::dataset::make("Expected", { false, false, false, true, true })
+        make("Expected", { false, false, false, true, true })
         ),
         input_info1, input_info2, output_info,expected)
 {
@@ -91,16 +93,16 @@ using NEHeightConcatenateLayerFixture = ConcatenateLayerValidationFixture<Tensor
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEHeightConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                    framework::dataset::make("DataType",
+                                                                                                                    make("DataType",
                                                                                                                             DataType::F32),
-                                                                                                                    framework::dataset::make("Axis", 1)))
+                                                                                                                    make("Axis", 1)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEHeightConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEHeightConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                                  framework::dataset::make("Axis", 1)))
+                                                                                                                  make("Axis", 1)))
 
 {
     // Validate output
@@ -112,9 +114,9 @@ TEST_SUITE_END() // Float
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEHeightConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                      framework::dataset::make("DataType",
+                                                                                                                      make("DataType",
                                                                                                                               DataType::QASYMM8),
-                                                                                                                      framework::dataset::make("Axis", 1)))
+                                                                                                                      make("Axis", 1)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -123,9 +125,9 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEHeightConcatenateLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("Axis", 1)))
+                                                                                                                     make("Axis", 1)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/InstanceNormalizationLayer.cpp
+++ b/tests/validation/NEON/InstanceNormalizationLayer.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Tolerance for float operations */
@@ -59,7 +61,7 @@ TEST_SUITE(InstanceNormalizationLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo",  { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32), // Mismatching data type input/output
+    make("InputInfo",  { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32), // Mismatching data type input/output
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32), // Mismatching shape input/output
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 2, DataType::F32), // Number of Input channels != 1
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::S16), // DataType != F32
@@ -70,7 +72,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F16),
+    make("OutputInfo", { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F16),
                                              TensorInfo(TensorShape(256U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::S16),
@@ -81,7 +83,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("Expected",   { false, false, false, false, true, true, true, true, true, true })
+    make("Expected",   { false, false, false, false, true, true, true, true, true, true })
     ),
     input_info, output_info, expected)
 {
@@ -99,9 +101,9 @@ using NEInstanceNormalizationLayerFixture = InstanceNormalizationLayerValidation
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEInstanceNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::Small4DShapes(),
-                                               framework::dataset::make("DataType", DataType::F32),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                               framework::dataset::make("InPlace", { false, true })))
+                                               make("DataType", DataType::F32),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                               make("InPlace", { false, true })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -113,9 +115,9 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEInstanceNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapes(),
-                                               framework::dataset::make("DataType", DataType::F16),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                               framework::dataset::make("InPlace", { false, true })))
+                                               make("DataType", DataType::F16),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                               make("InPlace", { false, true })))
 {
     if(CPUInfo::get().has_fp16())
     {

--- a/tests/validation/NEON/L2NormalizeLayer.cpp
+++ b/tests/validation/NEON/L2NormalizeLayer.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Tolerance for float operations */
@@ -55,7 +57,7 @@ TEST_SUITE(L2NormalizeLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo",  { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
+    make("InputInfo",  { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching shape input/output
                                              TensorInfo(TensorShape(128U, 64U), 2, DataType::F32), // Number of Input channels != 1
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::S16), // DataType != F32
@@ -64,7 +66,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(128U, 64U), 1, DataType::F16),
+    make("OutputInfo", { TensorInfo(TensorShape(128U, 64U), 1, DataType::F16),
                                              TensorInfo(TensorShape(256U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::S16),
@@ -73,7 +75,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("Axis",       {
+    make("Axis",       {
                                             0,
                                             0,
                                             0,
@@ -82,7 +84,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             3,
                                             -2,
                                             0 }),
-    framework::dataset::make("Expected",   { false, false, false, false, true, true, true, true })
+    make("Expected",   { false, false, false, false, true, true, true, true })
     ),
     input_info, output_info, axis, expected)
 {
@@ -99,18 +101,18 @@ using NEL2NormalizeLayerFixture = L2NormalizeLayerValidationFixture<Tensor, Acce
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEL2NormalizeLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("Axis", { -1, 0, 1, 2 }),
-                               framework::dataset::make("Epsilon", { 1e-6 })))
+                       combine(datasets::SmallShapes(), make("DataType", DataType::F32), make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("Axis", { -1, 0, 1, 2 }),
+                               make("Epsilon", { 1e-6 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEL2NormalizeLayerFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("Axis", { -1, 0, 2 }),
-                               framework::dataset::make("Epsilon", { 1e-6 })))
+                       combine(datasets::LargeShapes(), make("DataType", DataType::F32), make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("Axis", { -1, 0, 2 }),
+                               make("Epsilon", { 1e-6 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -120,9 +122,9 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEL2NormalizeLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("Axis", { -1, 0, 1, 2 }),
-                               framework::dataset::make("Epsilon", { 1e-6 })))
+                       combine(datasets::SmallShapes(), make("DataType", DataType::F16), make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("Axis", { -1, 0, 1, 2 }),
+                               make("Epsilon", { 1e-6 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -137,9 +139,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEL2NormalizeLayerFixture<half>, framework::Dat
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEL2NormalizeLayerFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("Axis", { -1, 0, 2 }),
-                               framework::dataset::make("Epsilon", { 1e-6 })))
+                       combine(datasets::LargeShapes(), make("DataType", DataType::F16), make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("Axis", { -1, 0, 2 }),
+                               make("Epsilon", { 1e-6 })))
 {
     if(CPUInfo::get().has_fp16())
     {

--- a/tests/validation/NEON/LogSoftmaxLayer.cpp
+++ b/tests/validation/NEON/LogSoftmaxLayer.cpp
@@ -54,7 +54,7 @@ constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);
 constexpr AbsoluteTolerance<int8_t> tolerance_qasymm8_signed(1);
 
 /** CNN data types */
-const auto CNNDataTypes = framework::dataset::make("DataType",
+const auto CNNDataTypes = make("DataType",
 {
 #ifdef ARM_COMPUTE_ENABLE_FP16
     DataType::F16,
@@ -73,9 +73,9 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NELogSoftmaxLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small4DShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::F16),
-                                                                                                                    framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                            framework::dataset::make("Axis", { 0, -1 })))
+                                                                                                                    make("DataType", DataType::F16),
+                                                                                                                    make("Beta", { 1.0f, 2.0f }),
+                                                                                                            make("Axis", { 0, -1 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -89,9 +89,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NELogSoftmaxLayerFixture<half>, framework::Data
     }
 }
 FIXTURE_DATA_TEST_CASE(RunSmall4D, NELogSoftmaxLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small4DShapes(),
-                                                                                                                      framework::dataset::make("DataType", DataType::F16),
-                                                                                                                      framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                              framework::dataset::make("Axis", { 0, -3, 2 })))
+                                                                                                                      make("DataType", DataType::F16),
+                                                                                                                      make("Beta", { 1.0f, 2.0f }),
+                                                                                                              make("Axis", { 0, -3, 2 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -105,9 +105,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall4D, NELogSoftmaxLayerFixture<half>, framework::Da
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NELogSoftmaxLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                  framework::dataset::make("DataType", DataType::F16),
-                                                                                                                  framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                          framework::dataset::make("Axis", { 0 })))
+                                                                                                                  make("DataType", DataType::F16),
+                                                                                                                  make("Beta", { 1.0f, 2.0f }),
+                                                                                                          make("Axis", { 0 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -125,25 +125,25 @@ TEST_SUITE_END() //FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall2D, NELogSoftmaxLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::F32),
-                                                                                                                       framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                               framework::dataset::make("Axis", { 0, 1 })))
+                                                                                                                       make("DataType", DataType::F32),
+                                                                                                                       make("Beta", { 1.0f, 2.0f }),
+                                                                                                               make("Axis", { 0, 1 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall4D, NELogSoftmaxLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small4DShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::F32),
-                                                                                                                       framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                               framework::dataset::make("Axis", { 0, 2, -1 })))
+                                                                                                                       make("DataType", DataType::F32),
+                                                                                                                       make("Beta", { 1.0f, 2.0f }),
+                                                                                                               make("Axis", { 0, 2, -1 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NELogSoftmaxLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                           framework::dataset::make("Axis", { 0 })))
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                                   make("Beta", { 1.0f, 2.0f }),
+                                                                                                           make("Axis", { 0 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -157,25 +157,25 @@ using NELogSoftmaxLayerQuantizedFixture = SoftmaxValidationQuantizedFixture<Tens
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall2D, NELogSoftmaxLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::QASYMM8),framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
-                                                                                                                            framework::dataset::make("Beta", { 1.0f, 2.f }),
-                                                                                                                    framework::dataset::make("Axis", { 0, 1 })))
+                                                                                                                    make("DataType", DataType::QASYMM8),make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
+                                                                                                                            make("Beta", { 1.0f, 2.f }),
+                                                                                                                    make("Axis", { 0, 1 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall4D, NELogSoftmaxLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::Small4DShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::QASYMM8),framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
-                                                                                                                            framework::dataset::make("Beta", { 1.0f, 2.f }),
-                                                                                                                    framework::dataset::make("Axis", { 0, -1, 1 })))
+                                                                                                                    make("DataType", DataType::QASYMM8),make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
+                                                                                                                            make("Beta", { 1.0f, 2.f }),
+                                                                                                                    make("Axis", { 0, -1, 1 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NELogSoftmaxLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                      framework::dataset::make("DataType", DataType::QASYMM8),framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
-                                                                                                                              framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                                      framework::dataset::make("Axis", { 0 })))
+                                                                                                                      make("DataType", DataType::QASYMM8),make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
+                                                                                                                              make("Beta", { 1.0f, 2.0f }),
+                                                                                                                      make("Axis", { 0 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/NEON/Logical.cpp
+++ b/tests/validation/NEON/Logical.cpp
@@ -37,6 +37,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 
 TEST_SUITE(LogicalAnd)
@@ -78,7 +80,7 @@ TEST_SUITE(LogicalNot)
 template <typename T>
 using NELogicalNotFixture = LogicalNotValidationFixture<Tensor, Accessor, NELogicalNot, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, NELogicalNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NELogicalNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/NEON/MaxUnpoolingLayer.cpp
+++ b/tests/validation/NEON/MaxUnpoolingLayer.cpp
@@ -41,20 +41,22 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(PoolingLayer)
 
 template <typename T>
 using NEMaxUnpoolingLayerFixture = MaxUnpoolingLayerValidationFixture<Tensor, Accessor, NEPoolingLayer, NEMaxUnpoolingLayer, T>;
 
-const auto PoolingLayerIndicesDatasetFPSmall = combine(framework::dataset::make("PoolType", { PoolingType::MAX }), framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                                       framework::dataset::make("PadStride", { PadStrideInfo(2, 2, 0, 0), PadStrideInfo(2, 1, 0, 0) }));
+const auto PoolingLayerIndicesDatasetFPSmall = combine(make("PoolType", { PoolingType::MAX }), make("PoolingSize", { Size2D(2, 2) }),
+                                                       make("PadStride", { PadStrideInfo(2, 2, 0, 0), PadStrideInfo(2, 1, 0, 0) }));
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(MaxUnpooling, NEMaxUnpoolingLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(), PoolingLayerIndicesDatasetFPSmall,
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
 
                                                                                                                   ))
 {
@@ -65,8 +67,8 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(MaxUnpooling, NEMaxUnpoolingLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(), PoolingLayerIndicesDatasetFPSmall,
-                                                                                                                  framework::dataset::make("DataType", DataType::F16),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
+                                                                                                                  make("DataType", DataType::F16),
+                                                                                                                  make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
 
                                                                                                                  ))
 {
@@ -89,8 +91,8 @@ TEST_SUITE_END() // Float
 TEST_SUITE(KernelSelection)
 
 DATA_TEST_CASE(KernelSelection, framework::DatasetMode::ALL,
-               combine(framework::dataset::make("CpuExt", std::string("NEON")),
-                       framework::dataset::make("DataType", { DataType::F32,
+               combine(make("CpuExt", std::string("NEON")),
+                       make("DataType", { DataType::F32,
                                                               DataType::F16,
                                                               DataType::QASYMM8,
                                                               DataType::QASYMM8_SIGNED

--- a/tests/validation/NEON/MeanStdDevNormalizationLayer.cpp
+++ b/tests/validation/NEON/MeanStdDevNormalizationLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Tolerance for float operations */
@@ -57,15 +59,15 @@ TEST_SUITE(MeanStdDevNormalizationLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::F32), // Mismatching data type input/output
+               make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::F32), // Mismatching data type input/output
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32), // Mismatching shapes
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { false, false, true })
+               make("Expected", { false, false, true })
                ),
                input_info, output_info, expected)
 {
@@ -81,9 +83,9 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEMeanStdDevNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small2DShapes(),
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("InPlace", { false, true }),
-                       framework::dataset::make("Epsilon", { 1e-3 })))
+                       make("DataType", DataType::F16),
+                       make("InPlace", { false, true }),
+                       make("Epsilon", { 1e-3 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -97,9 +99,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEMeanStdDevNormalizationLayerFixture<half>, fr
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEMeanStdDevNormalizationLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large2DMeanStdDevNormalizationShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::F16),
-                                                                                                                       framework::dataset::make("InPlace", { false, true }),
-                                                                                                                       framework::dataset::make("Epsilon", { 1e-8 })))
+                                                                                                                       make("DataType", DataType::F16),
+                                                                                                                       make("InPlace", { false, true }),
+                                                                                                                       make("Epsilon", { 1e-8 })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -117,17 +119,17 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEMeanStdDevNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small2DShapes(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("InPlace", { false, true }),
-                       framework::dataset::make("Epsilon", { 1e-7 })))
+                       make("DataType", DataType::F32),
+                       make("InPlace", { false, true }),
+                       make("Epsilon", { 1e-7 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEMeanStdDevNormalizationLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::Large2DMeanStdDevNormalizationShapes(),
-                                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                                        framework::dataset::make("InPlace", { false, true }),
-                                                                                                                        framework::dataset::make("Epsilon", { 1e-8 })))
+                                                                                                                        make("DataType", DataType::F32),
+                                                                                                                        make("InPlace", { false, true }),
+                                                                                                                        make("Epsilon", { 1e-8 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -139,9 +141,9 @@ TEST_SUITE_END() // Float
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEMeanStdDevNormalizationLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small2DShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("InPlace", { false, true }),
-                       framework::dataset::make("Epsilon", { 1e-7 })))
+                       make("DataType", DataType::QASYMM8),
+                       make("InPlace", { false, true }),
+                       make("Epsilon", { 1e-7 })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/NEON/NormalizationLayer.cpp
+++ b/tests/validation/NEON/NormalizationLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Tolerance for float operations */
@@ -50,12 +52,12 @@ constexpr AbsoluteTolerance<float> tolerance_f16(0.1f);
 constexpr AbsoluteTolerance<float> tolerance_f32(0.00001f);
 
 /** Input data set. */
-const auto NormalizationDataset = combine(datasets::SmallShapes(), datasets::NormalizationTypes(), framework::dataset::make("NormalizationSize", 3, 9, 2),
-                                                  framework::dataset::make("Beta", { 0.5f, 1.f, 2.f }),
-                                          framework::dataset::make("IsScaled", { true }));
-const auto NormalizationDatasetFP32 = combine(datasets::NormalizationTypes(), framework::dataset::make("NormalizationSize", 3, 9, 2),
-                                                      framework::dataset::make("Beta", { 0.5f, 1.f, 2.f }),
-                                              framework::dataset::make("IsScaled", { true, false }));
+const auto NormalizationDataset = combine(datasets::SmallShapes(), datasets::NormalizationTypes(), make("NormalizationSize", 3, 9, 2),
+                                                  make("Beta", { 0.5f, 1.f, 2.f }),
+                                          make("IsScaled", { true }));
+const auto NormalizationDatasetFP32 = combine(datasets::NormalizationTypes(), make("NormalizationSize", 3, 9, 2),
+                                                      make("Beta", { 0.5f, 1.f, 2.f }),
+                                              make("IsScaled", { true, false }));
 } // namespace
 
 TEST_SUITE(NEON)
@@ -64,25 +66,25 @@ TEST_SUITE(NormalizationLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Mismatching data type input/output
+    make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Mismatching data type input/output
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Mismatching shapes
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Even normalization
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Non implemented IN_MAP_2D
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+    make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                             TensorInfo(TensorShape(27U, 11U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                           }),
-    framework::dataset::make("NormInfo",  { NormalizationLayerInfo(NormType::IN_MAP_1D, 5),
+    make("NormInfo",  { NormalizationLayerInfo(NormType::IN_MAP_1D, 5),
                                             NormalizationLayerInfo(NormType::IN_MAP_1D, 5),
                                             NormalizationLayerInfo(NormType::IN_MAP_1D, 4),
                                             NormalizationLayerInfo(NormType::IN_MAP_2D, 5),
                                             NormalizationLayerInfo(NormType::CROSS_MAP, 1),
                                            }),
-    framework::dataset::make("Expected", { false, false, false, true, true })
+    make("Expected", { false, false, false, true, true })
     ),
     input_info, output_info, norm_info, expected)
 {
@@ -99,8 +101,8 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NENormalizationLayerFixture<half>, framework::DatasetMode::ALL, combine(NormalizationDataset,
-                                                                                                                 framework::dataset::make("DataType", DataType::F16),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataType", DataType::F16),
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -118,15 +120,15 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NENormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), NormalizationDatasetFP32,
-                                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                                framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                        make("DataType", DataType::F32),
+                                                                                                                make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NENormalizationLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), NormalizationDatasetFP32,
-                                                                                                                      framework::dataset::make("DataType", DataType::F32),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                      make("DataType", DataType::F32),
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);

--- a/tests/validation/NEON/PReluLayer.cpp
+++ b/tests/validation/NEON/PReluLayer.cpp
@@ -40,25 +40,27 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float>  tolerance_fp32(0.000001f);
 AbsoluteTolerance<int8_t> tolerance_s8(1);
 
 /** Input data sets **/
-const auto PReluLayerQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                              framework::dataset::make("DataType",
+const auto PReluLayerQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                              make("DataType",
                                                                        DataType::QASYMM8));
-const auto PReluLayerQASYMM8SignedDataset = combine(framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                    framework::dataset::make("DataType", DataType::QASYMM8_SIGNED));
-const auto PReluLayerFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                           framework::dataset::make("DataType", DataType::F32));
+const auto PReluLayerQASYMM8SignedDataset = combine(make("DataType", DataType::QASYMM8_SIGNED), make("DataType", DataType::QASYMM8_SIGNED),
+                                                    make("DataType", DataType::QASYMM8_SIGNED));
+const auto PReluLayerFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                           make("DataType", DataType::F32));
 
 #ifdef ARM_COMPUTE_ENABLE_FP16
 RelativeTolerance<float> tolerance_fp16(0.001f);
 
-const auto PReluLayerFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                           framework::dataset::make("DataType", DataType::F16));
+const auto PReluLayerFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                           make("DataType", DataType::F16));
 
 #endif // ARM_COMPUTE_ENABLE_FP16
 
@@ -70,25 +72,25 @@ TEST_SUITE(PReluLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),      // Window shrink
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, true, false, false, false})
+               make("Expected", { true, true, false, false, false})
                ),
                input1_info, input2_info, output_info, expected)
 {
@@ -110,9 +112,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPReluLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
                                                                                                                      PReluLayerQASYMM8Dataset,
-                                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                             framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
+                                                                                                                     make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                     make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                             make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
 
                       )
 {
@@ -122,9 +124,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPReluLayerQuantizedFixture<uint8_t>, framewor
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPReluLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                                                                                                                  PReluLayerQASYMM8Dataset,
-                                                                                                                 framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                 framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                 framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
+                                                                                                                 make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                 make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                 make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
 
                       )
 {
@@ -134,9 +136,9 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEPReluLayerQuantizedFixture<uint8_t>, framewor
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEPReluLayerQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapesBroadcast(),
                                                                                                                                PReluLayerQASYMM8Dataset,
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
                       )
 {
     // Validate output
@@ -145,9 +147,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEPReluLayerQuantizedBroadcastFixture<
 
 FIXTURE_DATA_TEST_CASE(RunLargeBroadcast, NEPReluLayerQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapesBroadcast(),
                                                                                                                                PReluLayerQASYMM8Dataset,
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
                       )
 {
     // Validate output
@@ -158,9 +160,9 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPReluLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
                                                                                                                     PReluLayerQASYMM8SignedDataset,
-                                                                                                                    framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.2f, 127) }),
-                                                                                                                    framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 64) }),
-                                                                                                            framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -128) }))
+                                                                                                                    make("QuantizationInfo", { QuantizationInfo(0.2f, 127) }),
+                                                                                                                    make("QuantizationInfo", { QuantizationInfo(0.1f, 64) }),
+                                                                                                            make("QuantizationInfo", { QuantizationInfo(0.5f, -128) }))
 
                       )
 {
@@ -170,9 +172,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPReluLayerQuantizedFixture<int8_t>, framework
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPReluLayerQuantizedFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
                                                                                                                         PReluLayerQASYMM8SignedDataset,
-                                                                                                                        framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 20) }),
-                                                                                                                        framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) }),
-                                                                                                                framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 5) }))
+                                                                                                                        make("QuantizationInfo", { QuantizationInfo(0.5f, 20) }),
+                                                                                                                        make("QuantizationInfo", { QuantizationInfo(0.5f, 10) }),
+                                                                                                                make("QuantizationInfo", { QuantizationInfo(0.5f, 5) }))
 
                       )
 {
@@ -182,9 +184,9 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEPReluLayerQuantizedFixture<int8_t>, framework
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEPReluLayerQuantizedBroadcastFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapesBroadcast(),
                                                                                                                                PReluLayerQASYMM8SignedDataset,
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.2f, 127) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 64) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -128) }))
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(0.2f, 127) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(0.1f, 64) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(0.5f, -128) }))
                       )
 {
     // Validate output
@@ -193,9 +195,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, NEPReluLayerQuantizedBroadcastFixture<
 
 FIXTURE_DATA_TEST_CASE(RunLargeBroadcast, NEPReluLayerQuantizedBroadcastFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapesBroadcast(),
                                                                                                                                PReluLayerQASYMM8SignedDataset,
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.2f, 127) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 64) }),
-                                                                                                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -128) }))
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(0.2f, 127) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(0.1f, 64) }),
+                                                                                                                               make("QuantizationInfo", { QuantizationInfo(0.5f, -128) }))
                       )
 {
     // Validate output

--- a/tests/validation/NEON/PadLayer.cpp
+++ b/tests/validation/NEON/PadLayer.cpp
@@ -40,9 +40,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-const auto PaddingSizesDataset = framework::dataset::make("PaddingSize",
+const auto PaddingSizesDataset = make("PaddingSize",
 {
     PaddingList{ { 0, 0 } },
     PaddingList{ { 1, 1 } },
@@ -60,7 +62,7 @@ TEST_SUITE(PadLayer)
 // clang-format off
 
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data type input/output
+               make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data type input/output
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
@@ -73,7 +75,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32)
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(28U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(29U, 17U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(29U, 15U, 4U, 3U), 1, DataType::F32),
@@ -86,7 +88,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(27U, 14U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 3U), 1, DataType::F32)
                                                      }),
-               framework::dataset::make("PaddingSize", { PaddingList{{0, 0}},
+               make("PaddingSize", { PaddingList{{0, 0}},
                                                          PaddingList{{1, 1}},
                                                          PaddingList{{1, 1}, {2, 2}},
                                                          PaddingList{{1,1}, {1,1}, {1,1}, {1,1}},
@@ -99,7 +101,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                          PaddingList{{0,0}, {1,0}, {0,1}, {1,2}},
                                                          PaddingList{{0,0}, {0,0}, {0,0}, {1,1}}
                                                          }),
-               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT,
+               make("PaddingMode", { PaddingMode::CONSTANT,
                                                          PaddingMode::CONSTANT,
                                                          PaddingMode::CONSTANT,
                                                          PaddingMode::CONSTANT,
@@ -111,7 +113,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                          PaddingMode::REFLECT,
                                                          PaddingMode::REFLECT,
                                                          PaddingMode::SYMMETRIC }),
-               framework::dataset::make("Expected", { false, false, true, true, true, true, false, false, true, false, false, true })
+               make("Expected", { false, false, true, true, true, true, false, false, true, false, false, true })
                ),
                input_info, output_info, padding, mode, expected)
 {
@@ -128,17 +130,17 @@ TEST_SUITE(Float)
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPaddingFixture<float>, framework::DatasetMode::ALL,
-                       combine(datasets::Small3DShapes(), framework::dataset::make("DataType", { DataType::F32 }),
+                       combine(datasets::Small3DShapes(), make("DataType", { DataType::F32 }),
                                        PaddingSizesDataset,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPaddingFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large3DShapes(), framework::dataset::make("DataType", { DataType::F32 }),
+                       combine(datasets::Large3DShapes(), make("DataType", { DataType::F32 }),
                                        PaddingSizesDataset,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -148,9 +150,9 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPaddingFixture<half>, framework::DatasetMode::ALL,
-                       combine(datasets::Small3DShapes(), framework::dataset::make("DataType", { DataType::F16 }),
+                       combine(datasets::Small3DShapes(), make("DataType", { DataType::F16 }),
                                        PaddingSizesDataset,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -164,9 +166,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPaddingFixture<half>, framework::DatasetMode:
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPaddingFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large3DShapes(), framework::dataset::make("DataType", { DataType::F16 }),
+                       combine(datasets::Large3DShapes(), make("DataType", { DataType::F16 }),
                                        PaddingSizesDataset,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -186,17 +188,17 @@ TEST_SUITE_END() // Float
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPaddingFixture<uint8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::Small3DShapes(), framework::dataset::make("DataType", { DataType::QASYMM8 }),
+                       combine(datasets::Small3DShapes(), make("DataType", { DataType::QASYMM8 }),
                                        PaddingSizesDataset,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPaddingFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large3DShapes(), framework::dataset::make("DataType", { DataType::QASYMM8 }),
+                       combine(datasets::Large3DShapes(), make("DataType", { DataType::QASYMM8 }),
                                        PaddingSizesDataset,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/Permute.cpp
+++ b/tests/validation/NEON/Permute.cpp
@@ -41,14 +41,16 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-const auto PermuteVectors2 = framework::dataset::make("PermutationVector",
+const auto PermuteVectors2 = make("PermutationVector",
 {
     PermutationVector(0U, 1U),
     PermutationVector(1U, 0U),
 });
-const auto PermuteVectors3 = framework::dataset::make("PermutationVector",
+const auto PermuteVectors3 = make("PermutationVector",
 {
     PermutationVector(2U, 0U, 1U),
     PermutationVector(1U, 2U, 0U),
@@ -57,7 +59,7 @@ const auto PermuteVectors3 = framework::dataset::make("PermutationVector",
     PermutationVector(1U, 0U, 2U),
     PermutationVector(2U, 1U, 0U),
 });
-const auto PermuteVectors4 = framework::dataset::make("PermutationVector",
+const auto PermuteVectors4 = make("PermutationVector",
 {
     PermutationVector(3U, 2U, 0U, 1U),
     PermutationVector(3U, 2U, 1U, 0U),
@@ -67,8 +69,8 @@ const auto PermuteVectors4 = framework::dataset::make("PermutationVector",
     PermutationVector(3U, 0U, 2U, 1U),
     PermutationVector(0U, 3U, 2U, 1U)
 });
-const auto PermuteVectors         = concat(concat(PermuteVectors2, PermuteVectors3), PermuteVectors4);
-const auto PermuteParametersSmall = concat(concat(datasets::Small2DShapes(), datasets::Small3DShapes()), datasets::Small4DShapes()) * PermuteVectors;
+const auto PermuteVectors         = concat(PermuteVectors2, PermuteVectors3, PermuteVectors4);
+const auto PermuteParametersSmall = concat(datasets::Small2DShapes(), datasets::Small3DShapes(), datasets::Small4DShapes()) * PermuteVectors;
 const auto PermuteParametersLarge = datasets::Large4DShapes() * PermuteVectors;
 } // namespace
 TEST_SUITE(NEON)
@@ -77,7 +79,7 @@ TEST_SUITE(Permute)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-                                                framework::dataset::make("InputInfo",{
+                                                make("InputInfo",{
                                                                                         TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),     // permutation not supported
                                                                                         TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),     // permutation not supported
                                                                                         TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),     // permutation not supported
@@ -95,7 +97,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                                                         TensorInfo(TensorShape(1024U, 1024U, 1024U, 1U), 1, DataType::F16) // big tensor
 
                                                                                     }),
-                                                framework::dataset::make("OutputInfo", {
+                                                make("OutputInfo", {
                                                                                         TensorInfo(TensorShape(5U, 7U, 7U, 3U), 1, DataType::U16),
                                                                                         TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),
                                                                                         TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),
@@ -112,7 +114,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                                                         TensorInfo(TensorShape(1024U, 1024U, 1023U, 1U), 1, DataType::F16),
                                                                                         TensorInfo(TensorShape(1024U, 1024U, 1024U, 1U), 1, DataType::F16)
                                                                                     }),
-                                                framework::dataset::make("PermutationVector", {
+                                                make("PermutationVector", {
                                                                                                 PermutationVector(2U, 1U, 0U),
                                                                                                 PermutationVector(2U, 2U, 1U),
                                                                                                 PermutationVector(1U, 1U, 1U),
@@ -129,7 +131,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                                                                 PermutationVector(1U, 0U),
                                                                                                 PermutationVector(1U, 0U)
                                                                                     }),
-                                                framework::dataset::make("Expected", { true, false, false, false, true, true, false,true, false, true, false, true, false, true, false })),
+                                                make("Expected", { true, false, false, false, true, true, false,true, false, true, false, true, false, true, false })),
                                             input_info, output_info, perm_vect, expected)
 {
     ARM_COMPUTE_EXPECT(bool(NEPermute::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), perm_vect)) == expected, framework::LogLevel::ERRORS);
@@ -142,14 +144,14 @@ using NEPermuteFixture = PermuteValidationFixture<Tensor, Accessor, NEPermute, T
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPermuteFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U8))
+                       PermuteParametersSmall * make("DataType", DataType::U8))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPermuteFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U8))
+                       PermuteParametersLarge * make("DataType", DataType::U8))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -158,13 +160,13 @@ TEST_SUITE_END()
 
 TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPermuteFixture<uint16_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U16))
+                       PermuteParametersSmall * make("DataType", DataType::U16))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPermuteFixture<uint16_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U16))
+                       PermuteParametersLarge * make("DataType", DataType::U16))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -173,13 +175,13 @@ TEST_SUITE_END()
 
 TEST_SUITE(U32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPermuteFixture<uint32_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U32))
+                       PermuteParametersSmall * make("DataType", DataType::U32))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPermuteFixture<uint32_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U32))
+                       PermuteParametersLarge * make("DataType", DataType::U32))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -189,7 +191,7 @@ TEST_SUITE_END()
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(F16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPermuteFixture<float16_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::F16))
+                       PermuteParametersSmall * make("DataType", DataType::F16))
 {
     if (cpu_supports_dtypes({DataType::F16}))
     {
@@ -203,7 +205,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPermuteFixture<float16_t>, framework::Dataset
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPermuteFixture<float16_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::F16))
+                       PermuteParametersLarge * make("DataType", DataType::F16))
 {
     if (cpu_supports_dtypes({DataType::F16}))
     {

--- a/tests/validation/NEON/PixelWiseMultiplication.cpp
+++ b/tests/validation/NEON/PixelWiseMultiplication.cpp
@@ -55,27 +55,27 @@ constexpr AbsoluteTolerance<float> tolerance_qasymm8(1); /**< Tolerance value fo
 constexpr AbsoluteTolerance<float> tolerance_qsymm16(1); /**< Tolerance value for comparing reference's output against implementation's output for 16-bit quantized symmetric data types */
 
 const auto PixelWiseMultiplicationQSYMM16QuantDataset = combine(
-                                                                    framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
-                                                                    framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
-                                                                framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }));
+                                                                    make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
+                                                                    make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
+                                                                make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }));
 
 const auto PixelWiseMultiplicationQASYMM8QuantDataset = combine(
-                                                                    framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
-                                                                    framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
-                                                                framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 32768.f, 0) }));
+                                                                    make("Src0QInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                    make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
+                                                                make("OutQInfo", { QuantizationInfo(1.f / 32768.f, 0) }));
 
 const auto PixelWiseMultiplicationQASYMM8QuantInPlaceDataset = combine(
-                                                                           framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 32768.f, 10) }),
-                                                                           framework::dataset::make("Src1QInfo", { QuantizationInfo(5.f / 32768.f, 10) }),
-                                                                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 10) }));
+                                                                           make("Src0QInfo", { QuantizationInfo(5.f / 32768.f, 10) }),
+                                                                           make("Src1QInfo", { QuantizationInfo(5.f / 32768.f, 10) }),
+                                                                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 10) }));
 
 const auto PixelWiseMultiplicationPolicySTNUDataset = combine(
-                                                          framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                          framework::dataset::make("RoundingPolicy", { RoundingPolicy::TO_NEAREST_UP }));
+                                                          make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                          make("RoundingPolicy", { RoundingPolicy::TO_NEAREST_UP }));
 
 const auto PixelWiseMultiplicationPolicySTZDataset = combine(
-                                                         framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                         framework::dataset::make("RoundingPolicy", { RoundingPolicy::TO_ZERO }));
+                                                         make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                         make("RoundingPolicy", { RoundingPolicy::TO_ZERO }));
 
 /** Tests for in-place computation
  * With current interface storing TensorInfo with quantization information
@@ -88,8 +88,8 @@ const auto PixelWiseMultiplicationPolicySTZDataset = combine(
  * expected to have either different quantization information, data type
  * or different shape we are not testing in-place computation.
  */
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 
 #define DEFAULT_VALIDATE validate(Accessor(_target), _reference);
 #define VALIDATE(TYPE, TOLERANCE) validate(Accessor(_target), _reference, AbsoluteTolerance<TYPE>(TOLERANCE), 0.f);
@@ -100,12 +100,12 @@ const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
     FIXTURE_DATA_TEST_CASE(TEST_NAME, NEPixelWiseMultiplication##FIXTURE, framework::DatasetMode::MODE,                        \
                            combine(                                            \
                            datasets::SHAPES,                                                                              \
-                           framework::dataset::make("DataType1", DataType::DT1),                                         \
-                           framework::dataset::make("DataType2", DataType::DT2),                                         \
-                           framework::dataset::make("DataType3", DataType::DT3),                                         \
-                           framework::dataset::make("Scale", std::move(SCALE)),                                          \
+                           make("DataType1", DataType::DT1),                                         \
+                           make("DataType2", DataType::DT2),                                         \
+                           make("DataType3", DataType::DT3),                                         \
+                           make("Scale", std::move(SCALE)),                                          \
                            datasets::ConvertPolicies(),                                                                  \
-                           framework::dataset::make("RoundingPolicy", RoundingPolicy::RP),                               \
+                           make("RoundingPolicy", RoundingPolicy::RP),                               \
                            (INPLACE_DATASET)))                                                                            \
     {                                                                                                                     \
         if((DataType::DT1 != DataType::F16 &&                                                                             \
@@ -189,7 +189,7 @@ TEST_SUITE(PixelWiseMultiplication)
 
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),                 //1 Ok
+               make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),                 //1 Ok
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),                 //2 Ok
                                                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),                 //3 Window shrink
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),                 //4 Invalid scale
@@ -204,7 +204,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8_SIGNED),     //13 Quantized cannot do WRAP
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),                //14 S32 does not support scale255
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
@@ -219,7 +219,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8_SIGNED),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
@@ -234,7 +234,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8_SIGNED),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("Scale",{  scale_unity,
+               make("Scale",{  scale_unity,
                                                    scale_unity,
                                                    scale_unity,
                                                    -1.f,
@@ -248,7 +248,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                    scale_unity,
                                                    scale_unity,
                                                    scale_255}),
-               framework::dataset::make("OverflowPolicy",{
+               make("OverflowPolicy",{
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
@@ -264,7 +264,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::SATURATE,
                                         }),
-               framework::dataset::make("Expected", { true, true, true, false, false, false, false, false, true , false, false, true, false, false})
+               make("Expected", { true, true, true, false, false, false, false, false, true , false, false, true, false, false})
                ),
                input1_info, input2_info, output_info, scale, policy, expected)
 {
@@ -340,10 +340,10 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8_SIGNED)
 TEST_SUITE(ScaleUnity)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQASYMM8SignedFixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                     framework::dataset::make("DataTypeIn1", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("DataTypeIn2", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("DataTypeOut", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("Scale", { scale_unity }),
+                                                                                                                     make("DataTypeIn1", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("DataTypeIn2", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("DataTypeOut", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("Scale", { scale_unity }),
                                                                                                                      PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                      PixelWiseMultiplicationQASYMM8QuantDataset,
                                                                                                                      OutOfPlaceDataSet))
@@ -353,10 +353,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQASYMM8SignedFixture, 
 }
 #ifdef ARM_COMPUTE_ENABLE_SME2
 FIXTURE_DATA_TEST_CASE(RunSMEMul, NEPixelWiseMultiplicationQASYMM8SignedFixture, framework::DatasetMode::ALL, combine(datasets::SMEMulShapes(),
-                                                                                                                     framework::dataset::make("DataTypeIn1", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("DataTypeIn2", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("DataTypeOut", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("Scale", { scale_unity }),
+                                                                                                                     make("DataTypeIn1", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("DataTypeIn2", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("DataTypeOut", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("Scale", { scale_unity }),
                                                                                                                      PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                      PixelWiseMultiplicationQASYMM8QuantDataset,
                                                                                                                      OutOfPlaceDataSet))
@@ -366,10 +366,10 @@ FIXTURE_DATA_TEST_CASE(RunSMEMul, NEPixelWiseMultiplicationQASYMM8SignedFixture,
 }
 #endif // ARM_COMPUTE_ENABLE_SME2
 FIXTURE_DATA_TEST_CASE(RunSmallInPlace, NEPixelWiseMultiplicationQASYMM8SignedFixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataTypeIn2", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataTypeOut", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("Scale", { scale_unity }),
+                       make("DataTypeIn1", DataType::QASYMM8_SIGNED),
+                       make("DataTypeIn2", DataType::QASYMM8_SIGNED),
+                       make("DataTypeOut", DataType::QASYMM8_SIGNED),
+                       make("Scale", { scale_unity }),
                        PixelWiseMultiplicationPolicySTZDataset,
                        PixelWiseMultiplicationQASYMM8QuantInPlaceDataset,
                        InPlaceDataSet))
@@ -380,10 +380,10 @@ FIXTURE_DATA_TEST_CASE(RunSmallInPlace, NEPixelWiseMultiplicationQASYMM8SignedFi
 TEST_SUITE(Broadcast)
 #ifdef ARM_COMPUTE_ENABLE_SME2
 FIXTURE_DATA_TEST_CASE(RunSMEMul, NEPixelWiseMultiplicationBroadcastQASYMM8SignedFixture, framework::DatasetMode::ALL, combine(datasets::SMEMulShapesBroadcast(),
-                                                                                                                     framework::dataset::make("DataTypeIn1", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("DataTypeIn2", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("DataTypeOut", DataType::QASYMM8_SIGNED),
-                                                                                                                     framework::dataset::make("Scale", { scale_unity }),
+                                                                                                                     make("DataTypeIn1", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("DataTypeIn2", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("DataTypeOut", DataType::QASYMM8_SIGNED),
+                                                                                                                     make("Scale", { scale_unity }),
                                                                                                                      PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                      PixelWiseMultiplicationQASYMM8QuantDataset,
                                                                                                                      OutOfPlaceDataSet))
@@ -399,10 +399,10 @@ TEST_SUITE_END() // QASYMM8_SIGNED
 TEST_SUITE(QASYMM8)
 TEST_SUITE(Scale255)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQASYMM8Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("Scale", { scale_255 }),
+                                                                                                                       make("DataTypeIn1", DataType::QASYMM8),
+                                                                                                                       make("DataTypeIn2", DataType::QASYMM8),
+                                                                                                                       make("DataTypeOut", DataType::QASYMM8),
+                                                                                                                       make("Scale", { scale_255 }),
                                                                                                                        PixelWiseMultiplicationPolicySTNUDataset,
                                                                                                                        PixelWiseMultiplicationQASYMM8QuantDataset,
                                                                                                                OutOfPlaceDataSet))
@@ -413,10 +413,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQASYMM8Fixture, framew
 TEST_SUITE_END() // Scale255
 TEST_SUITE(ScaleUnity)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQASYMM8Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("Scale", { scale_unity }),
+                                                                                                                       make("DataTypeIn1", DataType::QASYMM8),
+                                                                                                                       make("DataTypeIn2", DataType::QASYMM8),
+                                                                                                                       make("DataTypeOut", DataType::QASYMM8),
+                                                                                                                       make("Scale", { scale_unity }),
                                                                                                                        PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                        PixelWiseMultiplicationQASYMM8QuantDataset,
                                                                                                                OutOfPlaceDataSet))
@@ -427,10 +427,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQASYMM8Fixture, framew
 TEST_SUITE_END() // ScaleUnity
 TEST_SUITE(ScaleOther)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQASYMM8Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("Scale", { scale_other }),
+                                                                                                                       make("DataTypeIn1", DataType::QASYMM8),
+                                                                                                                       make("DataTypeIn2", DataType::QASYMM8),
+                                                                                                                       make("DataTypeOut", DataType::QASYMM8),
+                                                                                                                       make("Scale", { scale_other }),
                                                                                                                        PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                        PixelWiseMultiplicationQASYMM8QuantDataset,
                                                                                                                OutOfPlaceDataSet))
@@ -442,10 +442,10 @@ TEST_SUITE_END() // ScaleOther
 TEST_SUITE(Broadcast)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationBroadcastQASYMM8Fixture, framework::DatasetMode::ALL,
                        combine(datasets::SmallShapesBroadcast(),
-                                                                               framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                       framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                               framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                       framework::dataset::make("Scale", { scale_other }),
+                                                                               make("DataTypeIn1", DataType::QASYMM8),
+                                                                       make("DataTypeIn2", DataType::QASYMM8),
+                                                               make("DataTypeOut", DataType::QASYMM8),
+                                                       make("Scale", { scale_other }),
                                                PixelWiseMultiplicationPolicySTZDataset,
                                        PixelWiseMultiplicationQASYMM8QuantDataset,
                                OutOfPlaceDataSet))
@@ -455,10 +455,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationBroadcastQASYMM8Fixtur
 }
 FIXTURE_DATA_TEST_CASE(RunTinyInPlace, NEPixelWiseMultiplicationBroadcastQASYMM8Fixture, framework::DatasetMode::ALL,
                        combine(datasets::TinyShapesBroadcastInplace(),
-                                                                               framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                       framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                               framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                       framework::dataset::make("Scale", { scale_other }),
+                                                                               make("DataTypeIn1", DataType::QASYMM8),
+                                                                       make("DataTypeIn2", DataType::QASYMM8),
+                                                               make("DataTypeOut", DataType::QASYMM8),
+                                                       make("Scale", { scale_other }),
                                                PixelWiseMultiplicationPolicySTZDataset,
                                        PixelWiseMultiplicationQASYMM8QuantInPlaceDataset,
                                InPlaceDataSet))
@@ -471,10 +471,10 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QSYMM16)
 TEST_SUITE(Scale255)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQSYMM16Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("DataTypeIn2", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("DataTypeOut", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("Scale", { scale_255 }),
+                                                                                                                       make("DataTypeIn1", DataType::QSYMM16),
+                                                                                                                       make("DataTypeIn2", DataType::QSYMM16),
+                                                                                                                       make("DataTypeOut", DataType::QSYMM16),
+                                                                                                                       make("Scale", { scale_255 }),
                                                                                                                        PixelWiseMultiplicationPolicySTNUDataset,
                                                                                                                        PixelWiseMultiplicationQSYMM16QuantDataset,
                                                                                                                OutOfPlaceDataSet))
@@ -485,10 +485,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQSYMM16Fixture, framew
 TEST_SUITE_END() // Scale255
 TEST_SUITE(ScaleUnity)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQSYMM16Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("DataTypeIn2", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("DataTypeOut", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("Scale", { scale_unity }),
+                                                                                                                       make("DataTypeIn1", DataType::QSYMM16),
+                                                                                                                       make("DataTypeIn2", DataType::QSYMM16),
+                                                                                                                       make("DataTypeOut", DataType::QSYMM16),
+                                                                                                                       make("Scale", { scale_unity }),
                                                                                                                        PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                        PixelWiseMultiplicationQSYMM16QuantDataset,
                                                                                                                OutOfPlaceDataSet))
@@ -499,10 +499,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQSYMM16Fixture, framew
 TEST_SUITE_END() // ScaleUnity
 TEST_SUITE(ScaleOther)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQSYMM16Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("DataTypeIn2", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("DataTypeOut", DataType::QSYMM16),
-                                                                                                                       framework::dataset::make("Scale", { scale_other }),
+                                                                                                                       make("DataTypeIn1", DataType::QSYMM16),
+                                                                                                                       make("DataTypeIn2", DataType::QSYMM16),
+                                                                                                                       make("DataTypeOut", DataType::QSYMM16),
+                                                                                                                       make("Scale", { scale_other }),
                                                                                                                        PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                        PixelWiseMultiplicationQSYMM16QuantDataset,
                                                                                                                OutOfPlaceDataSet))
@@ -531,10 +531,10 @@ TEST_SUITE_END() // NonXBroadcast
 TEST_SUITE_END() // QSYMM16
 TEST_SUITE(QSYMM16toS32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationQSYMM16ToS32Fixture, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
-                                                                                                                    framework::dataset::make("DataTypeIn1", DataType::QSYMM16),
-                                                                                                                    framework::dataset::make("DataTypeIn2", DataType::QSYMM16),
-                                                                                                                    framework::dataset::make("DataTypeOut", DataType::S32),
-                                                                                                                    framework::dataset::make("Scale", { scale_unity }),
+                                                                                                                    make("DataTypeIn1", DataType::QSYMM16),
+                                                                                                                    make("DataTypeIn2", DataType::QSYMM16),
+                                                                                                                    make("DataTypeOut", DataType::S32),
+                                                                                                                    make("Scale", { scale_unity }),
                                                                                                                     PixelWiseMultiplicationPolicySTZDataset,
                                                                                                                     PixelWiseMultiplicationQSYMM16QuantDataset,
                                                                                                                     OutOfPlaceDataSet))
@@ -563,12 +563,12 @@ TEST_SUITE_END() // Quantized
 TEST_SUITE(U8U8toS16)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationU8U8ToS16Fixture, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                       framework::dataset::make("DataTypeIn1", DataType::U8),
-                                                                                                                       framework::dataset::make("DataTypeIn2", DataType::U8),
-                                                                                                                       framework::dataset::make("DataTypeOut", DataType::S16),
-                                                                                                                       framework::dataset::make("Scale", { scale_255 }),
+                                                                                                                       make("DataTypeIn1", DataType::U8),
+                                                                                                                       make("DataTypeIn2", DataType::U8),
+                                                                                                                       make("DataTypeOut", DataType::S16),
+                                                                                                                       make("Scale", { scale_255 }),
                                                                                                                        datasets::ConvertPolicies(),
-                                                                                                                       framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
+                                                                                                                       make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
                                                                                                                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -578,12 +578,12 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationU8U8ToS16Fixture, fram
 TEST_SUITE(NonXBroadcast)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationBroadcastU8U8ToS16Fixture, framework::DatasetMode::PRECOMMIT,
     combine(datasets::SmallShapesNonXBroadcast(),
-        framework::dataset::make("DataTypeIn1", DataType::U8),
-        framework::dataset::make("DataTypeIn2", DataType::U8),
-        framework::dataset::make("DataTypeOut", DataType::S16),
-        framework::dataset::make("Scale", { scale_255 }),
+        make("DataTypeIn1", DataType::U8),
+        make("DataTypeIn2", DataType::U8),
+        make("DataTypeOut", DataType::S16),
+        make("Scale", { scale_255 }),
         datasets::ConvertPolicies(),
-        framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
+        make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
         OutOfPlaceDataSet))
 {
     // Validate output
@@ -592,13 +592,13 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPixelWiseMultiplicationBroadcastU8U8ToS16Fixt
 TEST_SUITE_END() // NonXBroadcast
 
 FIXTURE_DATA_TEST_CASE(RunSmall1, NEPixelWiseMultiplicationU8U8ToS16Fixture, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                        framework::dataset::make("DataTypeIn1", DataType::U8),
-                                                                                                                        framework::dataset::make("DataTypeIn2", DataType::U8),
-                                                                                                                        framework::dataset::make("DataTypeOut", DataType::S16),
-                                                                                                                        framework::dataset::make("Scale", { scale_other }),
+                                                                                                                        make("DataTypeIn1", DataType::U8),
+                                                                                                                        make("DataTypeIn2", DataType::U8),
+                                                                                                                        make("DataTypeOut", DataType::S16),
+                                                                                                                        make("Scale", { scale_other }),
                                                                                                                         datasets::ConvertPolicies(),
-                                                                                                                        framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_ZERO),
-                                                                                                                        framework::dataset::make("InPlace", { false })))
+                                                                                                                        make("RoundingPolicy", RoundingPolicy::TO_ZERO),
+                                                                                                                        make("InPlace", { false })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -680,7 +680,7 @@ PIXEL_WISE_MULTIPLICATION_FIXTURE_DATA_TEST_CASE(RunSmall, ToS32Fixture<int32_t>
 TEST_SUITE_END() // ScaleOther
 
 TEST_SUITE(Broadcast)
-PIXEL_WISE_MULTIPLICATION_FIXTURE_DATA_TEST_CASE(RunSmall, BroadcastFixture<int32_t>, ALL, SmallShapesBroadcast(), S32, S32, S32, scale_unity, TO_ZERO, framework::dataset::make("InPlace", { false }),
+PIXEL_WISE_MULTIPLICATION_FIXTURE_DATA_TEST_CASE(RunSmall, BroadcastFixture<int32_t>, ALL, SmallShapesBroadcast(), S32, S32, S32, scale_unity, TO_ZERO, make("InPlace", { false }),
                                                  WRAP_VALIDATE(int32_t, 1))
 TEST_SUITE_END() // Broadcast
 
@@ -713,7 +713,7 @@ TEST_SUITE_END() // ScaleOther
 TEST_SUITE_END() // F32toF32
 
 TEST_SUITE(Broadcast)
-PIXEL_WISE_MULTIPLICATION_FIXTURE_DATA_TEST_CASE(RunSmall, BroadcastFixture<float>, ALL, SmallShapesBroadcast(), F32, F32, F32, scale_255, TO_NEAREST_UP, framework::dataset::make("InPlace", { false }),
+PIXEL_WISE_MULTIPLICATION_FIXTURE_DATA_TEST_CASE(RunSmall, BroadcastFixture<float>, ALL, SmallShapesBroadcast(), F32, F32, F32, scale_255, TO_NEAREST_UP, make("InPlace", { false }),
                                                  VALIDATE(float, 1.f))
 TEST_SUITE_END() // Broadcast
 

--- a/tests/validation/NEON/Pooling3dLayer.cpp
+++ b/tests/validation/NEON/Pooling3dLayer.cpp
@@ -42,30 +42,32 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Input data sets for floating-point data types */
-const auto Pooling3dLayerDatasetFP = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size3D(2, 3, 2) }),
-                                                             framework::dataset::make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(2, 2, 1) }),
-                                                     framework::dataset::make("Padding", { Padding3D(0, 1, 0), Padding3D(1, 1, 1) }),
-                                             framework::dataset::make("ExcludePadding", { true, false }));
+const auto Pooling3dLayerDatasetFP = combine(datasets::PoolingTypes(), make("PoolingSize", { Size3D(2, 3, 2) }),
+                                                             make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(2, 2, 1) }),
+                                                     make("Padding", { Padding3D(0, 1, 0), Padding3D(1, 1, 1) }),
+                                             make("ExcludePadding", { true, false }));
 
-const auto Pooling3dLayerDatasetFPSmall = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size3D(2, 2, 2), Size3D(3, 3, 3) }),
-                                                                  framework::dataset::make("Stride", { Size3D(2, 2, 2), Size3D(2, 1, 1) }),
-                                                          framework::dataset::make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
-                                                  framework::dataset::make("ExcludePadding", { true, false }));
+const auto Pooling3dLayerDatasetFPSmall = combine(datasets::PoolingTypes(), make("PoolingSize", { Size3D(2, 2, 2), Size3D(3, 3, 3) }),
+                                                                  make("Stride", { Size3D(2, 2, 2), Size3D(2, 1, 1) }),
+                                                          make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
+                                                  make("ExcludePadding", { true, false }));
 
-const auto Pooling3dLayerDatasetQASYMM8Small = combine(framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
-                                                                               framework::dataset::make("PoolingSize", { Size3D(3, 3, 3) }),
-                                                                       framework::dataset::make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(2, 2, 1) }),
-                                                               framework::dataset::make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
-                                                       framework::dataset::make("ExcludePadding", { true }));
+const auto Pooling3dLayerDatasetQASYMM8Small = combine(make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
+                                                                               make("PoolingSize", { Size3D(3, 3, 3) }),
+                                                                       make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(2, 2, 1) }),
+                                                               make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
+                                                       make("ExcludePadding", { true }));
 
-const auto Pooling3dLayerDatasetQASYMM8Large = combine(framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
-                                                                               framework::dataset::make("PoolingSize", { Size3D(3, 3, 3) }),
-                                                                       framework::dataset::make("Stride", { Size3D(1, 1, 1), Size3D(2, 2, 1) }),
-                                                               framework::dataset::make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 0) }),
-                                                       framework::dataset::make("ExcludePadding", { true }));
+const auto Pooling3dLayerDatasetQASYMM8Large = combine(make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
+                                                                               make("PoolingSize", { Size3D(3, 3, 3) }),
+                                                                       make("Stride", { Size3D(1, 1, 1), Size3D(2, 2, 1) }),
+                                                               make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 0) }),
+                                                       make("ExcludePadding", { true }));
 
 using ShapeDataset = framework::dataset::ContainerDataset<std::vector<TensorShape>>;
 
@@ -76,16 +78,16 @@ constexpr AbsoluteTolerance<float> tolerance_f16(0.01f);     /**< Tolerance valu
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);   /**< Tolerance value for comparing reference's output against implementation's output for unsigned 8-bit asymmetric type */
 constexpr AbsoluteTolerance<int8_t>  tolerance_qasymm8_s(1); /**< Tolerance value for comparing reference's output against implementation's output for signed 8-bit asymmetric type */
 
-const auto qasymm8_in_qinfo_dataset  = framework::dataset::make("InputQuantInfo", { QuantizationInfo(.2f, 10) });
-const auto qasymm8_out_qinfo_dataset = framework::dataset::make("OutputQuantInfo",
+const auto qasymm8_in_qinfo_dataset  = make("InputQuantInfo", { QuantizationInfo(.2f, 10) });
+const auto qasymm8_out_qinfo_dataset = make("OutputQuantInfo",
 {
     QuantizationInfo(.2f, 10), // Same qinfo
     QuantizationInfo(.1f, 5),  // Multiplier <= 1
     QuantizationInfo(2.f, 3)   // Multiplier > 1
 });
 
-const auto qasymm8_signed_in_qinfo_dataset  = framework::dataset::make("InputQuantInfo", { QuantizationInfo(.2f, -10) });
-const auto qasymm8_signed_out_qinfo_dataset = framework::dataset::make("OutputQuantInfo",
+const auto qasymm8_signed_in_qinfo_dataset  = make("InputQuantInfo", { QuantizationInfo(.2f, -10) });
+const auto qasymm8_signed_out_qinfo_dataset = make("OutputQuantInfo",
 {
     QuantizationInfo(.2f, -10), // Same qinfo
     QuantizationInfo(.1f, -5),  // Multiplier <= 1
@@ -134,7 +136,7 @@ TEST_CASE(SimpleIntegerAvgPooling, framework::DatasetMode::ALL)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(2U, 27U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC),     // Mismatching data type
+    make("InputInfo", { TensorInfo(TensorShape(2U, 27U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC),     // Mismatching data type
                                             TensorInfo(TensorShape(2U, 27U, 13U, 4U, 2U), 1, DataType::F32, DataLayout::NDHWC),     // Invalid pad/size combination
                                             TensorInfo(TensorShape(2U, 27U, 13U, 4U, 2U), 1, DataType::F32, DataLayout::NDHWC),     // Invalid pad/size combination
                                             TensorInfo(TensorShape(2U, 27U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC),     // Invalid output shape
@@ -149,7 +151,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(5U, 13U, 13U, 4U, 2U), 1, DataType::F32, DataLayout::NDHWC),
                                             TensorInfo(TensorShape(5U, 13U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC),
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(2U, 25U, 11U, 3U, 3U), 1, DataType::F16, DataLayout::NDHWC),
+    make("OutputInfo",{ TensorInfo(TensorShape(2U, 25U, 11U, 3U, 3U), 1, DataType::F16, DataLayout::NDHWC),
                                             TensorInfo(TensorShape(2U, 30U, 11U, 3U, 2U), 1, DataType::F32, DataLayout::NDHWC),
                                             TensorInfo(TensorShape(2U, 25U, 16U, 3U, 2U), 1, DataType::F32, DataLayout::NDHWC),
                                             TensorInfo(TensorShape(2U, 27U, 13U, 3U, 3U), 1, DataType::F32, DataLayout::NDHWC),
@@ -164,7 +166,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(5U, 6U, 6U, 2U, 2U),  1, DataType::F32, DataLayout::NDHWC),
                                             TensorInfo(TensorShape(5U, 6U, 6U, 2U, 3U),  1, DataType::F32, DataLayout::NDHWC),
                                     }),
-    framework::dataset::make("PoolInfo",  { Pooling3dLayerInfo(PoolingType::AVG, 3, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
+    make("PoolInfo",  { Pooling3dLayerInfo(PoolingType::AVG, 3, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
                                             Pooling3dLayerInfo(PoolingType::AVG, 2, Size3D(1, 1, 1), Padding3D(2, 0, 0)),
                                             Pooling3dLayerInfo(PoolingType::AVG, 2, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
                                             Pooling3dLayerInfo(PoolingType::L2,  3, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
@@ -180,7 +182,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             Pooling3dLayerInfo(PoolingType::AVG, 1, Size3D(2U, 2U, 2U), Padding3D(2, 2, 2), false), // pool size is equal to the padding size
                                             Pooling3dLayerInfo(PoolingType::AVG, 3, Size3D(2U, 2U, 2U), Padding3D(2,1,2,2,1,2), false, false, DimensionRoundingType::CEIL), // CEIL with asymmetric Padding
                                             }),
-    framework::dataset::make("Expected", { false, false, false, false, true, false, false, false, false, true , false, true, false, false, false})
+    make("Expected", { false, false, false, false, true, false, false, false, false, true , false, true, false, false, false})
     ),
     input_info, output_info, pool_info, expected)
 {
@@ -204,21 +206,21 @@ using NEPooling3dLayerGlobalFixture = Pooling3dLayerGlobalValidationFixture<Tens
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 
-FIXTURE_DATA_TEST_CASE(RunSpecial, NESpecial3dPoolingLayerFixture<float>, framework::DatasetMode::ALL, datasets::Pooling3dLayerDatasetSpecial() * framework::dataset::make("DataType", DataType::F32))
+FIXTURE_DATA_TEST_CASE(RunSpecial, NESpecial3dPoolingLayerFixture<float>, framework::DatasetMode::ALL, datasets::Pooling3dLayerDatasetSpecial() * make("DataType", DataType::F32))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayer3dFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5dShapes(), Pooling3dLayerDatasetFPSmall,
-                                                                                                            framework::dataset::make("DataType", DataType::F32)))
+                                                                                                            make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayer3dFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large5dShapes(), Pooling3dLayerDatasetFPSmall, framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::Large5dShapes(), Pooling3dLayerDatasetFPSmall, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -229,15 +231,15 @@ TEST_SUITE(GlobalPooling)
 // clang-format off
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayer3dFixture<float>, framework::DatasetMode::ALL,
                        combine(
-                                    framework::dataset::make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
+                                    make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
                                                                              TensorShape(4U, 27U, 13U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(27, 13, 4) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", {false, true}),
-                                    framework::dataset::make("DataType", DataType::F32)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(27, 13, 4) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", {false, true}),
+                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -245,11 +247,11 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayer3dFixture<float>, framework::Data
 
 FIXTURE_DATA_TEST_CASE(RunGlobalSmall, NEPooling3dLayerGlobalFixture<float>, framework::DatasetMode::ALL,
                        combine(
-                                    framework::dataset::make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
+                                    make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
                                                                              TensorShape(27U, 13U, 4U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("DataType", DataType::F32)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -257,15 +259,15 @@ FIXTURE_DATA_TEST_CASE(RunGlobalSmall, NEPooling3dLayerGlobalFixture<float>, fra
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayer3dFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(
-                                    framework::dataset::make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
+                                    make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
                                                                              TensorShape(4U, 79U, 37U, 11U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(79, 37, 11) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", {false, true}),
-                                    framework::dataset::make("DataType", DataType::F32)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(79, 37, 11) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", {false, true}),
+                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -278,7 +280,7 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayer3dFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5x5Shapes(), Pooling3dLayerDatasetFPSmall,
-                                                                                                           framework::dataset::make("DataType", DataType::F16)))
+                                                                                                           make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -294,7 +296,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayer3dFixture<half>, framework::Datas
 
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayer3dFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large5dShapes(), Pooling3dLayerDatasetFP,
-                                                                                                           framework::dataset::make("DataType",
+                                                                                                           make("DataType",
                                                                                                                    DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
@@ -314,15 +316,15 @@ TEST_SUITE(GlobalPooling)
 // clang-format off
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayer3dFixture<half>, framework::DatasetMode::ALL,
                        combine(
-                                    framework::dataset::make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
+                                    make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
                                                                              TensorShape(4U, 27U, 13U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(27, 13, 4) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", {false, true}),
-                                    framework::dataset::make("DataType", DataType::F16)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(27, 13, 4) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", {false, true}),
+                                    make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -339,11 +341,11 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayer3dFixture<half>, framework::Datas
 
 FIXTURE_DATA_TEST_CASE(RunSmallGlobal, NEPooling3dLayerGlobalFixture<half>, framework::DatasetMode::ALL,
                        combine(
-                                    framework::dataset::make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
+                                    make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
                                                                              TensorShape(27U, 13U, 4U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("DataType", DataType::F16)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -359,15 +361,15 @@ FIXTURE_DATA_TEST_CASE(RunSmallGlobal, NEPooling3dLayerGlobalFixture<half>, fram
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayer3dFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(
-                                    framework::dataset::make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
+                                    make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
                                                                              TensorShape(4U, 79U, 37U, 11U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(79, 37, 11) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F16)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(79, 37, 11) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -394,7 +396,7 @@ using NEPooling3dLayerQuantizedFixture = Pooling3dLayerValidationQuantizedFixtur
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPooling3dLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5dShapes(),Pooling3dLayerDatasetQASYMM8Small,
-                                                                                                                               framework::dataset::make("DataType", DataType::QASYMM8),
+                                                                                                                               make("DataType", DataType::QASYMM8),
                                                                                                                        qasymm8_in_qinfo_dataset,
                                                                                                                        qasymm8_out_qinfo_dataset))
 {
@@ -403,7 +405,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPooling3dLayerQuantizedFixture<uint8_t>, fram
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPooling3dLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::Large5dShapes(),Pooling3dLayerDatasetQASYMM8Large,
-                                                                                                                               framework::dataset::make("DataType", DataType::QASYMM8),
+                                                                                                                               make("DataType", DataType::QASYMM8),
                                                                                                                        qasymm8_in_qinfo_dataset,
                                                                                                                        qasymm8_out_qinfo_dataset))
 {
@@ -416,7 +418,7 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPooling3dLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5dShapes(),Pooling3dLayerDatasetQASYMM8Small,
-                                                                                                                              framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                              make("DataType", DataType::QASYMM8_SIGNED),
                                                                                                                       qasymm8_signed_in_qinfo_dataset,
                                                                                                                       qasymm8_signed_out_qinfo_dataset))
 {

--- a/tests/validation/NEON/PoolingLayer.cpp
+++ b/tests/validation/NEON/PoolingLayer.cpp
@@ -40,22 +40,24 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Input data sets for float data types */
 
-const auto PoolingLayerDatasetFP = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(7, 7), Size2D(3, 7), Size2D(7, 8) }),
-                                                   framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(1, 2, 1, 1), PadStrideInfo(2, 2, 1, 0) }),
-                                           framework::dataset::make("ExcludePadding", { true, false }));
-const auto PoolingLayerDatasetFPSmall = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(3, 3) }),
-                                                        framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0) }),
-                                                framework::dataset::make("ExcludePadding", { true, false }));
+const auto PoolingLayerDatasetFP = combine(datasets::PoolingTypes(), make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(7, 7), Size2D(3, 7), Size2D(7, 8) }),
+                                                   make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(1, 2, 1, 1), PadStrideInfo(2, 2, 1, 0) }),
+                                           make("ExcludePadding", { true, false }));
+const auto PoolingLayerDatasetFPSmall = combine(datasets::PoolingTypes(), make("PoolingSize", { Size2D(2, 2), Size2D(3, 3) }),
+                                                        make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0) }),
+                                                make("ExcludePadding", { true, false }));
 
 /** Input data sets for asymmetric data type */
 
-const auto PoolingLayerDatasetQASYMM8Small = combine(framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }), framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(3, 7), Size2D(7, 7) }),
-                                                             framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(1, 2, 1, 1) }),
-                                                     framework::dataset::make("ExcludePadding", { true }));
+const auto PoolingLayerDatasetQASYMM8Small = combine(make("PoolingType", { PoolingType::MAX, PoolingType::AVG }), make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(3, 7), Size2D(7, 7) }),
+                                                             make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(1, 2, 1, 1) }),
+                                                     make("ExcludePadding", { true }));
 
 constexpr AbsoluteTolerance<float> tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for float types */
 #ifdef ARM_COMPUTE_ENABLE_FP16
@@ -63,18 +65,18 @@ constexpr AbsoluteTolerance<float> tolerance_f16(0.01f);     /**< Tolerance valu
 #endif                                                       /* ARM_COMPUTE_ENABLE_FP16 */
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);   /**< Tolerance value for comparing reference's output against implementation's output for unsigned 8-bit asymmetric type */
 constexpr AbsoluteTolerance<int8_t>  tolerance_qasymm8_s(1); /**< Tolerance value for comparing reference's output against implementation's output for signed 8-bit asymmetric type */
-const auto                           pool_data_layout_dataset = framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC });
+const auto                           pool_data_layout_dataset = make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC });
 
-const auto qasymm8_in_qinfo_dataset  = framework::dataset::make("InputQuantInfo", { QuantizationInfo(.2f, 10) });
-const auto qasymm8_out_qinfo_dataset = framework::dataset::make("OutputQuantInfo",
+const auto qasymm8_in_qinfo_dataset  = make("InputQuantInfo", { QuantizationInfo(.2f, 10) });
+const auto qasymm8_out_qinfo_dataset = make("OutputQuantInfo",
 {
     QuantizationInfo(.2f, 10), // Same qinfo
     QuantizationInfo(.1f, 5),  // Multiplier <= 1
     QuantizationInfo(2.f, 3)   // Multiplier > 1
 });
 
-const auto qasymm8_signed_in_qinfo_dataset  = framework::dataset::make("InputQuantInfo", { QuantizationInfo(.2f, -10) });
-const auto qasymm8_signed_out_qinfo_dataset = framework::dataset::make("OutputQuantInfo",
+const auto qasymm8_signed_in_qinfo_dataset  = make("InputQuantInfo", { QuantizationInfo(.2f, -10) });
+const auto qasymm8_signed_out_qinfo_dataset = make("OutputQuantInfo",
 {
     QuantizationInfo(.2f, -10), // Same qinfo
     QuantizationInfo(.1f, -5),  // Multiplier <= 1
@@ -83,11 +85,11 @@ const auto qasymm8_signed_out_qinfo_dataset = framework::dataset::make("OutputQu
 
 // Cases where pooling region is completely outside the input tensor (excluding global pooling)
 const auto pool_outside_input_dataset = zip(
-                                                        framework::dataset::make("Shape", { TensorShape{ 2U, 2U, 1U }, TensorShape{ 2U, 2U, 4U }, TensorShape{ 3U, 5U, 2U }, TensorShape{ 10U, 20U, 3U } }),
-                                                        framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                                        framework::dataset::make("PoolingSize", { Size2D{ 2, 2 }, Size2D{ 3, 3 }, Size2D{ 2, 2 }, Size2D{ 3, 6 } }),
-                                                        framework::dataset::make("PadStride", { PadStrideInfo{ 1, 1, 2, 2 }, PadStrideInfo{ 1, 1, 4, 4 }, PadStrideInfo{ 1, 1, 3, 3 }, PadStrideInfo{ 1, 1, 2, 5 } }),
-                                                        framework::dataset::make("ExcludePadding", { false, false, false, false })
+                                                        make("Shape", { TensorShape{ 2U, 2U, 1U }, TensorShape{ 2U, 2U, 4U }, TensorShape{ 3U, 5U, 2U }, TensorShape{ 10U, 20U, 3U } }),
+                                                        make("PoolingType", { PoolingType::MAX, PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                                        make("PoolingSize", { Size2D{ 2, 2 }, Size2D{ 3, 3 }, Size2D{ 2, 2 }, Size2D{ 3, 6 } }),
+                                                        make("PadStride", { PadStrideInfo{ 1, 1, 2, 2 }, PadStrideInfo{ 1, 1, 4, 4 }, PadStrideInfo{ 1, 1, 3, 3 }, PadStrideInfo{ 1, 1, 2, 5 } }),
+                                                        make("ExcludePadding", { false, false, false, false })
                                             );
 } // namespace
 
@@ -97,7 +99,7 @@ TEST_SUITE(PoolingLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data type
+    make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data type
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Window shrink
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Invalid pad/size combination
                                             TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Invalid pad/size combination
@@ -109,7 +111,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(112, 112, 64,1), 1, DataType::F32, DataLayout::NHWC), // Mismatching number of channels
                                             TensorInfo(TensorShape(112, 112, 64,1), 1, DataType::F32, DataLayout::NHWC), // Mismatching width
                                          }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
+    make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
                                             TensorInfo(TensorShape(25U, 10U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(30U, 11U, 2U), 1, DataType::F32),
                                             TensorInfo(TensorShape(25U, 16U, 2U), 1, DataType::F32),
@@ -122,7 +124,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             TensorInfo(TensorShape(56, 51, 64,1), 1, DataType::F32, DataLayout::NHWC),
 
                                            }),
-    framework::dataset::make("PoolInfo",  { PoolingLayerInfo(PoolingType::AVG, 3, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 0)),
+    make("PoolInfo",  { PoolingLayerInfo(PoolingType::AVG, 3, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 0)),
                                             PoolingLayerInfo(PoolingType::AVG, 3, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 0)),
                                             PoolingLayerInfo(PoolingType::AVG, 2, DataLayout::NCHW, PadStrideInfo(1, 1, 2, 0)),
                                             PoolingLayerInfo(PoolingType::AVG, 2, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 2)),
@@ -135,7 +137,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                             PoolingLayerInfo(PoolingType::MAX,3,DataLayout::NHWC,PadStrideInfo(2,2,1,1)),
 
                                            }),
-    framework::dataset::make("Expected", { false, false, false, false, true, false, true, false, false, false, false})
+    make("Expected", { false, false, false, false, true, false, true, false, false, false, false})
     ),
     input_info, output_info, pool_info, expected)
 {
@@ -156,12 +158,12 @@ using NEPoolingLayerMixedDataLayoutFixture = PoolingLayerValidationFixture<Tenso
 template <typename T>
 using NESpecialPoolingLayerFixture = SpecialPoolingLayerValidationFixture<Tensor, Accessor, NEPoolingLayer, T>;
 
-const auto PoolingLayerIndicesDatasetFPSmall = combine(framework::dataset::make("PoolType", { PoolingType::MAX }), framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                                               framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0) }),
-                                                       framework::dataset::make("ExcludePadding", { true, false }));
-const auto PoolingLayerKernelIndicesDatasetFPSmall = combine(framework::dataset::make("PoolType", { PoolingType::MAX }), framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(7, 7) }),
-                                                                     framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0), PadStrideInfo(1, 1, 1, 1) }),
-                                                             framework::dataset::make("ExcludePadding", { false }));
+const auto PoolingLayerIndicesDatasetFPSmall = combine(make("PoolType", { PoolingType::MAX }), make("PoolingSize", { Size2D(2, 2) }),
+                                                               make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0) }),
+                                                       make("ExcludePadding", { true, false }));
+const auto PoolingLayerKernelIndicesDatasetFPSmall = combine(make("PoolType", { PoolingType::MAX }), make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(7, 7) }),
+                                                                     make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0), PadStrideInfo(1, 1, 1, 1) }),
+                                                             make("ExcludePadding", { false }));
 
 TEST_CASE(SimpleIntegerAvgPooling, framework::DatasetMode::ALL)
 {
@@ -199,30 +201,30 @@ TEST_CASE(SimpleIntegerAvgPooling, framework::DatasetMode::ALL)
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunIndices, NEPoolingLayerIndicesFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),PoolingLayerIndicesDatasetFPSmall,
-                                                                                                                           framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                   framework::dataset::make("UseKernelIndices", { false })))
+                                                                                                                           make("DataType", DataType::F32),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                   make("UseKernelIndices", { false })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
     validate(Accessor(_target_indices), _ref_indices);
 }
 FIXTURE_DATA_TEST_CASE(RunKernelIndices, NEPoolingLayerIndicesFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallNoneUnitShapes(),PoolingLayerKernelIndicesDatasetFPSmall,
-                                                                                                                           framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                   framework::dataset::make("UseKernelIndices", { true })))
+                                                                                                                           make("DataType", DataType::F32),
+                                                                                                                   make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                   make("UseKernelIndices", { true })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
     validate(Accessor(_target_indices), _ref_indices);
 }
-FIXTURE_DATA_TEST_CASE(RunSpecial, NESpecialPoolingLayerFixture<float>, framework::DatasetMode::ALL, datasets::PoolingLayerDatasetSpecial() * framework::dataset::make("DataType", DataType::F32))
+FIXTURE_DATA_TEST_CASE(RunSpecial, NESpecialPoolingLayerFixture<float>, framework::DatasetMode::ALL, datasets::PoolingLayerDatasetSpecial() * make("DataType", DataType::F32))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(), PoolingLayerDatasetFPSmall,
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::F32),
                                                                                                           pool_data_layout_dataset))
 {
@@ -230,17 +232,17 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayerFixture<float>, framework::Datase
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEPoolingLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),datasets::PoolingTypes(),
-                                                       framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                               framework::dataset::make("PadStride", { PadStrideInfo(2, 1, 0, 0) }),
-                                       framework::dataset::make("ExcludePadding", { false }),
-                               framework::dataset::make("DataType", DataType::F32),
+                                                       make("PoolingSize", { Size2D(2, 2) }),
+                                               make("PadStride", { PadStrideInfo(2, 1, 0, 0) }),
+                                       make("ExcludePadding", { false }),
+                               make("DataType", DataType::F32),
                        pool_data_layout_dataset))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), PoolingLayerDatasetFP,
-                                                                                                                framework::dataset::make("DataType",
+                                                                                                                make("DataType",
                                                                                                                         DataType::F32),
                                                                                                         pool_data_layout_dataset))
 {
@@ -249,7 +251,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayerFixture<float>, framework::Datase
 }
 TEST_SUITE(CornerCases)
 FIXTURE_DATA_TEST_CASE(PoolRegionCompletelyOutsideInput, NEPoolingLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(pool_outside_input_dataset,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::F32),
                        pool_data_layout_dataset))
 {
@@ -262,10 +264,10 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunIndices, NEPoolingLayerIndicesFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),PoolingLayerIndicesDatasetFPSmall,
-                                                                                                                          framework::dataset::make("DataType",
+                                                                                                                          make("DataType",
                                                                                                                                   DataType::F16),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                  framework::dataset::make("UseKernelIndices", { false })))
+                                                                                                                  make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                  make("UseKernelIndices", { false })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -280,7 +282,7 @@ FIXTURE_DATA_TEST_CASE(RunIndices, NEPoolingLayerIndicesFixture<half>, framework
     }
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(), PoolingLayerDatasetFPSmall,
-                                                                                                                 framework::dataset::make("DataType", DataType::F16),
+                                                                                                                 make("DataType", DataType::F16),
                                                                                                          pool_data_layout_dataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -295,7 +297,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayerFixture<half>, framework::Dataset
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), PoolingLayerDatasetFP,
-                                                                                                               framework::dataset::make("DataType", DataType::F16),
+                                                                                                               make("DataType", DataType::F16),
                                                                                                        pool_data_layout_dataset))
 {
     if(CPUInfo::get().has_fp16())
@@ -311,7 +313,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEPoolingLayerFixture<half>, framework::Dataset
 }
 TEST_SUITE(CornerCases)
 FIXTURE_DATA_TEST_CASE(PoolRegionCompletelyOutsideInput, NEPoolingLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(pool_outside_input_dataset,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::F16),
                        pool_data_layout_dataset))
 {
@@ -340,8 +342,8 @@ using NEPoolingLayerQuantizedMixedDataLayoutFixture = PoolingLayerValidationQuan
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmallNCHW, NEPoolingLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),PoolingLayerDatasetQASYMM8Small,
-                               framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW }),
+                               make("DataType", DataType::QASYMM8),
+                       make("DataLayout", { DataLayout::NCHW }),
                        qasymm8_in_qinfo_dataset,
                        qasymm8_in_qinfo_dataset))
 {
@@ -349,22 +351,22 @@ FIXTURE_DATA_TEST_CASE(RunSmallNCHW, NEPoolingLayerQuantizedFixture<uint8_t>, fr
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),PoolingLayerDatasetQASYMM8Small,
-                                                                                                                             framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                             make("DataType", DataType::QASYMM8),
+                                                                                                                     make("DataLayout", { DataLayout::NHWC }),
                                                                                                                      qasymm8_in_qinfo_dataset,
                                                                                                                      qasymm8_out_qinfo_dataset))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
 }
-FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEPoolingLayerQuantizedMixedDataLayoutFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
-                                                       framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                               framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
-                                       framework::dataset::make("ExcludePadding", { true }),
-                               framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
-                       framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 255.f, 10) }),
-                       framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 255.f, 5) })))
+FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEPoolingLayerQuantizedMixedDataLayoutFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
+                                                       make("PoolingSize", { Size2D(2, 2) }),
+                                               make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
+                                       make("ExcludePadding", { true }),
+                               make("DataType", DataType::QASYMM8),
+                       make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
+                       make("InputQuantInfo", { QuantizationInfo(1.f / 255.f, 10) }),
+                       make("OutputQuantInfo", { QuantizationInfo(1.f / 255.f, 5) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -372,22 +374,22 @@ FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEPoolingLayerQuantizedMixedDataLayou
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPoolingLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),PoolingLayerDatasetQASYMM8Small,
-                                                                                                                            framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                    framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                            make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                    make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                                                                                     qasymm8_signed_in_qinfo_dataset,
                                                                                                                     qasymm8_signed_in_qinfo_dataset))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_s);
 }
-FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEPoolingLayerQuantizedMixedDataLayoutFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
-                                                       framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                               framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
-                                       framework::dataset::make("ExcludePadding", { true }),
-                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
-                       framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) }),
-                       framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) })))
+FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, NEPoolingLayerQuantizedMixedDataLayoutFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
+                                                       make("PoolingSize", { Size2D(2, 2) }),
+                                               make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
+                                       make("ExcludePadding", { true }),
+                               make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
+                       make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) }),
+                       make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_s);

--- a/tests/validation/NEON/PriorBoxLayer.cpp
+++ b/tests/validation/NEON/PriorBoxLayer.cpp
@@ -39,6 +39,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_f32(0.00001f); /**< Tolerance value for comparing reference's output against implementation's output for DataType::F32 */
@@ -53,15 +55,15 @@ using NEPriorBoxLayerFixture = PriorBoxLayerValidationFixture<Tensor, Accessor, 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("Input1Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32)
+               make("Input1Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32)
                                                      }),
-               framework::dataset::make("Input2Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32)
+               make("Input2Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32)
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(1200U, 2U), 1, DataType::F32)
+               make("OutputInfo",{ TensorInfo(TensorShape(1200U, 2U), 1, DataType::F32)
                                                      }),
-               framework::dataset::make("PriorBoxInfo",{ PriorBoxLayerInfo(std::vector<float>(1), std::vector<float>(1), 0, true, true, std::vector<float>(1), std::vector<float>(1), Coordinates2D{8, 8}, std::array<float, 2>())
+               make("PriorBoxInfo",{ PriorBoxLayerInfo(std::vector<float>(1), std::vector<float>(1), 0, true, true, std::vector<float>(1), std::vector<float>(1), Coordinates2D{8, 8}, std::array<float, 2>())
                                                      }),
-               framework::dataset::make("Expected", { true})
+               make("Expected", { true})
                ),
                input1_info, input2_info, output_info, info, expected)
 {
@@ -74,15 +76,15 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEPriorBoxLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallPriorBoxLayerDataset(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32, 0);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEPriorBoxLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargePriorBoxLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F32),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataType", DataType::F32),
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32, 0);

--- a/tests/validation/NEON/QLSTMLayerNormalization.cpp
+++ b/tests/validation/NEON/QLSTMLayerNormalization.cpp
@@ -204,10 +204,10 @@ constexpr uint32_t qsymm16_per_vector = vector_size_byte / sizeof(int16_t);
     )
 
 #define QSYMM16_DATASET_1D \
-    concat(concat(QSYMM16_DATASET_ITER(1, 0), QSYMM16_DATASET_ITER(1, 1)), QSYMM16_DATASET_ITER(1, 2))
+    concat(QSYMM16_DATASET_ITER(1, 0), QSYMM16_DATASET_ITER(1, 1), QSYMM16_DATASET_ITER(1, 2))
 
 #define QSYMM16_DATASET_2D \
-    concat(concat(QSYMM16_DATASET_ITER(3, 0), QSYMM16_DATASET_ITER(3, 1)), QSYMM16_DATASET_ITER(3, 2))
+    concat(QSYMM16_DATASET_ITER(3, 0), QSYMM16_DATASET_ITER(3, 1), QSYMM16_DATASET_ITER(3, 2))
 
 FIXTURE_DATA_TEST_CASE(RandomValue1D, NEQLSTMLayerNormalizationFixture<int16_t>, framework::DatasetMode::ALL, QSYMM16_DATASET_1D)
 {

--- a/tests/validation/NEON/QuantizationLayer.cpp
+++ b/tests/validation/NEON/QuantizationLayer.cpp
@@ -42,6 +42,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Tolerance for quantization */
@@ -107,7 +109,7 @@ TEST_CASE(QSymm8_per_channel_validate_scales, framework::DatasetMode::ALL)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Wrong output data type
+               make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Wrong output data type
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),  // Wrong output data type
                                                        TensorInfo(TensorShape(16U, 16U, 2U, 5U), 1, DataType::F32),  // Missmatching shapes
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),  // Valid
@@ -117,7 +119,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F16),  // PER_CHANNEL only supported for F32
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32), // Quantization info's scales not initialized
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::U16),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),
@@ -127,7 +129,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QSYMM8_PER_CHANNEL),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QSYMM8_PER_CHANNEL),
                                                      }),
-               framework::dataset::make("Expected", { false, false, false, true,false,false,false,false,false})
+               make("Expected", { false, false, false, true,false,false,false,false,false})
                ),
                input_info, output_info, expected)
 {
@@ -148,41 +150,41 @@ using NEQuantizationLayerQSYMM8_PER_CHANNEL_Fixture = QuantizationValidationFixt
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, NEQuantizationLayerQASYMM8Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8Signed, NEQuantizationLayerQASYMM8SignedFixture<float>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, NEQuantizationLayerQASYMM16Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u16);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeQASYMM8, NEQuantizationLayerQASYMM8Fixture<float>, framework::DatasetMode::NIGHTLY, combine(QuantizationLargeShapes,
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeQASYMM16, NEQuantizationLayerQASYMM16Fixture<float>, framework::DatasetMode::NIGHTLY, combine(QuantizationLargeShapes,
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u16);
@@ -190,9 +192,9 @@ FIXTURE_DATA_TEST_CASE(RunLargeQASYMM16, NEQuantizationLayerQASYMM16Fixture<floa
 
 
 FIXTURE_DATA_TEST_CASE(RunSmallQSYMM8_PER_CHANNEL, NEQuantizationLayerQSYMM8_PER_CHANNEL_Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QSYMM8_PER_CHANNEL }),
-                       framework::dataset::make("QuantizationInfoIgnored", { QuantizationInfo() })))
+                       make("DataType", DataType::F32),
+                       make("DataTypeOut", { DataType::QSYMM8_PER_CHANNEL }),
+                       make("QuantizationInfoIgnored", { QuantizationInfo() })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);
@@ -202,9 +204,9 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, NEQuantizationLayerQASYMM8Fixture<half>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F16),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -218,9 +220,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, NEQuantizationLayerQASYMM8Fixture<half>,
     }
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8Signed, NEQuantizationLayerQASYMM8SignedFixture<half>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F16),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -234,9 +236,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8Signed, NEQuantizationLayerQASYMM8SignedFi
     }
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, NEQuantizationLayerQASYMM16Fixture<half>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F16),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -250,9 +252,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, NEQuantizationLayerQASYMM16Fixture<half
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLargeQASYMM8, NEQuantizationLayerQASYMM8Fixture<half>, framework::DatasetMode::NIGHTLY, combine(QuantizationLargeShapes,
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F16),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -266,9 +268,9 @@ FIXTURE_DATA_TEST_CASE(RunLargeQASYMM8, NEQuantizationLayerQASYMM8Fixture<half>,
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLargeQASYMM16, NEQuantizationLayerQASYMM16Fixture<half>, framework::DatasetMode::NIGHTLY, combine(QuantizationLargeShapes,
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataType", DataType::F16),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -294,37 +296,37 @@ template <typename T>
 using NEQuantizationLayerQASYMM16GenFixture = QuantizationValidationGenericFixture<Tensor, Accessor, NEQuantizationLayer, T, uint16_t>;
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, NEQuantizationLayerQASYMM8GenFixture<uint8_t>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(0.5f, 10) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(2.0f, 15), QuantizationInfo(0.5f, 25) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(0.5f, 10) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(2.0f, 15), QuantizationInfo(0.5f, 25) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
 }
 FIXTURE_DATA_TEST_CASE(ConvertUint8toInt8, NEQuantizationLayerQASYMM8GenFixture<uint8_t>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(2.0f, -1) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(2.0f, 127) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(2.0f, -1) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(2.0f, 127) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8_SIGNED, NEQuantizationLayerQASYMM8_SIGNEDGenFixture<uint8_t>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10), QuantizationInfo(2.0f, -25) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.0f, 15), QuantizationInfo(1.0f, 127) })))
+                       make("DataTypeIn", DataType::QASYMM8),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10), QuantizationInfo(2.0f, -25) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(1.0f, 15), QuantizationInfo(1.0f, 127) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, NEQuantizationLayerQASYMM16GenFixture<uint8_t>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(4.0f, 23) })))
+                       make("DataTypeIn", DataType::QASYMM8),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(4.0f, 23) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u16);
@@ -332,28 +334,28 @@ FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, NEQuantizationLayerQASYMM16GenFixture<u
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8_SIGNED, NEQuantizationLayerQASYMM8_SIGNEDGenFixture<int8_t>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(2.0f, -5), QuantizationInfo(1.0f, 43) })))
+                       make("DataTypeIn", DataType::QASYMM8_SIGNED),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(2.0f, -5), QuantizationInfo(1.0f, 43) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, NEQuantizationLayerQASYMM8GenFixture<int8_t>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(2.0f, 10), QuantizationInfo(2.0f, -25) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.0f, 30), QuantizationInfo(2.0f, -128) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(2.0f, 10), QuantizationInfo(2.0f, -25) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(1.0f, 30), QuantizationInfo(2.0f, -128) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
 }
 FIXTURE_DATA_TEST_CASE(ConvertInt8toUint8, NEQuantizationLayerQASYMM8_SIGNEDGenFixture<int8_t>, framework::DatasetMode::ALL, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 0) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.0f, -128) })))
+                       make("DataTypeIn", DataType::QASYMM8_SIGNED),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 0) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(1.0f, -128) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);

--- a/tests/validation/NEON/RNNLayer.cpp
+++ b/tests/validation/NEON/RNNLayer.cpp
@@ -37,6 +37,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> tolerance_f32(0.001f); /**< Relative tolerance value for comparing reference's output against implementation's output for DataType:F32 */
@@ -52,7 +54,7 @@ TEST_SUITE(RNNLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::U8),      // Wrong data type
+               make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::U8),      // Wrong data type
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Wrong input size
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),     // Wrong weights size
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),     // Wrong recurrent weights size
@@ -61,7 +63,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),     // Wrong hidden output size
                                                        TensorInfo(TensorShape(32U, 32U), 1, DataType::F32),
                }),
-               framework::dataset::make("WeightsInfo", { TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
+               make("WeightsInfo", { TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
@@ -70,7 +72,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 32U), 1, DataType::F32),
                }),
-               framework::dataset::make("RecurrentWeightsInfo", { TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
+               make("RecurrentWeightsInfo", { TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F32),
@@ -79,7 +81,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                                   TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(32U, 32U), 1, DataType::F32),
                }),
-               framework::dataset::make("BiasInfo", { TensorInfo(TensorShape(11U), 1, DataType::F32),
+               make("BiasInfo", { TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
@@ -88,7 +90,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(32U), 1, DataType::F32),
                }),
-               framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
+               make("OutputInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
@@ -97,7 +99,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 32U), 1, DataType::F32),
                }),
-               framework::dataset::make("HiddenStateInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
+               make("HiddenStateInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
@@ -106,7 +108,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                              TensorInfo(TensorShape(11U, 13U, 2U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(32U, 32U), 1, DataType::F32),
                }),
-               framework::dataset::make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
+               make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -115,7 +117,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                }),
-               framework::dataset::make("Expected", { false, false, false, false, false, false, false, true })
+               make("Expected", { false, false, false, false, false, false, false, true })
                ),
                input_info, weights_info, recurrent_weights_info, bias_info, output_info, hidden_output_info, info, expected)
 {
@@ -128,7 +130,7 @@ template <typename T>
 using NERNNLayerFixture = RNNLayerValidationFixture<Tensor, Accessor, NERNNLayer, T>;
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NERNNLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NERNNLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -137,7 +139,7 @@ TEST_SUITE_END() // FP32
 
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NERNNLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NERNNLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {

--- a/tests/validation/NEON/ROIAlignLayer.cpp
+++ b/tests/validation/NEON/ROIAlignLayer.cpp
@@ -42,6 +42,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> relative_tolerance_f32(0.01f);
@@ -62,7 +64,7 @@ TEST_SUITE(RoiAlign)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32),
+               make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Mismatching data type input/rois
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Mismatching data type input/output
                                                        TensorInfo(TensorShape(250U, 128U, 2U), 1, DataType::F32), // Mismatching depth size input/output
@@ -71,7 +73,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Mismatching height and width input/output
 
                                                      }),
-               framework::dataset::make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
+               make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
@@ -79,7 +81,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                       TensorInfo(TensorShape(4, 4U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
                                                     }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
@@ -87,7 +89,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 5U, 3U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
+               make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
@@ -95,7 +97,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       }),
-               framework::dataset::make("Expected", { true, false, false, false, false, false, false })
+               make("Expected", { true, false, false, false, false, false, false })
                ),
                input_info, rois_info, output_info, pool_info, expected)
 {
@@ -110,8 +112,8 @@ using NEROIAlignLayerFloatFixture = ROIAlignLayerFixture<Tensor, Accessor, NEROI
 TEST_SUITE(Float)
 FIXTURE_DATA_TEST_CASE(SmallROIAlignLayerFloat, NEROIAlignLayerFloatFixture, framework::DatasetMode::ALL,
                        framework::dataset::combine(framework::dataset::combine(datasets::SmallROIDataset(),
-                                                                               framework::dataset::make("DataType", { DataType::F32 })),
-                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                               make("DataType", { DataType::F32 })),
+                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference, relative_tolerance_f32, .02f, absolute_tolerance_f32);
@@ -120,8 +122,8 @@ FIXTURE_DATA_TEST_CASE(SmallROIAlignLayerFloat, NEROIAlignLayerFloatFixture, fra
 using NEROIAlignLayerHalfFixture = ROIAlignLayerFixture<Tensor, Accessor, NEROIAlignLayer, half, half>;
 FIXTURE_DATA_TEST_CASE(SmallROIAlignLayerHalf, NEROIAlignLayerHalfFixture, framework::DatasetMode::ALL,
                        framework::dataset::combine(framework::dataset::combine(datasets::SmallROIDataset(),
-                                                                               framework::dataset::make("DataType", { DataType::F16 })),
-                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                               make("DataType", { DataType::F16 })),
+                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -145,10 +147,10 @@ using NEROIAlignLayerQuantizedFixture = ROIAlignLayerQuantizedFixture<Tensor, Ac
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(Small, NEROIAlignLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                                       framework::dataset::make("DataType", { DataType::QASYMM8 }),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
-                               framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
+                                                       make("DataType", { DataType::QASYMM8 }),
+                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
+                               make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);
@@ -158,10 +160,10 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(Small, NEROIAlignLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                                       framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED }),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
-                               framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
+                                                       make("DataType", { DataType::QASYMM8_SIGNED }),
+                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
+                               make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8_s);

--- a/tests/validation/NEON/ROIPoolingLayer.cpp
+++ b/tests/validation/NEON/ROIPoolingLayer.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 RelativeTolerance<float> relative_tolerance_f32(0.01f);
@@ -54,7 +56,7 @@ TEST_SUITE(RoiPooling)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Successful test
+               make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Successful test
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::QASYMM8), // Successful test (quantized)
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Incorrect rois type
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Mismatching data type input/output
@@ -64,7 +66,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Mismatching height and width input/output
 
                                                      }),
-               framework::dataset::make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
+               make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
@@ -73,7 +75,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                       TensorInfo(TensorShape(4, 4U), 1, DataType::U16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
                                                     }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F16),
@@ -82,7 +84,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 5U, 3U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
+               make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
@@ -91,7 +93,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       }),
-               framework::dataset::make("Expected", { true, true, false, false, false, false, false })
+               make("Expected", { true, true, false, false, false, false, false })
                ),
                input_info, rois_info, output_info, pool_info, expected)
 {
@@ -105,8 +107,8 @@ using NEROIPoolingLayerFloatFixture = ROIPoolingLayerFixture<Tensor, Accessor, N
 TEST_SUITE(Float)
 FIXTURE_DATA_TEST_CASE(SmallROIPoolingLayerFloat, NEROIPoolingLayerFloatFixture, framework::DatasetMode::ALL,
                        framework::dataset::combine(framework::dataset::combine(datasets::SmallROIDataset(),
-                                                                               framework::dataset::make("DataType", { DataType::F32 })),
-                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                                                                               make("DataType", { DataType::F32 })),
+                                                   make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(Accessor(_target), _reference, relative_tolerance_f32, .02f, absolute_tolerance_f32);
@@ -123,10 +125,10 @@ TEST_SUITE(QASYMM8)
 
 FIXTURE_DATA_TEST_CASE(Small, NEROIPoolingLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                                       framework::dataset::make("DataType", { DataType::QASYMM8 }),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
-                               framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
+                                                       make("DataType", { DataType::QASYMM8 }),
+                                               make("DataLayout", { DataLayout::NCHW }),
+                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
+                               make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/NEON/Range.cpp
+++ b/tests/validation/NEON/Range.cpp
@@ -40,16 +40,18 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr RelativeTolerance<float> tolerance(0.01f);
 constexpr AbsoluteTolerance<float> abs_tolerance(0.02f);
 
-const auto start_dataset          = framework::dataset::make("Start", { float(3), float(-17), float(16) });
-const auto unsigned_start_dataset = framework::dataset::make("Start", { float(3), float(16) });
-const auto float_step_dataset     = framework::dataset::make("Step", { float(1), float(-0.2f), float(0.2), float(12.2), float(-12.2), float(-1.2), float(-3), float(3) });
-const auto step_dataset           = framework::dataset::make("Step", { float(1), float(12), float(-12), float(-1), float(-3), float(3) });
-const auto unsigned_step_dataset  = framework::dataset::make("Step", { float(1), float(12), float(3) });
+const auto start_dataset          = make("Start", { float(3), float(-17), float(16) });
+const auto unsigned_start_dataset = make("Start", { float(3), float(16) });
+const auto float_step_dataset     = make("Step", { float(1), float(-0.2f), float(0.2), float(12.2), float(-12.2), float(-1.2), float(-3), float(3) });
+const auto step_dataset           = make("Step", { float(1), float(12), float(-12), float(-1), float(-3), float(3) });
+const auto unsigned_step_dataset  = make("Step", { float(1), float(12), float(3) });
 } // namespace
 
 TEST_SUITE(NEON)
@@ -59,7 +61,7 @@ TEST_SUITE(Range)
 // clang-format off
 
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("OutputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(27U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U), 1, DataType::U8),
@@ -69,7 +71,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                         TensorInfo(TensorShape(10U), 1, DataType::QASYMM8),
                                                         TensorInfo(TensorShape(10U), 1, DataType::U8),
                                                       }),
-               framework::dataset::make("Start",{ 0.0f,
+               make("Start",{ 0.0f,
                                                   15.0f,
                                                   1500.0f,
                                                   100.0f,
@@ -79,7 +81,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                   10.0f,
                                                   10.0f
                                                 }),
-               framework::dataset::make("End",{ 100.0f,
+               make("End",{ 100.0f,
                                                 15.0f,
                                                 2500.0f,
                                                 -1000.0f,
@@ -89,7 +91,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                 100.0f,
                                                 100.0f
                                               }),
-               framework::dataset::make("Step",{ 100.0f,
+               make("Step",{ 100.0f,
                                                  15.0f,
                                                  10.0f,
                                                  100.0f,
@@ -99,7 +101,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
                                                  10.0f,
                                                  10.0f
                                               }),
-               framework::dataset::make("Expected", { false, // 1-D tensor expected
+               make("Expected", { false, // 1-D tensor expected
                                                     false, // start == end
                                                     false, // output vector size insufficient
                                                     false, // sign of step incorrect
@@ -122,10 +124,10 @@ using NERangeFixture = RangeFixture<Tensor, Accessor, NERange, T>;
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERangeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(
-                                                                                                                 framework::dataset::make("DataType", DataType::U8),
+                                                                                                                 make("DataType", DataType::U8),
                                                                                                                  unsigned_start_dataset,
                                                                                                              unsigned_step_dataset,
-                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                     make("QuantizationInfo", { QuantizationInfo() })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance, 0.f, abs_tolerance);
@@ -134,10 +136,10 @@ TEST_SUITE_END() // U8
 
 TEST_SUITE(S16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERangeFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(
-                                                                                                                 framework::dataset::make("DataType", DataType::S16),
+                                                                                                                 make("DataType", DataType::S16),
                                                                                                                  start_dataset,
                                                                                                              step_dataset,
-                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                     make("QuantizationInfo", { QuantizationInfo() })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance, 0.f, abs_tolerance);
@@ -148,10 +150,10 @@ TEST_SUITE(Float)
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERangeFixture<half>, framework::DatasetMode::PRECOMMIT, combine(
-                                                                                                              framework::dataset::make("DataType", DataType::F16),
+                                                                                                              make("DataType", DataType::F16),
                                                                                                               start_dataset,
                                                                                                           float_step_dataset,
-                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                  make("QuantizationInfo", { QuantizationInfo() })))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -169,10 +171,10 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NERangeFixture<float>, framework::DatasetMode::PRECOMMIT, combine(
-                                                                                                               framework::dataset::make("DataType", DataType::F32),
+                                                                                                               make("DataType", DataType::F32),
                                                                                                                start_dataset,
                                                                                                            float_step_dataset,
-                                                                                                   framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                   make("QuantizationInfo", { QuantizationInfo() })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance, 0.f, abs_tolerance);

--- a/tests/validation/NEON/ReduceMean.cpp
+++ b/tests/validation/NEON/ReduceMean.cpp
@@ -44,6 +44,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for 32-bit floating-point type */
@@ -61,9 +63,9 @@ constexpr AbsoluteTolerance<int8_t>  tolerance_s8(2);    /**< Tolerance value fo
 constexpr AbsoluteTolerance<uint8_t> zero_tolerance_u8(0);
 constexpr AbsoluteTolerance<int8_t>  zero_tolerance_s8(0);
 
-const auto axis_keep = combine(framework::dataset::make("Axis", { Coordinates(0), Coordinates(1, 0), Coordinates(1, 2), Coordinates(0, 2), Coordinates(1, 3), Coordinates(2, 3), Coordinates(0, 1, 2, 3) }),
-                               framework::dataset::make("KeepDims", { true }));
-const auto axis_drop = combine(framework::dataset::make("Axis", { Coordinates(0), Coordinates(1), Coordinates(3) }), framework::dataset::make("KeepDims", { false }));
+const auto axis_keep = combine(make("Axis", { Coordinates(0), Coordinates(1, 0), Coordinates(1, 2), Coordinates(0, 2), Coordinates(1, 3), Coordinates(2, 3), Coordinates(0, 1, 2, 3) }),
+                               make("KeepDims", { true }));
+const auto axis_drop = combine(make("Axis", { Coordinates(0), Coordinates(1), Coordinates(3) }), make("KeepDims", { false }));
 } // namespace
 TEST_SUITE(NEON)
 TEST_SUITE(ReduceMean)
@@ -152,22 +154,22 @@ TEST_CASE(ProperRoundingPolicyNonXReduction, framework::DatasetMode::ALL)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
+        make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid output shape
                                                 TensorInfo(TensorShape(32U, 16U, 16U, 2U), 1, DataType::F32),// OK
                                                 TensorInfo(TensorShape{228U, 19U, 2U, 2U}, 1, DataType::F32),// OK
                                                 TensorInfo(TensorShape{228U, 19U, 2U, 1U}, 1, DataType::F32) // Cannot support axis 3 not valid
         }),
-        framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
+        make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(32U, 16U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(19U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(19U), 1, DataType::F32)
 
         }),
-        framework::dataset::make("Axis", { Coordinates(4), Coordinates(0,2), Coordinates(2), Coordinates(3,2,0), Coordinates(3,2,0) }),
-        framework::dataset::make("Keep", { true, true, true, false, false }),
-        framework::dataset::make("Expected", { false, false, true, true, false })
+        make("Axis", { Coordinates(4), Coordinates(0,2), Coordinates(2), Coordinates(3,2,0), Coordinates(3,2,0) }),
+        make("Keep", { true, true, true, false, false }),
+        make("Expected", { false, false, true, true, false })
         ),
         input_info, output_info, axis, keep, expected)
 {
@@ -187,7 +189,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEReduceMeanFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -204,7 +206,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEReduceMeanFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -223,7 +225,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEReduceMeanFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -232,7 +234,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEReduceMeanFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
@@ -248,9 +250,9 @@ TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEReduceMeanQuantizedFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
@@ -260,9 +262,9 @@ TEST_SUITE(Requant)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEReduceMeanQuantizedFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), axis_drop,
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 200, 16) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8), axis_drop,
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 200, 16) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
@@ -272,9 +274,9 @@ TEST_SUITE_END() // Requant
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEReduceMeanQuantizedFixture<uint8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_u8);
@@ -285,9 +287,9 @@ TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEReduceMeanQuantizedFixture<int8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 127, -10), QuantizationInfo(1.f / 250, -20) }),
-                               framework::dataset::make("QuantizationInfoInputOutput", { QuantizationInfo(1.f / 127, -10) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 127, -10), QuantizationInfo(1.f / 250, -20) }),
+                               make("QuantizationInfoInputOutput", { QuantizationInfo(1.f / 127, -10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);
@@ -296,9 +298,9 @@ TEST_SUITE(Requant)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEReduceMeanQuantizedFixture<int8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), axis_drop,
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 113, 10) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), axis_drop,
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 113, 10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);
@@ -308,9 +310,9 @@ TEST_SUITE_END() // Requant
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEReduceMeanQuantizedFixture<int8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 127, -10) }),
-                               framework::dataset::make("QuantizationInfoInputOutput", { QuantizationInfo(1.f / 127, -10) })))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 127, -10) }),
+                               make("QuantizationInfoInputOutput", { QuantizationInfo(1.f / 127, -10) })))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_s8);

--- a/tests/validation/NEON/ReductionOperation.cpp
+++ b/tests/validation/NEON/ReductionOperation.cpp
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 /** Tolerance for float operations */
@@ -52,7 +54,7 @@ RelativeTolerance<float> rel_tolerance_f16(0.1f);
 /** Tolerance for quantized operations */
 RelativeTolerance<float> tolerance_quantized(1.f);
 
-const auto ReductionOperations = framework::dataset::make("ReductionOperation",
+const auto ReductionOperations = make("ReductionOperation",
 {
     ReductionOperation::SUM,
     ReductionOperation::PROD,
@@ -60,17 +62,17 @@ const auto ReductionOperations = framework::dataset::make("ReductionOperation",
     ReductionOperation::MAX,
 });
 
-const auto QuantizationInfos = framework::dataset::make("QuantizationInfo",
+const auto QuantizationInfos = make("QuantizationInfo",
 {
     QuantizationInfo(1.f / 117, 10), // Numbers chosen so that the quantized values are in range of qasymm8_signed data type
     QuantizationInfo(1.f / 64, 5),
     QuantizationInfo(1.f / 32, 2)
 });
 
-const auto Axises = framework::dataset::make("Axis",
+const auto Axises = make("Axis",
 { 0, 1, 2, 3 });
 
-const auto KeepDims = framework::dataset::make("KeepDims", { true, false });
+const auto KeepDims = make("KeepDims", { true, false });
 
 } // namespace
 
@@ -80,23 +82,23 @@ TEST_SUITE(ReductionOperation)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo",          { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
+    make("InputInfo",          { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
                                                      TensorInfo(TensorShape(128U, 64U), 2, DataType::F32), // Number of Input channels != 1
                                                      TensorInfo(TensorShape(128U, 64U), 1, DataType::S16), // DataType != F32
                                                      TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Axis >= num_max_dimensions
                                                      TensorInfo(TensorShape(128U, 64U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(128U, 64U), 1, DataType::F32) // Kept dimension when keep_dims = false
                                                    }),
-    framework::dataset::make("OutputInfo",         { TensorInfo(TensorShape(1U, 64U), 1, DataType::F16),
+    make("OutputInfo",         { TensorInfo(TensorShape(1U, 64U), 1, DataType::F16),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::S16),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32)
                                                    }),
-    framework::dataset::make("Axis",               { 0U, 0U, 0U, static_cast<unsigned int>(TensorShape::num_max_dimensions), 0U, 0U }),
-    framework::dataset::make("KeepDims",           { true, true, true, true, true, false}),
-    framework::dataset::make("Expected",           { false, false, false, false, true, false })
+    make("Axis",               { 0U, 0U, 0U, static_cast<unsigned int>(TensorShape::num_max_dimensions), 0U, 0U }),
+    make("KeepDims",           { true, true, true, true, true, false}),
+    make("Expected",           { false, false, false, false, true, false })
     ),
     input_info, output_info, axis, keep_dims, expected)
 {
@@ -108,8 +110,8 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
     ARM_COMPUTE_EXPECT(is_valid == expected, framework::LogLevel::ERRORS);
 }
 
-DATA_TEST_CASE(ValidateNoPadding, framework::DatasetMode::ALL, combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F32), framework::dataset::make("Axis",
-{ 0, 1 }), framework::dataset::make("ReductionOperation", {ReductionOperation::SUM,}), KeepDims),
+DATA_TEST_CASE(ValidateNoPadding, framework::DatasetMode::ALL, combine(datasets::Small4DShapes(), make("DataType", DataType::F32), make("Axis",
+{ 0, 1 }), make("ReductionOperation", {ReductionOperation::SUM,}), KeepDims),
                shape, data_type, axis, op, keep_dims)
 {
     TensorShape         input_shape = TensorShape(shape);
@@ -137,13 +139,13 @@ using NEReductionOperationFixture = ReductionOperationFixture<Tensor, Accessor, 
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEReductionOperationFixture<float>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F32), Axises, ReductionOperations, KeepDims))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F32), Axises, ReductionOperations, KeepDims))
 {
     // Validate output
     validate(Accessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEReductionOperationFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::F32), Axises, ReductionOperations, KeepDims))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::F32), Axises, ReductionOperations, KeepDims))
 {
     // Validate output
     validate(Accessor(_target), _reference, rel_tolerance_f32, 0, tolerance_f32);
@@ -153,7 +155,7 @@ TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEReductionOperationFixture<half>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F16), Axises, ReductionOperations, KeepDims))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F16), Axises, ReductionOperations, KeepDims))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -167,7 +169,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEReductionOperationFixture<half>, framework::D
     }
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NEReductionOperationFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::F16), Axises, ReductionOperations, KeepDims))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::F16), Axises, ReductionOperations, KeepDims))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -188,7 +190,7 @@ using NEReductionOperationQuantizedFixture = ReductionOperationQuantizedFixture<
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEReductionOperationQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), Axises,
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8), Axises,
                                                ReductionOperations,
                                        QuantizationInfos,
                                KeepDims))
@@ -200,7 +202,7 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEReductionOperationQuantizedFixture<int8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), Axises,
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), Axises,
                                                ReductionOperations,
                                        QuantizationInfos,
                                KeepDims))

--- a/tests/validation/NEON/ReorgLayer.cpp
+++ b/tests/validation/NEON/ReorgLayer.cpp
@@ -41,26 +41,28 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(ReorgLayer)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::S64),    // Wrong output tensor
+               make("InputInfo", { TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::S64),    // Wrong output tensor
                                                        TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::F32),    // Wrong output tensor
                                                        TensorInfo(TensorShape(3U, 12U, 4U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(3U, 12U, 4U, 2U), 1, DataType::F32),     // Wrong data type
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::S64),
+               make("OutputInfo",{ TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::S64),
                                                        TensorInfo(TensorShape(5U, 6U, 4U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 6U, 2, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 4U, 36U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 4U, 36U, 2U), 1, DataType::F16),
                                                      }),
-               framework::dataset::make("Stride", { 2, 2, 4, 3 }),
-               framework::dataset::make("Expected", { false, true, false, true, false })
+               make("Stride", { 2, 2, 4, 3 }),
+               make("Expected", { false, true, false, true, false })
                ),
                input_info, output_info, stride, expected)
 {
@@ -74,17 +76,17 @@ template <typename T>
 using NEReorgLayerFixture = ReorgLayerValidationFixture<Tensor, Accessor, NEReorgLayer, T>;
 
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReorgLayerFixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReorgLayerFixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), make("DataType",
                                                                                                                   DataType::S32),
-                                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), make("DataType",
                                                                                                                 DataType::S32),
-                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -92,17 +94,17 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int32_t>, framework::Datase
 TEST_SUITE_END() // S32
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReorgLayerFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReorgLayerFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), make("DataType",
                                                                                                                   DataType::S16),
-                                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), make("DataType",
                                                                                                                 DataType::S16),
-                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -110,16 +112,16 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int16_t>, framework::Datase
 TEST_SUITE_END() // S16
 
 TEST_SUITE(S8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReorgLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReorgLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), make("DataType",
                                                                                                                  DataType::S8),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), framework::dataset::make("DataType", DataType::S8),
-                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+FIXTURE_DATA_TEST_CASE(RunLarge, NEReorgLayerFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), make("DataType", DataType::S8),
+                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/ReshapeLayer.cpp
+++ b/tests/validation/NEON/ReshapeLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(ReshapeLayer)
 
@@ -48,21 +50,21 @@ TEST_SUITE(ReshapeLayer)
 // clang-format off
 
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-                                                              framework::dataset::make("InputInfo",
+                                                              make("InputInfo",
 {
     TensorInfo(TensorShape(9U, 5U, 7U, 3U), 1, DataType::F32),
     TensorInfo(TensorShape(8U, 4U, 6U, 4U), 1, DataType::F32),
     TensorInfo(TensorShape(8U, 4U, 6U, 4U), 1, DataType::F32), // mismatching dimensions
     TensorInfo(TensorShape(9U, 5U, 7U, 3U), 1, DataType::F16), // mismatching types
 }),
-                                                              framework::dataset::make("OutputInfo",
+                                                              make("OutputInfo",
 {
     TensorInfo(TensorShape(9U, 5U, 21U), 1, DataType::F32),
     TensorInfo(TensorShape(8U, 24U, 4U), 1, DataType::F32),
     TensorInfo(TensorShape(192U, 192U),  1, DataType::F32),
     TensorInfo(TensorShape(9U, 5U, 21U), 1, DataType::F32),
 }),
-                                                              framework::dataset::make("Expected", { true, true, false, false })
+                                                              make("Expected", { true, true, false, false })
 ),
 input_info, output_info, expected)
 {
@@ -83,7 +85,7 @@ using NEReshapeLayerPaddedFixture = ReshapeLayerPaddedValidationFixture<Tensor, 
 
 TEST_SUITE(Float)
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -93,7 +95,7 @@ TEST_SUITE_END() //Float
 
 TEST_SUITE(Integer)
 TEST_SUITE(S8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::S8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::S8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -101,7 +103,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerFixture<int8_t>, framework::Datas
 TEST_SUITE_END() //S8
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::S16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::S16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -112,7 +114,7 @@ TEST_SUITE_END() //Integer
 TEST_SUITE(Padded)
 TEST_SUITE(Float)
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerPaddedFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerPaddedFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -122,7 +124,7 @@ TEST_SUITE_END() //Float
 
 TEST_SUITE(Integer)
 TEST_SUITE(S8)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerPaddedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::S8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerPaddedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::S8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -130,7 +132,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerPaddedFixture<int8_t>, framework:
 TEST_SUITE_END() //S8
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerPaddedFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::S16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEReshapeLayerPaddedFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::S16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/Scale.cpp
+++ b/tests/validation/NEON/Scale.cpp
@@ -36,6 +36,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 using datasets::ScaleShapesBaseDataSet;
@@ -58,19 +60,19 @@ constexpr uint32_t num_elements_per_vector()
 }
 
 /** Quantization information data set */
-const auto QuantizationInfoSet = framework::dataset::make("QuantizationInfo",
+const auto QuantizationInfoSet = make("QuantizationInfo",
 {
     QuantizationInfo(0.5f, -10),
 });
 
 /** Quantization information data set */
-const auto InputQuantizationInfoSet = framework::dataset::make("InputQuantizationInfo",
+const auto InputQuantizationInfoSet = make("InputQuantizationInfo",
 {
     QuantizationInfo(0.5f, -10),
 });
 
 /** Quantization information data set */
-const auto OutputQuantizationInfoSet = framework::dataset::make("OutputQuantizationInfo",
+const auto OutputQuantizationInfoSet = make("OutputQuantizationInfo",
 {
     QuantizationInfo(0.2f, 20),
 });
@@ -258,10 +260,10 @@ TEST_CASE(AlignedCornerNotSupported, framework::DatasetMode::ALL)
 TEST_SUITE_END() // Validate
 
 DATA_TEST_CASE(CheckNoPadding, framework::DatasetMode::ALL, combine(datasets::Medium4DShapes(),
-                                                                                            framework::dataset::make("DataType", { DataType::F32, DataType::QASYMM8 }),
-                                                                                    framework::dataset::make("InterpolationPolicy", { InterpolationPolicy::BILINEAR, InterpolationPolicy::NEAREST_NEIGHBOR }),
-                                                                            framework::dataset::make("SamplingPolicy", { SamplingPolicy::CENTER, SamplingPolicy::TOP_LEFT }),
-                                                                    framework::dataset::make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW })),
+                                                                                            make("DataType", { DataType::F32, DataType::QASYMM8 }),
+                                                                                    make("InterpolationPolicy", { InterpolationPolicy::BILINEAR, InterpolationPolicy::NEAREST_NEIGHBOR }),
+                                                                            make("SamplingPolicy", { SamplingPolicy::CENTER, SamplingPolicy::TOP_LEFT }),
+                                                                    make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW })),
                shape, data_type, interpolation_policy, sampling_policy, data_layout)
 {
     constexpr auto  default_border_mode = BorderMode::CONSTANT;
@@ -292,10 +294,10 @@ DATA_TEST_CASE(CheckNoPadding, framework::DatasetMode::ALL, combine(datasets::Me
 }
 
 DATA_TEST_CASE(CheckNoPaddingInterpAREA, framework::DatasetMode::ALL, combine(datasets::Medium4DShapes(),
-                                                                                                      framework::dataset::make("DataType", { DataType::U8 }),
-                                                                                              framework::dataset::make("InterpolationPolicy", { InterpolationPolicy::AREA }),
-                                                                                      framework::dataset::make("SamplingPolicy", { SamplingPolicy::CENTER, SamplingPolicy::TOP_LEFT }),
-                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW })),
+                                                                                                      make("DataType", { DataType::U8 }),
+                                                                                              make("InterpolationPolicy", { InterpolationPolicy::AREA }),
+                                                                                      make("SamplingPolicy", { SamplingPolicy::CENTER, SamplingPolicy::TOP_LEFT }),
+                                                                              make("DataLayout", { DataLayout::NCHW })),
                shape, data_type, interpolation_policy, sampling_policy, data_layout)
 {
     constexpr auto  default_border_mode = BorderMode::CONSTANT;
@@ -339,8 +341,8 @@ using NEScaleQuantizedMixedDataLayoutFixture = ScaleValidationQuantizedFixture<T
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-const auto f32_shape      = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<float>())), framework::dataset::make("DataType", DataType::F32));
-const auto f32_shape_nhwc = combine(datasets::Small3DShapes(), framework::dataset::make("DataType", DataType::F32));
+const auto f32_shape      = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<float>())), make("DataType", DataType::F32));
+const auto f32_shape_nhwc = combine(datasets::Small3DShapes(), make("DataType", DataType::F32));
 FIXTURE_DATA_TEST_CASE(RunSmall, NEScaleFixture<float>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(f32_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -398,8 +400,8 @@ FIXTURE_DATA_TEST_CASE(RunMediumAlignCornersNHWC, NEScaleFixture<float>, framewo
 TEST_SUITE_END() // FP32
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(FP16)
-const auto f16_shape      = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<half>())), framework::dataset::make("DataType", DataType::F16));
-const auto f16_shape_nhwc = combine(datasets::Small3DShapes(), framework::dataset::make("DataType", DataType::F16));
+const auto f16_shape      = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<half>())), make("DataType", DataType::F16));
+const auto f16_shape_nhwc = combine(datasets::Small3DShapes(), make("DataType", DataType::F16));
 FIXTURE_DATA_TEST_CASE(RunSmall, NEScaleFixture<half>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(f16_shape, ScaleSamplingPolicySet))
 {
     if(CPUInfo::get().has_fp16())
@@ -491,7 +493,7 @@ TEST_SUITE_END() // Float
 
 TEST_SUITE(Integer)
 TEST_SUITE(U8)
-const auto u8_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), framework::dataset::make("DataType", DataType::U8));
+const auto u8_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), make("DataType", DataType::U8));
 FIXTURE_DATA_TEST_CASE(RunSmall, NEScaleFixture<uint8_t>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(u8_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -512,7 +514,7 @@ FIXTURE_DATA_TEST_CASE(RunSmallAlignCorners, NEScaleFixture<uint8_t>, framework:
 }
 TEST_SUITE_END() // U8
 TEST_SUITE(S8)
-const auto s8_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<int8_t>())), framework::dataset::make("DataType", DataType::S8));
+const auto s8_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<int8_t>())), make("DataType", DataType::S8));
 FIXTURE_DATA_TEST_CASE(RunSmall, NEScaleFixture<int8_t>, framework::DatasetMode::ALL, ASSEMBLE_S8_DATASET(s8_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -533,7 +535,7 @@ FIXTURE_DATA_TEST_CASE(RunSmallAlignCorners, NEScaleFixture<int8_t>, framework::
 }
 TEST_SUITE_END() // S8
 TEST_SUITE(S16)
-const auto s16_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<int16_t>())), framework::dataset::make("DataType", DataType::S16));
+const auto s16_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<int16_t>())), make("DataType", DataType::S16));
 FIXTURE_DATA_TEST_CASE(RunSmall, NEScaleFixture<int16_t>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(s16_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -557,7 +559,7 @@ TEST_SUITE_END() // Integer
 
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
-const auto qasymm8_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), framework::dataset::make("DataType", DataType::QASYMM8));
+const auto qasymm8_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), make("DataType", DataType::QASYMM8));
 FIXTURE_DATA_TEST_CASE(RunSmall, NEScaleQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, ASSEMBLE_QUANTIZED_DATASET(qasymm8_shape, ScaleSamplingPolicySet, QuantizationInfoSet))
 {
     //Create valid region
@@ -599,7 +601,7 @@ FIXTURE_DATA_TEST_CASE(RunSmallAlignCorners, NEScaleQuantizedFixture<uint8_t>, f
 }
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
-const auto                          qasymm8_signed_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<int8_t>())), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED));
+const auto                          qasymm8_signed_shape = combine((SCALE_SHAPE_DATASET(num_elements_per_vector<int8_t>())), make("DataType", DataType::QASYMM8_SIGNED));
 constexpr AbsoluteTolerance<int8_t> tolerance_qasymm8_signed{ 1 };
 FIXTURE_DATA_TEST_CASE(RunSmall, NEScaleQuantizedFixture<int8_t>, framework::DatasetMode::ALL, ASSEMBLE_QUANTIZED_DATASET(qasymm8_signed_shape, ScaleSamplingPolicySet, QuantizationInfoSet))
 {

--- a/tests/validation/NEON/Select.cpp
+++ b/tests/validation/NEON/Select.cpp
@@ -39,10 +39,12 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-auto run_small_dataset = combine(datasets::SmallShapes(), framework::dataset::make("has_same_rank", { false, true }));
-auto run_large_dataset = combine(datasets::LargeShapes(), framework::dataset::make("has_same_rank", { false, true }));
+auto run_small_dataset = combine(datasets::SmallShapes(), make("has_same_rank", { false, true }));
+auto run_large_dataset = combine(datasets::LargeShapes(), make("has_same_rank", { false, true }));
 } // namespace
 
 TEST_SUITE(NEON)
@@ -51,35 +53,35 @@ TEST_SUITE(Select)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("CInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S8), // Invalid condition datatype
+        make("CInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S8), // Invalid condition datatype
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8), // Invalid output datatype
                                             TensorInfo(TensorShape(13U), 1, DataType::U8),          // Invalid c shape
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8), // Mismatching shapes
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                             TensorInfo(TensorShape(2U), 1, DataType::U8),
         }),
-        framework::dataset::make("XInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+        make("XInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 10U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("YInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+        make("YInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("Expected", { false, false, false, false, true, true})
+        make("Expected", { false, false, false, false, true, true})
         ),
         c_info, x_info, y_info, output_info, expected)
 {
@@ -102,7 +104,7 @@ TEST_SUITE(F16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NESelectFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_small_dataset, make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -118,7 +120,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NESelectFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_large_dataset, make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -137,7 +139,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NESelectFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_small_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -146,7 +148,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NESelectFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_large_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/Slice.cpp
+++ b/tests/validation/NEON/Slice.cpp
@@ -40,20 +40,22 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(Slice)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
+        make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Negative begin
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Big number of coordinates
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Starts", { Coordinates(3, 1, 0), Coordinates(-3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
-        framework::dataset::make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, 3, 1) }),
-        framework::dataset::make("Expected", { false, false, false, true })
+        make("Starts", { Coordinates(3, 1, 0), Coordinates(-3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
+        make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, 3, 1) }),
+        make("Expected", { false, false, false, true })
                                                           ),
                input_info, starts, ends, expected)
 {
@@ -73,7 +75,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NESliceFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallSliceDataset(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -89,7 +91,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NESliceFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeSliceDataset(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -108,7 +110,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NESliceFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -117,7 +119,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NESliceFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/SpaceToBatchLayer.cpp
+++ b/tests/validation/NEON/SpaceToBatchLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(SpaceToBatchLayer)
 
@@ -50,27 +52,27 @@ using NESpaceToBatchLayerFixture = SpaceToBatchLayerValidationFixture<Tensor, Ac
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
+               make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),    // Wrong data type block shape
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U, 4U), 1, DataType::F32),    // Wrong tensor shape
                                                      }),
-               framework::dataset::make("BlockShapeInfo",{ TensorInfo(TensorShape(2U), 1, DataType::S32),
+               make("BlockShapeInfo",{ TensorInfo(TensorShape(2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(2U), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("PaddingsShapeInfo",{ TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
+               make("PaddingsShapeInfo",{ TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false})
+               make("Expected", { true, false, false, false})
                ),
                input_info, block_shape_info, paddings_info, output_info, expected)
 {
@@ -78,23 +80,23 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
     ARM_COMPUTE_EXPECT(has_error == expected, framework::LogLevel::ERRORS);
 }
 DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
+               make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Negative block shapes
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U, 4U), 1, DataType::F32), // Wrong tensor shape
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U, 4U), 1, DataType::F32), // Wrong paddings
                                                      }),
-               framework::dataset::make("BlockShapeX", { 2, 2, 2, 2, 2 }),
-               framework::dataset::make("BlockShapeY", { 2, 2, -2, 2, 2 }),
-               framework::dataset::make("PadLeft", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
-               framework::dataset::make("PadRight", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
+               make("BlockShapeX", { 2, 2, 2, 2, 2 }),
+               make("BlockShapeY", { 2, 2, -2, 2, 2 }),
+               make("PadLeft", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
+               make("PadRight", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
+               make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false, false})
+               make("Expected", { true, false, false, false, false})
                ),
                input_info, block_shape_x, block_shape_y, padding_left, padding_right, output_info, expected)
 {
@@ -106,16 +108,16 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(Small, NESpaceToBatchLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToBatchLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Small, NESpaceToBatchLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToBatchLayerDataset(), make("DataType",
                                                                                                                     DataType::F32),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(Large, NESpaceToBatchLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToBatchLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Large, NESpaceToBatchLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToBatchLayerDataset(), make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -124,15 +126,15 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(Small, NESpaceToBatchLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToBatchLayerDataset(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F16),
-                                                                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::F16),
+                                                                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(Large, NESpaceToBatchLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToBatchLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F16),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataType", DataType::F16),
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -146,17 +148,17 @@ using NESpaceToBatchLayerQuantizedFixture = SpaceToBatchLayerValidationQuantized
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(Small, NESpaceToBatchLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToBatchLayerDataset(),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { 1.f / 255.f, 9.f })))
+                                                                                                                       make("DataType", DataType::QASYMM8),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                       make("QuantizationInfo", { 1.f / 255.f, 9.f })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(Large, NESpaceToBatchLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToBatchLayerDataset(),
-                                                                                                                     framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                     framework::dataset::make("QuantizationInfo", { 1.f / 255.f, 9.f })))
+                                                                                                                     make("DataType", DataType::QASYMM8),
+                                                                                                                     make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                     make("QuantizationInfo", { 1.f / 255.f, 9.f })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/SpaceToDepthLayer.cpp
+++ b/tests/validation/NEON/SpaceToDepthLayer.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(SpaceToDepthLayer)
 
@@ -50,18 +52,18 @@ using NESpaceToDepthLayerFixture = SpaceToDepthLayerValidationFixture<Tensor, Ac
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
-               framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
+               make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Negative block shapes
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U, 4U), 1, DataType::F32), // Wrong tensor shape
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 8U, 1U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 8U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 8U, 1U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 8U, 8U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 8U, 1U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("BlockShape", { 2, 2, -2, 2 }),
-               framework::dataset::make("Expected", { true, false, false, false})
+               make("BlockShape", { 2, 2, -2, 2 }),
+               make("Expected", { true, false, false, false})
                ),
                input_info, output_info, block_shape, expected)
 {
@@ -73,16 +75,16 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(Small, NESpaceToDepthLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Small, NESpaceToDepthLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                     DataType::F32),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(Large, NESpaceToDepthLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Large, NESpaceToDepthLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -90,16 +92,16 @@ FIXTURE_DATA_TEST_CASE(Large, NESpaceToDepthLayerFixture<float>, framework::Data
 TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(Small, NESpaceToDepthLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Small, NESpaceToDepthLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                    DataType::F16),
-                                                                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(Large, NESpaceToDepthLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Large, NESpaceToDepthLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                  DataType::F16),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/Split.cpp
+++ b/tests/validation/NEON/Split.cpp
@@ -40,19 +40,21 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(Split)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
+        make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid number of splits
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Axis", { 4, 2, 2 }),
-        framework::dataset::make("Splits", { 4, 5, 4 }),
-        framework::dataset::make("Expected", { false, false, true })
+        make("Axis", { 4, 2, 2 }),
+        make("Splits", { 4, 5, 4 }),
+        make("Expected", { false, false, true })
                                                           ),
                input_info, axis, splits, expected)
 {
@@ -68,16 +70,16 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
 }
 
 DATA_TEST_CASE(ValidateSplitShapes, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32),
+        make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Axis", { 2, 2 }),
-        framework::dataset::make("Splits", { std::vector<TensorInfo>{TensorInfo(TensorShape(27U, 3U, 4U,  2U), 1, DataType::F32),
+        make("Axis", { 2, 2 }),
+        make("Splits", { std::vector<TensorInfo>{TensorInfo(TensorShape(27U, 3U, 4U,  2U), 1, DataType::F32),
                                                                      TensorInfo(TensorShape(27U, 3U, 4U,  2U), 1, DataType::F32),
                                                                      TensorInfo(TensorShape(27U, 3U, 8U,  2U), 1, DataType::F32)},
                                              std::vector<TensorInfo>{TensorInfo(TensorShape(27U, 3U, 3U,  2U), 1, DataType::F32),
                                                                      TensorInfo(TensorShape(27U, 3U, 13U, 2U), 1, DataType::F32)} }),
-        framework::dataset::make("Expected", { true, true })
+        make("Expected", { true, true })
         ),
         input_info, axis, splits, expected)
 {
@@ -105,7 +107,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NESplitFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSplitDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallSplitDataset(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -125,7 +127,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NESplitFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSplitDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeSplitDataset(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -148,7 +150,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NESplitFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSplitDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallSplitDataset(), make("DataType", DataType::F32)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)
@@ -160,7 +162,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NESplitFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSplitDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeSplitDataset(), make("DataType", DataType::F32)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)
@@ -172,7 +174,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
 FIXTURE_DATA_TEST_CASE(RunSmallSplitShapes,
                        NESplitShapesFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSplitShapesDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallSplitShapesDataset(), make("DataType", DataType::F32)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)

--- a/tests/validation/NEON/StridedSlice.cpp
+++ b/tests/validation/NEON/StridedSlice.cpp
@@ -41,22 +41,24 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(StridedSlice)
 
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
+        make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Zero stride
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Big number of coordinates
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Invalid Coords/Strides
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Starts", { Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
-        framework::dataset::make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, -1, 1), Coordinates(13, 3, 1) }),
-        framework::dataset::make("Strides", { BiStrides(2, 1, 1),  BiStrides(2, 0, 1), BiStrides(2, 1, 1), BiStrides(2, -1, 1), BiStrides(2, 1, 1) }),
-        framework::dataset::make("Expected", { false, false, false, false, true })
+        make("Starts", { Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
+        make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, -1, 1), Coordinates(13, 3, 1) }),
+        make("Strides", { BiStrides(2, 1, 1),  BiStrides(2, 0, 1), BiStrides(2, 1, 1), BiStrides(2, -1, 1), BiStrides(2, 1, 1) }),
+        make("Expected", { false, false, false, false, true })
                                                           ),
                input_info, starts, ends, strides, expected)
 {
@@ -75,7 +77,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEStridedSliceFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallStridedSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallStridedSliceDataset(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -91,7 +93,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEStridedSliceFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeStridedSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeStridedSliceDataset(), make("DataType", DataType::F16)))
 {
     if(CPUInfo::get().has_fp16())
     {
@@ -110,7 +112,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        NEStridedSliceFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallStridedSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallStridedSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -119,7 +121,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        NEStridedSliceFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeStridedSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeStridedSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/Tile.cpp
+++ b/tests/validation/NEON/Tile.cpp
@@ -39,9 +39,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-const auto MultiplesDataset = framework::dataset::make("Multiples", { Multiples{ 3 },
+const auto MultiplesDataset = make("Multiples", { Multiples{ 3 },
                                                                       Multiples{ 2, 2 },
                                                                       Multiples{ 1, 1, 3, 4 },
                                                                       Multiples{ 2, 1, 2, 2 },
@@ -55,17 +57,17 @@ TEST_SUITE(Tile)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo", { TensorInfo(TensorShape(10, 10), 1, DataType::F32),
+        make("InputInfo", { TensorInfo(TensorShape(10, 10), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10, 10), 1, DataType::F32),  // Mismatching shape
                                                 TensorInfo(TensorShape(10, 10), 1, DataType::F16), // Mismatching type
                                                 TensorInfo(TensorShape(10, 10), 1, DataType::F32)}),
         // Wrong multiples
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(10, 20), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(10, 20), 1, DataType::F32),
                                                 TensorInfo(TensorShape(20, 20), 1, DataType::F32),
                                                 TensorInfo(TensorShape(20, 20), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10, 20), 1, DataType::F32)}),
-        framework::dataset::make("Multiples",{ Multiples{1, 2}, Multiples{1, 2}, Multiples{0, 1} }),
-        framework::dataset::make("Expected", {true, false, false, false })
+        make("Multiples",{ Multiples{1, 2}, Multiples{1, 2}, Multiples{0, 1} }),
+        make("Expected", {true, false, false, false })
         ),
         input_info, output_info, multiples, expected)
 {
@@ -80,13 +82,13 @@ using NETileFixture = TileValidationFixture<Tensor, Accessor, NETile, T>;
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NETileFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(RunSmall, NETileFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F16),
                                                                                                  MultiplesDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NETileFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F16), MultiplesDataset))
+FIXTURE_DATA_TEST_CASE(RunLarge, NETileFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F16), MultiplesDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -94,13 +96,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, NETileFixture<half>, framework::DatasetMode::NI
 TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NETileFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(RunSmall, NETileFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F32),
                                                                                                   MultiplesDataset))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NETileFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(RunLarge, NETileFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F32),
                                                                                                 MultiplesDataset))
 {
     // Validate output
@@ -112,7 +114,7 @@ TEST_SUITE_END() // Float
 TEST_SUITE(Integer)
 TEST_SUITE(S8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NETileFixture<int8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", { DataType::S8 }),
+                       combine(datasets::SmallShapes(), make("DataType", { DataType::S8 }),
                            MultiplesDataset))
 {
     // Validate output
@@ -124,7 +126,7 @@ TEST_SUITE_END() // Integer
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NETileFixture<uint8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", { DataType::QASYMM8 }),
+                       combine(datasets::SmallShapes(), make("DataType", { DataType::QASYMM8 }),
                            MultiplesDataset))
 {
     // Validate output

--- a/tests/validation/NEON/Transpose.cpp
+++ b/tests/validation/NEON/Transpose.cpp
@@ -48,17 +48,17 @@ TEST_SUITE(Transpose)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(21U, 13U), 1, DataType::U16), // Invalid shape
+    make("InputInfo", { TensorInfo(TensorShape(21U, 13U), 1, DataType::U16), // Invalid shape
                                             TensorInfo(TensorShape(20U, 13U), 1, DataType::U8),  // Wrong data type
                                             TensorInfo(TensorShape(20U, 16U), 1, DataType::U16),
                                             TensorInfo(TensorShape(20U, 16U), 1, DataType::U32),
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(21U, 13U), 1, DataType::U16),
+    make("OutputInfo",{ TensorInfo(TensorShape(21U, 13U), 1, DataType::U16),
                                             TensorInfo(TensorShape(31U, 20U), 1, DataType::U16),
                                             TensorInfo(TensorShape(16U, 20U), 1, DataType::U16),
                                             TensorInfo(TensorShape(16U, 20U), 1, DataType::U32),
                                            }),
-    framework::dataset::make("Expected", { false, false, true, true })
+    make("Expected", { false, false, true, true })
     ),
     a_info, output_info, expected)
 {
@@ -91,13 +91,13 @@ using NETransposeFixture = TransposeValidationFixture<Tensor, Accessor, NETransp
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NETransposeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
-                                                                                                         framework::dataset::make("DataType", DataType::U8)))
+                                                                                                         make("DataType", DataType::U8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NETransposeFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
-                                                                                                       framework::dataset::make("DataType", DataType::U8)))
+                                                                                                       make("DataType", DataType::U8)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -106,13 +106,13 @@ TEST_SUITE_END()
 
 TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall, NETransposeFixture<uint16_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
-                                                                                                          framework::dataset::make("DataType", DataType::U16)))
+                                                                                                          make("DataType", DataType::U16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NETransposeFixture<uint16_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
-                                                                                                        framework::dataset::make("DataType", DataType::U16)))
+                                                                                                        make("DataType", DataType::U16)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -121,13 +121,13 @@ TEST_SUITE_END()
 
 TEST_SUITE(U32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NETransposeFixture<uint32_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
-                                                                                                          framework::dataset::make("DataType", DataType::U32)))
+                                                                                                          make("DataType", DataType::U32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, NETransposeFixture<uint32_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
-                                                                                                        framework::dataset::make("DataType", DataType::U32)))
+                                                                                                        make("DataType", DataType::U32)))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/NEON/UNIT/DynamicTensor.cpp
+++ b/tests/validation/NEON/UNIT/DynamicTensor.cpp
@@ -41,6 +41,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
 constexpr AbsoluteTolerance<float> absolute_tolerance_float(0.0001f); /**< Absolute Tolerance value for comparing reference's output against implementation's output for DataType::F32 */
@@ -70,8 +72,8 @@ using NEDynamicTensorType3SingleFunction = DynamicTensorType3SingleFunction<Tens
  * */
 FIXTURE_DATA_TEST_CASE(DynamicTensorType3Single, NEDynamicTensorType3SingleFunction, framework::DatasetMode::ALL,
                        framework::dataset::zip(
-                                               framework::dataset::make("Level0Shape", { TensorShape(12U, 11U, 3U), TensorShape(256U, 8U, 12U) }),
-                                               framework::dataset::make("Level1Shape", { TensorShape(67U, 31U, 15U), TensorShape(11U, 2U, 3U) })
+                                               make("Level0Shape", { TensorShape(12U, 11U, 3U), TensorShape(256U, 8U, 12U) }),
+                                               make("Level1Shape", { TensorShape(67U, 31U, 15U), TensorShape(11U, 2U, 3U) })
                                                ))
 {
     if(input_l0.total_size() < input_l1.total_size())
@@ -96,11 +98,11 @@ using NEDynamicTensorType3ComplexFunction = DynamicTensorType3ComplexFunction<Te
 FIXTURE_DATA_TEST_CASE(DynamicTensorType3Complex, NEDynamicTensorType3ComplexFunction, framework::DatasetMode::ALL,
                        framework::dataset::zip(
                                                                                                    framework::dataset::zip(framework::dataset::zip(framework::dataset::zip(
-                                                                                                   framework::dataset::make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 6U), TensorShape(128U, 128U, 6U) } }),
-                                                                                                   framework::dataset::make("WeightsManager", { TensorShape(3U, 3U, 6U, 3U) })),
-                                                                                               framework::dataset::make("BiasShape", { TensorShape(3U) })),
-                                                                       framework::dataset::make("OutputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 3U), TensorShape(128U, 128U, 3U) } })),
-                                                                                                   framework::dataset::make("PadStrideInfo", { PadStrideInfo(1U, 1U, 1U, 1U) })
+                                                                                                   make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 6U), TensorShape(128U, 128U, 6U) } }),
+                                                                                                   make("WeightsManager", { TensorShape(3U, 3U, 6U, 3U) })),
+                                                                                               make("BiasShape", { TensorShape(3U) })),
+                                                                       make("OutputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 3U), TensorShape(128U, 128U, 3U) } })),
+                                                                                                   make("PadStrideInfo", { PadStrideInfo(1U, 1U, 1U, 1U) })
                                                ))
 {
     for(unsigned int i = 0; i < num_iterations; ++i)
@@ -116,7 +118,7 @@ using NEDynamicTensorType2PipelineFunction = DynamicTensorType2PipelineFunction<
  *  Create and manage the tensors needed to run a pipeline. After the function is executed, resize the input size and rerun.
  */
 FIXTURE_DATA_TEST_CASE(DynamicTensorType2Pipeline, NEDynamicTensorType2PipelineFunction, framework::DatasetMode::ALL,
-                       framework::dataset::make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 6U), TensorShape(128U, 128U, 6U) } }))
+                       make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 6U), TensorShape(128U, 128U, 6U) } }))
 {
 }
 TEST_SUITE_END() // DynamicTensor

--- a/tests/validation/NEON/Unstack.cpp
+++ b/tests/validation/NEON/Unstack.cpp
@@ -40,10 +40,12 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 namespace
 {
-const auto unstack_axis_dataset  = framework::dataset::make("Axis", -3, 3);
-const auto unstack_num_dataset   = framework::dataset::make("Num", 1, 3); // The length of the dimension axis
+const auto unstack_axis_dataset  = make("Axis", -3, 3);
+const auto unstack_num_dataset   = make("Num", 1, 3); // The length of the dimension axis
 const auto unstack_dataset_small = datasets::Small3DShapes() * unstack_axis_dataset * unstack_num_dataset;
 } //namespace
 
@@ -51,7 +53,7 @@ TEST_SUITE(NEON)
 TEST_SUITE(Unstack)
 
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-                                                                      framework::dataset::make("InputInfo",
+                                                                      make("InputInfo",
 {
     TensorInfo(TensorShape(1U, 9U, 8U), 1, DataType::U8),   // Passes, 1 slice on x axis
     TensorInfo(TensorShape(1U, 2U, 3U), 1, DataType::U8),   // fails because axis > input's rank
@@ -60,15 +62,15 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
     TensorInfo(TensorShape(13U, 7U, 5U), 1, DataType::S16), // fails, too few output slices
     TensorInfo(TensorShape(1U, 2U, 3U), 1, DataType::U8),   // fails mismatching data types
 }),
-                                                                      framework::dataset::make("OutputInfo",
+                                                                      make("OutputInfo",
 {
     std::vector<TensorInfo>{ TensorInfo(TensorShape(9U, 8U), 1, DataType::U8) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(2U, 3U), 1, DataType::U8) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(2U, 3U), 1, DataType::S32) },
 
     std::vector<TensorInfo>{ TensorInfo(TensorShape(7U, 5U), 1, DataType::S32), TensorInfo(TensorShape(7U, 5U), 1, DataType::S32), TensorInfo(TensorShape(7U, 5U), 1, DataType::S32) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(7U, 5U), 1, DataType::S16) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(9U, 8U), 1, DataType::S32) },
 }),
-                                                                      framework::dataset::make("Axis", { -3, 3, -4, -3, 1, 1 }),
-                                                                      framework::dataset::make("Num", { 1, 1, 1, 1, 0, 1 }),
-                                                                      framework::dataset::make("Expected", { true, false, false, true, false, false })
+                                                                      make("Axis", { -3, 3, -4, -3, 1, 1 }),
+                                                                      make("Num", { 1, 1, 1, 1, 0, 1 }),
+                                                                      make("Expected", { true, false, false, true, false, false })
 ),
 input_info, output_info, axis, num, expected)
 {
@@ -85,7 +87,7 @@ template <typename T>
 using NEUnstackFixture = UnstackValidationFixture<Tensor, ITensor, Accessor, NEUnstack, T>;
 
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEUnstackFixture<float>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * framework::dataset::make("DataType", { DataType::F32 }))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEUnstackFixture<float>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * make("DataType", { DataType::F32 }))
 {
     ARM_COMPUTE_ERROR_ON(_target.size() != _reference.size());
     // Validate output
@@ -98,7 +100,7 @@ TEST_SUITE_END() // F32
 
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(F16)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEUnstackFixture<half>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * framework::dataset::make("DataType", { DataType::F16 }))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEUnstackFixture<half>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * make("DataType", { DataType::F16 }))
 {
     ARM_COMPUTE_ERROR_ON(_target.size() != _reference.size());
 
@@ -120,7 +122,7 @@ TEST_SUITE_END() // F16
 #endif           /* ARM_COMPUTE_ENABLE_FP16 */
 
 TEST_SUITE(Quantized)
-FIXTURE_DATA_TEST_CASE(RunSmall, NEUnstackFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * framework::dataset::make("DataType", { DataType::QASYMM8 }))
+FIXTURE_DATA_TEST_CASE(RunSmall, NEUnstackFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * make("DataType", { DataType::QASYMM8 }))
 {
     ARM_COMPUTE_ERROR_ON(_target.size() != _reference.size());
     // Validate output

--- a/tests/validation/NEON/WidthConcatenateLayer.cpp
+++ b/tests/validation/NEON/WidthConcatenateLayer.cpp
@@ -39,30 +39,32 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+
 TEST_SUITE(NEON)
 TEST_SUITE(WidthConcatenateLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(
-        framework::dataset::make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
+        make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
                                                   TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching y dimension
                                                   TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching total width
                                                   TensorInfo(TensorShape(16U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(21U, 35U, 5U), 1, DataType::F32)
         }),
-        framework::dataset::make("InputInfo2", {  TensorInfo(TensorShape(24U, 27U, 4U), 1, DataType::F32),
+        make("InputInfo2", {  TensorInfo(TensorShape(24U, 27U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(52U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(52U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(10U, 35U, 5U), 1, DataType::F32)
         }),
-        framework::dataset::make("OutputInfo", {  TensorInfo(TensorShape(47U, 27U, 5U), 1, DataType::F16),
+        make("OutputInfo", {  TensorInfo(TensorShape(47U, 27U, 5U), 1, DataType::F16),
                                                   TensorInfo(TensorShape(75U, 12U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(11U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(32U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(31U, 35U, 5U), 1, DataType::F32)
         }),
-        framework::dataset::make("Expected", { false, false, false, true, true })
+        make("Expected", { false, false, false, true, true })
         ),
         input_info1, input_info2, output_info,expected)
 {
@@ -88,17 +90,17 @@ using NEWidthConcatenateLayerFixture = ConcatenateLayerValidationFixture<Tensor,
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEWidthConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                   framework::dataset::make("DataType",
+                                                                                                                   make("DataType",
                                                                                                                            DataType::F32),
-                                                                                                                   framework::dataset::make("Axis", 0)))
+                                                                                                                   make("Axis", 0)))
 
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, NEWidthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, NEWidthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                  DataType::F32),
-                                                                                                                 framework::dataset::make("Axis", 0)))
+                                                                                                                 make("Axis", 0)))
 
 {
     // Validate output
@@ -110,9 +112,9 @@ TEST_SUITE_END()
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEWidthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("Axis", 0)))
+                                                                                                                     make("Axis", 0)))
 
 {
     // Validate output
@@ -122,9 +124,9 @@ TEST_SUITE_END()
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, NEWidthConcatenateLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                    framework::dataset::make("DataType",
+                                                                                                                    make("DataType",
                                                                                                                             DataType::QASYMM8_SIGNED),
-                                                                                                                    framework::dataset::make("Axis", 0)))
+                                                                                                                    make("Axis", 0)))
 
 {
     // Validate output


### PR DESCRIPTION
Updated NEON validation tests to use the local make alias instead of fully qualifying framework::dataset::make, streamlining dataset setup in the permute, fill-border, dequantization layer, arithmetic addition, elementwise kernel selection, direct convolution layer, and convolution layer suites

Added the missing <type_traits> include in JoinDataset.h and implemented a variadic concat overload so tests can join multiple datasets without nested calls.

Change-Id: I5b441c5f19a7fffc8f4763ed32cc2406d49cd4c5