### PR TITLE
refactor: Flatten nested concat usage in validation/CL and CPP.

### DIFF
--- a/tests/validation/CL/AbsLayer.cpp
+++ b/tests/validation/CL/AbsLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Arm Limited.
+ * Copyright (c) 2019, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(AbsLayer)
 template <typename T>
@@ -47,13 +48,13 @@ using CLAbsLayerFixture = AbsValidationFixture<CLTensor, CLAccessor, CLAbsLayer,
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLAbsLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLAbsLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLAbsLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLAbsLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     // Validate output
@@ -62,13 +63,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLAbsLayerFixture<half>, framework::DatasetMode
 
 TEST_SUITE_END() // FP16
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLAbsLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLAbsLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLAbsLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLAbsLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output

--- a/tests/validation/CL/ActivationLayer.cpp
+++ b/tests/validation/CL/ActivationLayer.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_qsymm16(1.f);
@@ -81,14 +82,14 @@ AbsoluteTolerance<float> tolerance(ActivationLayerInfo::ActivationFunction activ
 }
 
 /** CNN data types */
-const auto CNNDataTypes = framework::dataset::make("DataType",
+const auto CNNDataTypes = make("DataType",
 {
     DataType::F16,
     DataType::F32
 });
 
 /** Input data sets. */
-const auto ActivationDataset = combine(framework::dataset::make("InPlace", { false, true }), datasets::ActivationFunctions(), framework::dataset::make("AlphaBeta", { 0.5f, 1.f }));
+const auto ActivationDataset = combine(make("InPlace", { false, true }), datasets::ActivationFunctions(), make("AlphaBeta", { 0.5f, 1.f }));
 
 } // namespace
 
@@ -96,7 +97,7 @@ TEST_SUITE(CL)
 TEST_SUITE(ActivationLayer)
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
@@ -106,7 +107,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QSYMM16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QSYMM16), // Invalid activation function for QSYMM16
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8),
@@ -116,7 +117,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QSYMM16, QuantizationInfo(1.f / 32768.f, 0)),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QSYMM16, QuantizationInfo(1.f / 32768.f, 0)),
                                                      }),
-               framework::dataset::make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
+               make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU),
@@ -126,7 +127,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::SQRT),
                                                           }),
-               framework::dataset::make("Expected", { false, true, true, true, false, false, true, true, false })),
+               make("Expected", { false, true, true, true, false, false, true, true, false })),
                input_info, output_info, act_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLActivationLayer::validate(&input_info.clone()->set_is_resizable(false), (output_info.total_size() == 0) ? nullptr : &output_info.clone()->set_is_resizable(false), act_info)) == expected, framework::LogLevel::ERRORS);
@@ -144,7 +145,7 @@ TEST_SUITE(Float)
 TEST_SUITE(FP16)
 /** [CLActivationLayer Test snippet] **/
 FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), ActivationDataset,
-                                                                                                      framework::dataset::make("DataType",
+                                                                                                      make("DataType",
                                                                                                               DataType::F16)))
 {
     // Validate output
@@ -154,7 +155,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerFixture<half>, framework::Data
 TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), ActivationDataset, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), ActivationDataset, make("DataType",
                                                                                                        DataType::F32)))
 {
     // Validate output
@@ -166,22 +167,22 @@ TEST_SUITE_END() // Float
 template <typename T>
 using CLActivationLayerQuantizedFixture = ActivationValidationQuantizedFixture<CLTensor, CLAccessor, CLActivationLayer, T>;
 
-const auto QuantizedActivationDataset8 = combine(framework::dataset::make("InPlace", { false }),
+const auto QuantizedActivationDataset8 = combine(make("InPlace", { false }),
                                                          concat(datasets::ActivationFunctionsQuantized(),
-                                                                framework::dataset::make("ActivationFunction",
+                                                                make("ActivationFunction",
 { ActivationLayerInfo::ActivationFunction::HARD_SWISH, ActivationLayerInfo::ActivationFunction::LEAKY_RELU })),
-framework::dataset::make("AlphaBeta", { 0.5f, 1.f }));
+make("AlphaBeta", { 0.5f, 1.f }));
 
-const auto QuantizedActivationDataset16 = combine(framework::dataset::make("InPlace", { false }),
+const auto QuantizedActivationDataset16 = combine(make("InPlace", { false }),
                                                           datasets::ActivationFunctionsQuantized(),
-                                                  framework::dataset::make("AlphaBeta", { 0.5f, 1.f }));
+                                                  make("AlphaBeta", { 0.5f, 1.f }));
 
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), QuantizedActivationDataset8,
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::QASYMM8),
-                                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
+                                                                                                                  make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance(_function, _data_type));
@@ -189,9 +190,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerQuantizedFixture<uint8_t>, fra
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), QuantizedActivationDataset8,
-                                                                                                                 framework::dataset::make("DataType",
+                                                                                                                 make("DataType",
                                                                                                                          DataType::QASYMM8_SIGNED),
-                                                                                                                 framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 10.0f) })))
+                                                                                                                 make("QuantizationInfo", { QuantizationInfo(0.1f, 10.0f) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance(_function, _data_type));
@@ -199,9 +200,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerQuantizedFixture<int8_t>, fram
 TEST_SUITE_END() // QASYMM8_SIGNED
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLActivationLayerQuantizedFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), QuantizedActivationDataset16,
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::QSYMM16),
-                                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 32768.f, 0) })))
+                                                                                                                  make("QuantizationInfo", { QuantizationInfo(1.f / 32768.f, 0) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qsymm16);

--- a/tests/validation/CL/ArgMinMax.cpp
+++ b/tests/validation/CL/ArgMinMax.cpp
@@ -37,9 +37,10 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-const auto ArgMinMaxSmallDataset = framework::dataset::make("Shape",
+const auto ArgMinMaxSmallDataset = make("Shape",
 {
     TensorShape{ 1U, 7U, 1U, 3U },
     TensorShape{ 3U, 1U, 3U, 2U },
@@ -51,7 +52,7 @@ const auto ArgMinMaxSmallDataset = framework::dataset::make("Shape",
     TensorShape{ 2560, 2U, 2U, 2U },
 });
 
-const auto ArgMinMaxSmallDatasetAxis0 = framework::dataset::make("Shape",
+const auto ArgMinMaxSmallDatasetAxis0 = make("Shape",
 {
     TensorShape{ 1U, 5U },
     TensorShape{ 2U, 3U },
@@ -63,11 +64,11 @@ const auto ArgMinMaxSmallDatasetAxis0 = framework::dataset::make("Shape",
     TensorShape{ 15U, 2U },
 });
 
-const auto OpsDataset   = framework::dataset::make("Operation", { ReductionOperation::ARG_IDX_MIN, ReductionOperation::ARG_IDX_MAX });
-const auto AxisDataset  = framework::dataset::make("Axis", { 0, 1, 2, 3 });
-const auto QInfoDataset = framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) });
+const auto OpsDataset   = make("Operation", { ReductionOperation::ARG_IDX_MIN, ReductionOperation::ARG_IDX_MAX });
+const auto AxisDataset  = make("Axis", { 0, 1, 2, 3 });
+const auto QInfoDataset = make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) });
 
-const auto ArgMinMaxLargeDataset = framework::dataset::make("Shape",
+const auto ArgMinMaxLargeDataset = make("Shape",
 { TensorShape{ 517U, 123U, 13U, 2U } });
 } // namespace
 TEST_SUITE(CL)
@@ -75,21 +76,21 @@ TEST_SUITE(ArgMinMax)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid output shape
                                                 TensorInfo(TensorShape(32U, 16U, 16U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 16U, 16U, 2U), 1, DataType::F32), // Invalid operation
                                                 TensorInfo(TensorShape(32U, 16U, 16U, 2U), 1, DataType::F32) // Not allowed keeping the dimension
         }),
-        framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),
+        make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::S32),
                                                  TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(32U, 16U, 1U, 2U), 1, DataType::U32)
         }),
-        framework::dataset::make("Axis", { 4, 0, 2, 0, 2 }),
-        framework::dataset::make("Operation", { ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::MEAN_SUM, ReductionOperation::ARG_IDX_MAX }),
-        framework::dataset::make("Expected", { false, false, true, false, false })),
+        make("Axis", { 4, 0, 2, 0, 2 }),
+        make("Operation", { ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::ARG_IDX_MAX, ReductionOperation::MEAN_SUM, ReductionOperation::ARG_IDX_MAX }),
+        make("Expected", { false, false, true, false, false })),
         input_info, output_info, axis, operation, expected)
 {
     const Status status = CLArgMinMaxLayer::validate(&input_info.clone()->set_is_resizable(false), axis, &output_info.clone()->set_is_resizable(false), operation);
@@ -111,9 +112,9 @@ FIXTURE_DATA_TEST_CASE(RunSmallAxis0,
                        CLArgMinMaxValidationFixture_S32_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDatasetAxis0,
-                                                       framework::dataset::make("DataTypeIn", DataType::S32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
-                                       framework::dataset::make("Axis", { 0 }),
+                                                       make("DataTypeIn", DataType::S32),
+                                               make("DataTypeOut", DataType::S32),
+                                       make("Axis", { 0 }),
                                OpsDataset))
 {
     // Validate output
@@ -124,8 +125,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLArgMinMaxValidationFixture_S32_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset,
-                                                       framework::dataset::make("DataTypeIn", DataType::S32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::S32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -136,8 +137,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLArgMinMaxValidationFixture_S32_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset,
-                                                       framework::dataset::make("DataTypeIn", DataType::S32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::S32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -153,8 +154,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLArgMinMaxValidationFixture_F16_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset,
-                                                       framework::dataset::make("DataTypeIn", DataType::F16),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F16),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -166,8 +167,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLArgMinMaxValidationFixture_F16_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset,
-                                                       framework::dataset::make("DataTypeIn", DataType::F16),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F16),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -181,8 +182,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLArgMinMaxValidationFixture_F32_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset,
-                                                       framework::dataset::make("DataTypeIn", DataType::F32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -194,8 +195,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall_F32_S64,
                        CLArgMinMaxValidationFixture_F32_S64,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset,
-                                                       framework::dataset::make("DataTypeIn", DataType::F32),
-                                               framework::dataset::make("DataTypeOut", DataType::S64),
+                                                       make("DataTypeIn", DataType::F32),
+                                               make("DataTypeOut", DataType::S64),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -207,8 +208,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLArgMinMaxValidationFixture_F32_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset,
-                                                       framework::dataset::make("DataTypeIn", DataType::F32),
-                                               framework::dataset::make("DataTypeOut", DataType::S32),
+                                                       make("DataTypeIn", DataType::F32),
+                                               make("DataTypeOut", DataType::S32),
                                        AxisDataset,
                                OpsDataset))
 {
@@ -231,8 +232,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLArgMinMaxQuantizedValidationFixture_U8_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset,
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))
@@ -244,8 +245,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLArgMinMaxQuantizedValidationFixture_U8_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset,
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))
@@ -260,8 +261,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLArgMinMaxQuantizedValidationFixture_S8_S32,
                        framework::DatasetMode::PRECOMMIT,
                        combine(ArgMinMaxSmallDataset,
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8_SIGNED),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8_SIGNED),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))
@@ -273,8 +274,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLArgMinMaxQuantizedValidationFixture_S8_S32,
                        framework::DatasetMode::NIGHTLY,
                        combine(ArgMinMaxLargeDataset,
-                                                               framework::dataset::make("DataTypeIn", DataType::QASYMM8_SIGNED),
-                                                       framework::dataset::make("DataTypeOut", DataType::S32),
+                                                               make("DataTypeIn", DataType::QASYMM8_SIGNED),
+                                                       make("DataTypeOut", DataType::S32),
                                                AxisDataset,
                                        OpsDataset,
                                QInfoDataset))

--- a/tests/validation/CL/ArithmeticAddition.cpp
+++ b/tests/validation/CL/ArithmeticAddition.cpp
@@ -41,18 +41,19 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Input data sets **/
-const auto EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto EmptyActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -60,19 +61,19 @@ TEST_SUITE(ArithmeticAddition)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false})),
+               make("Expected", { true, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLArithmeticAddition::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), ConvertPolicy::WRAP)) == expected, framework::LogLevel::ERRORS);
@@ -110,9 +111,9 @@ using CLArithmeticAdditionFixture = ArithmeticAdditionValidationFixture<CLTensor
 
 TEST_SUITE(Integer)
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                   DataType::U8),
-                                                                                                                  framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                  make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                   OutOfPlaceDataSet))
 {
     // Validate output
@@ -121,18 +122,18 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFixture<uint8_t>, framework
 TEST_SUITE_END() // U8
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                   DataType::S16),
-                                                                                                                  framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                  make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                   OutOfPlaceDataSet))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLArithmeticAdditionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLArithmeticAdditionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                         DataType::S16),
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                 OutOfPlaceDataSet))
 {
     // Validate output
@@ -147,11 +148,11 @@ using CLArithmeticAdditionQuantizedFixture = ArithmeticAdditionValidationQuantiz
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                       make("DataType", DataType::QASYMM8),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -161,11 +162,11 @@ template <typename T>
 using CLArithmeticAdditionBroadcastQuantizedFixture = ArithmeticAdditionValidationQuantizedBroadcastFixture<CLTensor, CLAccessor, CLArithmeticAddition, T>;
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLArithmeticAdditionBroadcastQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapesBroadcast(),
-                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                               framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                       make("DataType", DataType::QASYMM8),
+                                                               make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                OutOfPlaceDataSet))
 {
     // Validate output
@@ -173,11 +174,11 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLArithmeticAdditionBroadcastQuantized
 }
 FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInPlace, CLArithmeticAdditionBroadcastQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::TinyShapesBroadcastInplace(),
-                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                               framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 255.f, 10) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(1.f / 255.f, 10) }),
-                                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 10) }),
+                                                                       make("DataType", DataType::QASYMM8),
+                                                               make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                       make("Src0QInfo", { QuantizationInfo(1.f / 255.f, 10) }),
+                                               make("Src1QInfo", { QuantizationInfo(1.f / 255.f, 10) }),
+                                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 10) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -186,11 +187,11 @@ FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInPlace, CLArithmeticAdditionBroadcastQua
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 10) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 10) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -199,11 +200,11 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionQuantizedFixture<int8_t>, f
 TEST_SUITE_END() // QASYMM8_SIGNED
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionQuantizedFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QSYMM16),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("DataType", DataType::QSYMM16),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -217,9 +218,9 @@ using CLArithmeticAdditionFloatFixture = ArithmeticAdditionValidationFloatFixtur
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFloatFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFloatFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                       DataType::F16),
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       EmptyActivationFunctionsDataset,
                                                                                                               OutOfPlaceDataSet))
 {
@@ -227,9 +228,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFloatFixture<half>, framewo
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunWithActivation, CLArithmeticAdditionFloatFixture<half>, framework::DatasetMode::ALL, combine(datasets::TinyShapes(),
-                                                                                                                       framework::dataset::make("DataType",
+                                                                                                                       make("DataType",
                                                                                                                                DataType::F16),
-                                                                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                        ActivationFunctionsDataset,
                                                                                                                        OutOfPlaceDataSet))
 {
@@ -240,9 +241,9 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFloatFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::F32),
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      EmptyActivationFunctionsDataset,
                                                                                                                      InPlaceDataSet))
 {
@@ -250,9 +251,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticAdditionFloatFixture<float>, framew
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunWithActivation, CLArithmeticAdditionFloatFixture<float>, framework::DatasetMode::ALL, combine(datasets::TinyShapes(),
-                                                                                                                        framework::dataset::make("DataType",
+                                                                                                                        make("DataType",
                                                                                                                                 DataType::F32),
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                         ActivationFunctionsDataset,
                                                                                                                         OutOfPlaceDataSet))
 {
@@ -260,9 +261,9 @@ FIXTURE_DATA_TEST_CASE(RunWithActivation, CLArithmeticAdditionFloatFixture<float
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLArithmeticAdditionFloatFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLArithmeticAdditionFloatFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                    DataType::F32),
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    EmptyActivationFunctionsDataset,
                                                                                                                    OutOfPlaceDataSet))
 {
@@ -274,8 +275,8 @@ template <typename T>
 using CLArithmeticAdditionBroadcastFloatFixture = ArithmeticAdditionBroadcastValidationFloatFixture<CLTensor, CLAccessor, CLArithmeticAddition, T>;
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLArithmeticAdditionBroadcastFloatFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        EmptyActivationFunctionsDataset,
                        OutOfPlaceDataSet))
 {
@@ -283,8 +284,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLArithmeticAdditionBroadcastFloatFixt
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunWithActivationBroadcast, CLArithmeticAdditionBroadcastFloatFixture<float>, framework::DatasetMode::ALL, combine(datasets::TinyShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        ActivationFunctionsDataset,
                        OutOfPlaceDataSet))
 {
@@ -293,8 +294,8 @@ FIXTURE_DATA_TEST_CASE(RunWithActivationBroadcast, CLArithmeticAdditionBroadcast
 }
 
 FIXTURE_DATA_TEST_CASE(RunLargeBroadcast, CLArithmeticAdditionBroadcastFloatFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        EmptyActivationFunctionsDataset,
                        OutOfPlaceDataSet))
 {

--- a/tests/validation/CL/ArithmeticDivision.cpp
+++ b/tests/validation/CL/ArithmeticDivision.cpp
@@ -41,26 +41,27 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
 RelativeTolerance<float> tolerance_fp16(0.001f);
 
 /** Input data sets **/
-const auto ArithmeticDivisionFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                                   framework::dataset::make("DataType", DataType::F16));
-const auto ArithmeticDivisionFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                                   framework::dataset::make("DataType", DataType::F32));
-const auto ArithmeticDivisionS32Dataset = combine(framework::dataset::make("DataType", DataType::S32), framework::dataset::make("DataType", DataType::S32),
-                                                  framework::dataset::make("DataType", DataType::S32));
-const auto EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo", { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset      = framework::dataset::make("ActivationInfo",
+const auto ArithmeticDivisionFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                                   make("DataType", DataType::F16));
+const auto ArithmeticDivisionFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                                   make("DataType", DataType::F32));
+const auto ArithmeticDivisionS32Dataset = combine(make("DataType", DataType::S32), make("DataType", DataType::S32),
+                                                  make("DataType", DataType::S32));
+const auto EmptyActivationFunctionsDataset = make("ActivationInfo", { ActivationLayerInfo() });
+const auto ActivationFunctionsDataset      = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -68,22 +69,22 @@ TEST_SUITE(ArithmeticDivision)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false})),
+               make("Expected", { true, false, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLArithmeticDivision::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);

--- a/tests/validation/CL/ArithmeticSubtraction.cpp
+++ b/tests/validation/CL/ArithmeticSubtraction.cpp
@@ -41,18 +41,19 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Input data sets **/
-const auto EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto EmptyActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -60,19 +61,19 @@ TEST_SUITE(ArithmeticSubtraction)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false})),
+               make("Expected", { true, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLArithmeticSubtraction::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), ConvertPolicy::WRAP)) == expected, framework::LogLevel::ERRORS);
@@ -137,9 +138,9 @@ using CLArithmeticSubtractionFixture = ArithmeticSubtractionValidationFixture<CL
 
 TEST_SUITE(Integer)
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                        DataType::U8),
-                                                                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                OutOfPlaceDataSet))
 {
     // Validate output
@@ -148,18 +149,18 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFixture<uint8_t>, framew
 TEST_SUITE_END() // U8
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                      DataType::S16),
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      OutOfPlaceDataSet))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLArithmeticSubtractionFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                                    DataType::S16),
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    OutOfPlaceDataSet))
 {
     // Validate output
@@ -174,22 +175,22 @@ using CLArithmeticSubtractionQuantizedFixture = ArithmeticSubtractionValidationQ
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                       make("DataType", DataType::QASYMM8),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunTinyInPlace, CLArithmeticSubtractionQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::TinyShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                       make("DataType", DataType::QASYMM8),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                       make("Src1QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                       make("OutQInfo", { QuantizationInfo(5.f / 255.f, 20) }),
                        InPlaceDataSet))
 {
     // Validate output
@@ -198,11 +199,11 @@ FIXTURE_DATA_TEST_CASE(RunTinyInPlace, CLArithmeticSubtractionQuantizedFixture<u
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 10) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 10) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -211,11 +212,11 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionQuantizedFixture<int8_t>
 TEST_SUITE_END() // QASYMM8_SIGNED
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionQuantizedFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                       framework::dataset::make("DataType", DataType::QSYMM16),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("DataType", DataType::QSYMM16),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -229,9 +230,9 @@ using CLArithmeticSubtractionFloatFixture = ArithmeticSubtractionValidationFloat
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFloatFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFloatFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                  DataType::F16),
-                                                                                                                 framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                 make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                  EmptyActivationFunctionsDataset,
                                                                                                                  OutOfPlaceDataSet))
 {
@@ -239,8 +240,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFloatFixture<half>, fram
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunWithActivation, CLArithmeticSubtractionFloatFixture<half>, framework::DatasetMode::ALL, combine(datasets::TinyShapes(),
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F16),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        ActivationFunctionsDataset,
                        InPlaceDataSet))
 {
@@ -251,8 +252,8 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFloatFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
-                                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                                        framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                        make("DataType", DataType::F32),
+                                                                                                                        make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                         EmptyActivationFunctionsDataset,
                                                                                                                         OutOfPlaceDataSet))
 {
@@ -260,8 +261,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLArithmeticSubtractionFloatFixture<float>, fra
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunWithActivation, CLArithmeticSubtractionFloatFixture<float>, framework::DatasetMode::ALL, combine(datasets::TinyShapes(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        ActivationFunctionsDataset,
                        InPlaceDataSet))
 {
@@ -270,8 +271,8 @@ FIXTURE_DATA_TEST_CASE(RunWithActivation, CLArithmeticSubtractionFloatFixture<fl
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLArithmeticSubtractionFloatFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(),
-                                                                                                                      framework::dataset::make("DataType", DataType::F32),
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("DataType", DataType::F32),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       EmptyActivationFunctionsDataset,
                                                                                                                       OutOfPlaceDataSet))
 {
@@ -283,8 +284,8 @@ template <typename T>
 using CLArithmeticSubtractionBroadcastFloatFixture = ArithmeticSubtractionBroadcastValidationFloatFixture<CLTensor, CLAccessor, CLArithmeticSubtraction, T>;
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLArithmeticSubtractionBroadcastFloatFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        EmptyActivationFunctionsDataset,
                        OutOfPlaceDataSet))
 {
@@ -293,8 +294,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLArithmeticSubtractionBroadcastFloatF
 }
 FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInplace, CLArithmeticSubtractionBroadcastFloatFixture<float>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::TinyShapesBroadcastInplace(),
-                                                       framework::dataset::make("DataType", DataType::F32),
-                                               framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                       make("DataType", DataType::F32),
+                                               make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                        EmptyActivationFunctionsDataset,
                                InPlaceDataSet))
 {
@@ -302,8 +303,8 @@ FIXTURE_DATA_TEST_CASE(RunTinyBroadcastInplace, CLArithmeticSubtractionBroadcast
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunWithActivationBroadcast, CLArithmeticSubtractionBroadcastFloatFixture<float>, framework::DatasetMode::ALL, combine(datasets::TinyShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        ActivationFunctionsDataset,
                        OutOfPlaceDataSet))
 {
@@ -312,8 +313,8 @@ FIXTURE_DATA_TEST_CASE(RunWithActivationBroadcast, CLArithmeticSubtractionBroadc
 }
 
 FIXTURE_DATA_TEST_CASE(RunLargeBroadcast, CLArithmeticSubtractionBroadcastFloatFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapesBroadcast(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                       make("DataType", DataType::F32),
+                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                        EmptyActivationFunctionsDataset,
                        OutOfPlaceDataSet))
 {

--- a/tests/validation/CL/BatchConcatenateLayer.cpp
+++ b/tests/validation/CL/BatchConcatenateLayer.cpp
@@ -39,30 +39,31 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(BatchConcatenateLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32), // Mismatching data type input/output
                                                   TensorInfo(TensorShape(20U, 27U, 4U, 4U), 1, DataType::F32), // Mismatching x dimension
                                                   TensorInfo(TensorShape(23U, 26U, 4U, 3U), 1, DataType::F32), // Mismatching y dim
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 3U), 1, DataType::F32), // Mismatching z dim
                                                   TensorInfo(TensorShape(16U, 27U, 3U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32),
+        make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 3U, 3U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 3U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F16),
+        make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 5U, 4U), 1, DataType::F16),
                                                   TensorInfo(TensorShape(23U, 12U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 20U, 4U, 3U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 3U, 12U), 1, DataType::F32)
         }),
-        framework::dataset::make("Expected", { false, false, false, false, true })),
+        make("Expected", { false, false, false, false, true })),
         input_info1, input_info2, output_info,expected)
 {
     std::vector<TensorInfo> inputs_vector_info;
@@ -89,17 +90,17 @@ using CLBatchConcatenateLayerFixture = ConcatenateLayerValidationFixture<CLTenso
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchConcatenateLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::F16),
-                                                                                                                  framework::dataset::make("Axis", 3)))
+                                                                                                                  make("Axis", 3)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large3DShapes(), datasets::Small4DShapes()),
-                                                                                                                        framework::dataset::make("DataType",
+                                                                                                                        make("DataType",
                                                                                                                                 DataType::F16),
-                                                                                                                framework::dataset::make("Axis", 3)))
+                                                                                                                make("Axis", 3)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -108,16 +109,16 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                   framework::dataset::make("DataType",
+                                                                                                                   make("DataType",
                                                                                                                            DataType::F32),
-                                                                                                                   framework::dataset::make("Axis", 3)))
+                                                                                                                   make("Axis", 3)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                  DataType::F32),
-                                                                                                                 framework::dataset::make("Axis", 3)))
+                                                                                                                 make("Axis", 3)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -128,16 +129,16 @@ TEST_SUITE_END()
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("Axis", 3)))
+                                                                                                                     make("Axis", 3)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                    DataType::QASYMM8),
-                                                                                                                   framework::dataset::make("Axis", 3)))
+                                                                                                                   make("Axis", 3)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/BatchNormalizationLayer.cpp
+++ b/tests/validation/CL/BatchNormalizationLayer.cpp
@@ -46,23 +46,24 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float>           rel_tolerance_f32(0.05f);   /**< Tolerance value for comparing reference's output against implementation's output for DataType::F32 */
 constexpr AbsoluteTolerance<float> abs_tolerance_f32(0.0001f); /**< Tolerance value for comparing reference's output against implementation's output for DataType::F32 */
 constexpr AbsoluteTolerance<float> tolerance_f16(0.02f);       /**< Tolerance value for comparing reference's output against implementation's output for DataType::F16 */
-const auto                         act_infos = framework::dataset::make("ActivationInfo",
+const auto                         act_infos = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 6.f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 8.f, 2.f),
 });
 
-const auto common_fusion_dataset = combine(framework::dataset::make("UseBias",
+const auto common_fusion_dataset = combine(make("UseBias",
 { false, true }),
-framework::dataset::make("UseBeta", { false, true }),
-framework::dataset::make("UseGamma", { false, true }),
-framework::dataset::make("Epsilon", { 0.001f }));
+make("UseBeta", { false, true }),
+make("UseGamma", { false, true }),
+make("Epsilon", { 0.001f }));
 
 } // namespace
 
@@ -74,7 +75,7 @@ using CLBatchNormalizationLayerFixture = BatchNormalizationLayerValidationFixtur
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),    // Window shrink
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Mismatching data types
@@ -82,7 +83,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Unsupported fused activation
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),    // Fused activation's a < b
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
@@ -90,7 +91,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
+               make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F16),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F32),
@@ -98,7 +99,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                      TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                    }),
-                framework::dataset::make("ActivationLayerInfo",{ ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
+                make("ActivationLayerInfo",{ ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 6.f),
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 6.f),
@@ -106,7 +107,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::TANH),
                                                      ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 2.f, 6.f),
                                                    }),
-               framework::dataset::make("Expected", { true, false, false, false, false, false, false})),
+               make("Expected", { true, false, false, false, false, false, false})),
                input_info, output_info, mvbg_info, act_info, expected)
 {
     const auto &mean_info = mvbg_info;
@@ -122,10 +123,10 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(Random, CLBatchNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomBatchNormalizationLayerDataset(),
-                                                                                                                   framework::dataset::make("UseBeta", { false, true }), framework::dataset::make("UseGamma", { false, true }),
+                                                                                                                   make("UseBeta", { false, true }), make("UseGamma", { false, true }),
                                                                                                                    act_infos,
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, abs_tolerance_f32, 0);
@@ -134,11 +135,11 @@ TEST_SUITE_END() //FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(Random, CLBatchNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomBatchNormalizationLayerDataset(),
-                                                                                                                  framework::dataset::make("UseBeta", { false, true }), framework::dataset::make("UseGamma", { false, true }),
-                                                                                                                  framework::dataset::make("ActivationInfo",
+                                                                                                                  make("UseBeta", { false, true }), make("UseGamma", { false, true }),
+                                                                                                                  make("ActivationInfo",
                                                                                                                           ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 6.f)),
-                                                                                                                  framework::dataset::make("DataType", DataType::F16),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                  make("DataType", DataType::F16),
+                                                                                                                  make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, 0);
@@ -151,15 +152,15 @@ TEST_SUITE_END() // BatchNormalizationLayer
 TEST_SUITE(BatchNormalizationLayerFusion)
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Weights", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),      // Valid
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Weights", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),      // Valid
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 1U), 1, DataType::F32),    // Invalid mean/var/beta/gamma shape
                                                      }),
-               framework::dataset::make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
+               make("MVBGInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(2U), 1, DataType::F16),
                                                      TensorInfo(TensorShape(5U), 1, DataType::F32),
                                                    }),
-               framework::dataset::make("Expected", { true, false, false})),
+               make("Expected", { true, false, false})),
                weights_info, mvbg_info, expected)
 {
     const auto &weights_in_info = weights_info;
@@ -186,16 +187,16 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchNormalizationLayerFusionFixture<float>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallConvolutionLayerReducedDataset(), common_fusion_dataset,
-                                       framework::dataset::make("DataType", DataType::F32),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                       make("DataType", DataType::F32),
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, rel_tolerance_f32, 0.f, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchNormalizationLayerFusionFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::SmallConvolutionLayerDataset(), common_fusion_dataset,
-                                       framework::dataset::make("DataType", DataType::F32),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                       make("DataType", DataType::F32),
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, rel_tolerance_f32, 0.f, abs_tolerance_f32);

--- a/tests/validation/CL/BatchToSpaceLayer.cpp
+++ b/tests/validation/CL/BatchToSpaceLayer.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(BatchToSpaceLayer)
 
@@ -50,7 +51,7 @@ using CLBatchToSpaceLayerFixture = BatchToSpaceLayerValidationFixture<CLTensor, 
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
+DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Supported: blockx != blocky && blockx > blocky
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Supported: blockx != blocky && blocky > blockx
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),     // Invalid: Mismatching data types
@@ -61,12 +62,12 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(framework::datas
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Supported: correct tensor shape with cropping
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 16U), 1, DataType::F32),    // Invalid tensor shape with cropping
                                                      }),
-               framework::dataset::make("BlockShapeX", { 2, 4, 2, 2, 2, 2, 2, 2, 2, 2 }),
-               framework::dataset::make("BlockShapeY", { 2, 2, 4, 2, -2, 2, 2, 2, 2, 2 }),
-               framework::dataset::make("CropInfo", {
+               make("BlockShapeX", { 2, 4, 2, 2, 2, 2, 2, 2, 2, 2 }),
+               make("BlockShapeY", { 2, 2, 4, 2, -2, 2, 2, 2, 2, 2 }),
+               make("CropInfo", {
                 CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{}, CropInfo{3, 2, 1, 3}, CropInfo{3, 2, 1, 3}
                }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 16U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 32U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F16),
@@ -77,7 +78,7 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(framework::datas
                                                        TensorInfo(TensorShape(27, 12U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, true, true, false, false, false, false, false, true, false})),
+               make("Expected", { true, true, true, false, false, false, false, false, true, false})),
                input_info, block_shape_x, block_shape_y, crop_info, output_info, expected)
 {
     bool has_error = bool(CLBatchToSpaceLayer::validate(&input_info.clone()->set_is_resizable(false), block_shape_x, block_shape_y, &output_info.clone()->set_is_resizable(false), crop_info));
@@ -88,26 +89,26 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(framework::datas
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                        DataType::F32),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallWithCropping, CLBatchToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), framework::dataset::make("DataType",
+                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), make("DataType",
                                                                                                                        DataType::F32),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                      DataType::F32),
-                                                                                                             framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                             make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -115,26 +116,26 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchToSpaceLayerFixture<float>, framework::D
 TEST_SUITE_END()
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                       DataType::F16),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallWithCropping, CLBatchToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), framework::dataset::make("DataType",
+                       combine(datasets::SmallBatchToSpaceLayerWithCroppingDataset(), make("DataType",
                                                                                                                        DataType::F16),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLBatchToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeBatchToSpaceLayerDataset(), make("DataType",
                                                                                                                     DataType::F16),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/BitwiseAnd.cpp
+++ b/tests/validation/CL/BitwiseAnd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Arm Limited.
+ * Copyright (c) 2017-2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,13 +40,14 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(BitwiseAnd)
 
 template <typename T>
 using CLBitwiseAndFixture = BitwiseAndValidationFixture<CLTensor, CLAccessor, CLBitwiseAnd, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseAndFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseAndFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/CL/BitwiseNot.cpp
+++ b/tests/validation/CL/BitwiseNot.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Arm Limited.
+ * Copyright (c) 2017-2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,13 +40,14 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(BitwiseNot)
 
 template <typename T>
 using CLBitwiseNotFixture = BitwiseNotValidationFixture<CLTensor, CLAccessor, CLBitwiseNot, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/CL/BitwiseOr.cpp
+++ b/tests/validation/CL/BitwiseOr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Arm Limited.
+ * Copyright (c) 2017-2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,13 +40,14 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(BitwiseOr)
 
 template <typename T>
 using CLBitwiseOrFixture = BitwiseOrValidationFixture<CLTensor, CLAccessor, CLBitwiseOr, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseOrFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseOrFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                    DataType::U8)))
 {
     // Validate output

--- a/tests/validation/CL/BitwiseXor.cpp
+++ b/tests/validation/CL/BitwiseXor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Arm Limited.
+ * Copyright (c) 2017-2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,13 +40,14 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(BitwiseXor)
 
 template <typename T>
 using CLBitwiseXorFixture = BitwiseXorValidationFixture<CLTensor, CLAccessor, CLBitwiseXor, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseXorFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLBitwiseXorFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/CL/BoundingBoxTransform.cpp
+++ b/tests/validation/CL/BoundingBoxTransform.cpp
@@ -37,6 +37,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> relative_tolerance_f32(0.01f);
@@ -49,7 +50,7 @@ constexpr AbsoluteTolerance<uint16_t> tolerance_qasymm16(1);
 
 // *INDENT-OFF*
 // clang-format off
-const auto BboxInfoDataset = framework::dataset::make("BboxInfo", { BoundingBoxTransformInfo(20U, 20U, 2U, true),
+const auto BboxInfoDataset = make("BboxInfo", { BoundingBoxTransformInfo(20U, 20U, 2U, true),
                                                                     BoundingBoxTransformInfo(128U, 128U, 4U, true),
                                                                     BoundingBoxTransformInfo(800U, 600U, 1U, false),
                                                                     BoundingBoxTransformInfo(800U, 600U, 2U, true, { { 1.0, 0.5, 1.5, 2.0 } }),
@@ -57,7 +58,7 @@ const auto BboxInfoDataset = framework::dataset::make("BboxInfo", { BoundingBoxT
                                                                     BoundingBoxTransformInfo(800U, 600U, 4U, false, { { 1.0, 0.5, 1.5, 2.0 } }, true)
                                                                   });
 
-const auto DeltaDataset = framework::dataset::make("DeltasShape", { TensorShape(36U, 1U),
+const auto DeltaDataset = make("DeltasShape", { TensorShape(36U, 1U),
                                                                     TensorShape(36U, 2U),
                                                                     TensorShape(36U, 2U),
                                                                     TensorShape(40U, 1U),
@@ -74,30 +75,30 @@ TEST_SUITE(BBoxTransform)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("BoxesInfo", { TensorInfo(TensorShape(4U, 128U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("BoxesInfo", { TensorInfo(TensorShape(4U, 128U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 128U), 1, DataType::F32), // Wrong number of box fields
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F16), // Wrong data type
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F32), // Wrong number of classes
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F32),  // Deltas and predicted boxes have different dimensions
                                                        TensorInfo(TensorShape(4U, 128U), 1, DataType::F32)}),  // Scaling is zero
-               framework::dataset::make("PredBoxesInfo",{ TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
+               make("PredBoxesInfo",{ TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(127U, 128U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 100U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 100U), 1, DataType::F32),
                                                           TensorInfo(TensorShape(128U, 128U), 1, DataType::F32)}),
-               framework::dataset::make("DeltasInfo", { TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
+               make("DeltasInfo", { TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(127U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 100U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 128U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(128U, 128U), 1, DataType::F32)}),
-               framework::dataset::make("BoundingBoxTransofmInfo", { BoundingBoxTransformInfo(800.f, 600.f, 1.f),
+               make("BoundingBoxTransofmInfo", { BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 1.f),
                                                                      BoundingBoxTransformInfo(800.f, 600.f, 0.f)}),
-               framework::dataset::make("Expected", { true, false, false, false, false, false})),
+               make("Expected", { true, false, false, false, false, false})),
                boxes_info, pred_boxes_info, deltas_info, bbox_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLBoundingBoxTransform::validate(&boxes_info.clone()->set_is_resizable(true), &pred_boxes_info.clone()->set_is_resizable(true), &deltas_info.clone()->set_is_resizable(true), bbox_info)) == expected, framework::LogLevel::ERRORS);
@@ -111,7 +112,7 @@ using CLBoundingBoxTransformFixture = BoundingBoxTransformFixture<CLTensor, CLAc
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(BoundingBox, CLBoundingBoxTransformFixture<float>, framework::DatasetMode::ALL,
-                       combine(DeltaDataset, BboxInfoDataset, framework::dataset::make("DataType", { DataType::F32 })))
+                       combine(DeltaDataset, BboxInfoDataset, make("DataType", { DataType::F32 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, relative_tolerance_f32, 0.f, absolute_tolerance_f32);
@@ -120,7 +121,7 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(BoundingBox, CLBoundingBoxTransformFixture<half>, framework::DatasetMode::ALL,
-                       combine(DeltaDataset, BboxInfoDataset, framework::dataset::make("DataType", { DataType::F16 })))
+                       combine(DeltaDataset, BboxInfoDataset, make("DataType", { DataType::F16 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, relative_tolerance_f16, 0.03f, absolute_tolerance_f16);
@@ -134,8 +135,8 @@ using CLBoundingBoxTransformQuantizedFixture = BoundingBoxTransformQuantizedFixt
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM16)
 FIXTURE_DATA_TEST_CASE(BoundingBox, CLBoundingBoxTransformQuantizedFixture<uint16_t>, framework::DatasetMode::ALL,
-                       combine(DeltaDataset, BboxInfoDataset, framework::dataset::make("DataType", { DataType::QASYMM16 }),
-                               framework::dataset::make("DeltasQuantInfo", { QuantizationInfo(1.f / 255.f, 127) })))
+                       combine(DeltaDataset, BboxInfoDataset, make("DataType", { DataType::QASYMM16 }),
+                               make("DeltasQuantInfo", { QuantizationInfo(1.f / 255.f, 127) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm16);

--- a/tests/validation/CL/ChannelShuffle.cpp
+++ b/tests/validation/CL/ChannelShuffle.cpp
@@ -40,28 +40,29 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(ChannelShuffle)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Invalid num groups
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Invalid num groups
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::U8),  // Mismatching data_type
                                                        TensorInfo(TensorShape(4U, 5U, 4U), 1, DataType::F32),  // Mismatching shapes
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Num groups == channels
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // (channels % num_groups) != 0
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),  // Valid
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U, 4U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("NumGroups",{ 1, 2, 2, 4, 3, 2,
+               make("NumGroups",{ 1, 2, 2, 4, 3, 2,
                                                      }),
-               framework::dataset::make("Expected", { false, false, false, false, false, true})),
+               make("Expected", { false, false, false, false, false, true})),
                input_info, output_info, num_groups, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLChannelShuffleLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), num_groups)) == expected, framework::LogLevel::ERRORS);
@@ -74,16 +75,16 @@ using CLChannelShuffleLayerFixture = ChannelShuffleLayerValidationFixture<CLTens
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLChannelShuffleLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomChannelShuffleLayerDataset(),
-                                                                                                                   framework::dataset::make("DataType", DataType::U8),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::U8),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLChannelShuffleLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomChannelShuffleLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType",
+                                                                                                                 make("DataType",
                                                                                                                          DataType::U8),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -93,17 +94,17 @@ TEST_SUITE_END()
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLChannelShuffleLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomChannelShuffleLayerDataset(),
-                                                                                                                        framework::dataset::make("DataType",
+                                                                                                                        make("DataType",
                                                                                                                                 DataType::F16),
-                                                                                                                framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLChannelShuffleLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomChannelShuffleLayerDataset(),
-                                                                                                                      framework::dataset::make("DataType",
+                                                                                                                      make("DataType",
                                                                                                                               DataType::F16),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -112,17 +113,17 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLChannelShuffleLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallRandomChannelShuffleLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType",
+                                                                                                                 make("DataType",
                                                                                                                          DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLChannelShuffleLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeRandomChannelShuffleLayerDataset(),
-                                                                                                                       framework::dataset::make("DataType",
+                                                                                                                       make("DataType",
                                                                                                                                DataType::F32),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/Col2Im.cpp
+++ b/tests/validation/CL/Col2Im.cpp
@@ -37,6 +37,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Col2Im)
 
@@ -101,11 +102,11 @@ using ClCol2ImFixture = Col2ImOpValidationFixture<CLTensor, CLAccessor, ClCol2Im
 FIXTURE_DATA_TEST_CASE(FP32,
                        ClCol2ImFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(8U, 16U, 3U, 1U), TensorShape(17U, 16U, 3U, 1U), TensorShape(7U, 16U, 3U, 1U) }),
-                                                   framework::dataset::make("ConvolvedWidth", 4),
-                                               framework::dataset::make("ConvolvedHeight", 4),
-                                       framework::dataset::make("Groups", { 1, 3 }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                       combine(make("InputShape", { TensorShape(8U, 16U, 3U, 1U), TensorShape(17U, 16U, 3U, 1U), TensorShape(7U, 16U, 3U, 1U) }),
+                                                   make("ConvolvedWidth", 4),
+                                               make("ConvolvedHeight", 4),
+                                       make("Groups", { 1, 3 }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -126,11 +127,11 @@ FIXTURE_DATA_TEST_CASE(FP32,
 FIXTURE_DATA_TEST_CASE(F16,
                        ClCol2ImFixture<half>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(17U, 16U, 3U, 1U)),
-                                                   framework::dataset::make("ConvolvedWidth", 4),
-                                               framework::dataset::make("ConvolvedHeight", 4),
-                                       framework::dataset::make("Groups", 3),
-                               framework::dataset::make("DataType", DataType::F16)))
+                       combine(make("InputShape", TensorShape(17U, 16U, 3U, 1U)),
+                                                   make("ConvolvedWidth", 4),
+                                               make("ConvolvedHeight", 4),
+                                       make("Groups", 3),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -151,11 +152,11 @@ FIXTURE_DATA_TEST_CASE(F16,
 FIXTURE_DATA_TEST_CASE(QASYMM8,
                        ClCol2ImFixture<uint8_t>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(17U, 16U, 3U, 1U)),
-                                                   framework::dataset::make("ConvolvedWidth", 4),
-                                               framework::dataset::make("ConvolvedHeight", 4),
-                                       framework::dataset::make("Groups", 3),
-                               framework::dataset::make("DataType", DataType::QASYMM8)))
+                       combine(make("InputShape", TensorShape(17U, 16U, 3U, 1U)),
+                                                   make("ConvolvedWidth", 4),
+                                               make("ConvolvedHeight", 4),
+                                       make("Groups", 3),
+                               make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/Comparisons.cpp
+++ b/tests/validation/CL/Comparisons.cpp
@@ -41,10 +41,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 const auto configure_dataset = combine(datasets::SmallShapes(),
-                                       framework::dataset::make("DataType", { DataType::QASYMM8, DataType::F16, DataType::F32 }));
+                                       make("DataType", { DataType::QASYMM8, DataType::F16, DataType::F32 }));
 
 const auto run_small_dataset = combine(datasets::ComparisonOperations(), datasets::SmallShapes());
 const auto run_large_dataset = combine(datasets::ComparisonOperations(), datasets::LargeShapes());
@@ -56,25 +57,25 @@ TEST_SUITE(Comparison)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Invalid output type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Invalid output type
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Mismatching input types
                                                  TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Mismatching shapes
                                                  TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S32),
                                                 TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
         }),
-        framework::dataset::make("Expected", { false, false, true, false, true})),
+        make("Expected", { false, false, true, false, true})),
         input1_info, input2_info, output_info, expected)
 {
     Status s = CLComparison::validate(&input1_info.clone()->set_is_resizable(false),
@@ -94,7 +95,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLComparisonFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_small_dataset, make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -102,7 +103,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLComparisonFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_large_dataset, make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -113,7 +114,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLComparisonFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_small_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -121,7 +122,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLComparisonFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_large_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -137,9 +138,9 @@ TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLComparisonQuantizedFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::QASYMM8),
-                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) })))
+                       combine(run_small_dataset, make("DataType", DataType::QASYMM8),
+                                       make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                               make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/ConvertFullyConnectedWeights.cpp
+++ b/tests/validation/CL/ConvertFullyConnectedWeights.cpp
@@ -39,9 +39,10 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-auto params = combine(framework::dataset::make("WeightsWidth", { 16, 32, 64 }), framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+auto params = combine(make("WeightsWidth", { 16, 32, 64 }), make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 } // namespace
 
 TEST_SUITE(CL)
@@ -49,27 +50,27 @@ TEST_SUITE(ConvertFullyConnectedWeights)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Mismatching data types
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Mismatching data types
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),     // Valid
                                             TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Mismatching shapes
                                             TensorInfo(TensorShape(27U, 42U), 1, DataType::F32),     // Wrong DataLayout
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 42U), 1, DataType::F16),
+    make("OutputInfo",{ TensorInfo(TensorShape(27U, 42U), 1, DataType::F16),
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),
                                             TensorInfo(TensorShape(32U, 42U), 1, DataType::F32),
                                           }),
-    framework::dataset::make("OriginalInput", { TensorShape(7U, 3U, 2U),
+    make("OriginalInput", { TensorShape(7U, 3U, 2U),
                                                 TensorShape(7U, 3U, 2U),
                                                 TensorShape(7U, 3U, 2U),
                                                 TensorShape(7U, 3U, 2U),
                                                }),
-    framework::dataset::make("DataLayout", { DataLayout::NCHW,
+    make("DataLayout", { DataLayout::NCHW,
                                              DataLayout::NCHW,
                                              DataLayout::NCHW,
                                              DataLayout::UNKNOWN,
                                                }),
-    framework::dataset::make("Expected", { false, true, false, false})),
+    make("Expected", { false, true, false, false})),
     input_info, output_info, original_input_shape, data_layout, expected)
 {
     bool is_valid = bool(CLConvertFullyConnectedWeights::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), original_input_shape, data_layout));
@@ -81,13 +82,13 @@ template <typename T>
 using CLConvertFullyConnectedWeightsFixture = ConvertFullyConnectedWeightsValidationFixture<CLTensor, CLAccessor, CLConvertFullyConnectedWeights, T>;
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::ALL, combine(datasets::Tiny3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::ALL, combine(datasets::Tiny3DShapes(), params, make("DataType",
                                                                                                                     DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLConvertFullyConnectedWeightsFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, make("DataType",
                                                                                                                         DataType::F32)))
 {
     // Validate output
@@ -96,13 +97,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLConvertFullyConnectedWeightsFixture<float>, f
 TEST_SUITE_END()
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::ALL, combine(datasets::Tiny3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::ALL, combine(datasets::Tiny3DShapes(), params, make("DataType",
                                                                                                                    DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLConvertFullyConnectedWeightsFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params, make("DataType",
                                                                                                                        DataType::F16)))
 {
     // Validate output
@@ -111,14 +112,14 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLConvertFullyConnectedWeightsFixture<half>, fr
 TEST_SUITE_END()
 
 TEST_SUITE(QASYMM8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLConvertFullyConnectedWeightsFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::Tiny3DShapes(), params, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLConvertFullyConnectedWeightsFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::Tiny3DShapes(), params, make("DataType",
                                                                                                                       DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLConvertFullyConnectedWeightsFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::Large3DShapes(), params,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8)))
 {
     // Validate output

--- a/tests/validation/CL/Convolution3D.cpp
+++ b/tests/validation/CL/Convolution3D.cpp
@@ -36,6 +36,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 const RelativeTolerance<half>        rel_tolerance_fp16(half(0.2)); /**< Relative tolerance for FP16 tests */
@@ -51,7 +52,7 @@ TEST_SUITE(DirectConvolution3D)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 5U, 3U), // Unsupported data layout
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputShape", { TensorShape(27U, 13U, 5U, 3U), // Unsupported data layout
                                                         TensorShape(27U, 13U, 5U, 3U), // Unsupported activation enabled
                                                         TensorShape(27U, 13U, 5U, 3U), // Mismatching data type
                                                         TensorShape(27U, 13U, 5U, 3U), // Unsupported data type
@@ -63,7 +64,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                         TensorShape(27U, 13U, 5U, 3U), // Mismatching output shape
                                                         TensorShape(27U, 13U, 5U, 3U)
                                                      }),
-               framework::dataset::make("WeightsShape", { TensorShape(4U, 27U, 3U, 3U, 3U),
+               make("WeightsShape", { TensorShape(4U, 27U, 3U, 3U, 3U),
                                                           TensorShape(4U, 27U, 3U, 3U, 3U),
                                                           TensorShape(4U, 27U, 3U, 3U, 3U),
                                                           TensorShape(4U, 27U, 3U, 3U, 3U),
@@ -75,7 +76,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                           TensorShape(4U, 27U, 3U, 3U, 3U),
                                                           TensorShape(4U, 27U, 3U, 3U, 3U)
                                                      }),
-               framework::dataset::make("BiasesShape", { TensorShape(4U),
+               make("BiasesShape", { TensorShape(4U),
                                                          TensorShape(4U),
                                                          TensorShape(4U),
                                                          TensorShape(4U),
@@ -87,7 +88,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                          TensorShape(4U),
                                                          TensorShape(4U)
                                                      }),
-               framework::dataset::make("OutputShape", { TensorShape(4U, 13U, 5U, 3U),
+               make("OutputShape", { TensorShape(4U, 13U, 5U, 3U),
                                                          TensorShape(4U, 13U, 5U, 3U),
                                                          TensorShape(4U, 13U, 5U, 3U),
                                                          TensorShape(4U, 13U, 5U, 3U),
@@ -99,7 +100,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                          TensorShape(4U, 11U, 5U, 3U),
                                                          TensorShape(4U, 13U, 5U, 3U)
                                                      }),
-               framework::dataset::make("Conv3dInfo",  { Conv3dInfo(Size3D(1U, 1U, 1U), Padding3D(1U, 1U, 1U), ActivationLayerInfo(), Size3D(1U, 1U, 1U), DimensionRoundingType::FLOOR, false),
+               make("Conv3dInfo",  { Conv3dInfo(Size3D(1U, 1U, 1U), Padding3D(1U, 1U, 1U), ActivationLayerInfo(), Size3D(1U, 1U, 1U), DimensionRoundingType::FLOOR, false),
                                                          Conv3dInfo(Size3D(1U, 1U, 1U), Padding3D(1U, 1U, 1U), ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU), Size3D(1U, 1U, 1U), DimensionRoundingType::FLOOR, false),
                                                          Conv3dInfo(Size3D(1U, 1U, 1U), Padding3D(1U, 1U, 1U), ActivationLayerInfo(), Size3D(1U, 1U, 1U), DimensionRoundingType::FLOOR, false),
                                                          Conv3dInfo(Size3D(1U, 1U, 1U), Padding3D(1U, 1U, 1U), ActivationLayerInfo(), Size3D(1U, 1U, 1U), DimensionRoundingType::FLOOR, false),
@@ -111,7 +112,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                          Conv3dInfo(Size3D(1U, 1U, 1U), Padding3D(1U, 1U, 1U), ActivationLayerInfo(), Size3D(1U, 1U, 1U), DimensionRoundingType::FLOOR, false),
                                                          Conv3dInfo(Size3D(1U, 1U, 1U), Padding3D(1U, 1U, 1U), ActivationLayerInfo(), Size3D(1U, 1U, 1U), DimensionRoundingType::FLOOR, false)
                                                       }),
-                framework::dataset::make("SrcDataType", { DataType::F32,
+                make("SrcDataType", { DataType::F32,
                                                           DataType::F32,
                                                           DataType::F32,
                                                           DataType::U32,
@@ -123,7 +124,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                           DataType::F32,
                                                           DataType::F32
                                                       }),
-                framework::dataset::make("WeightsDataType", { DataType::F32,
+                make("WeightsDataType", { DataType::F32,
                                                               DataType::F32,
                                                               DataType::F16,
                                                               DataType::U32,
@@ -135,7 +136,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                               DataType::F32,
                                                               DataType::F32
                                                       }),
-                framework::dataset::make("DataLayout", { DataLayout::NCDHW,
+                make("DataLayout", { DataLayout::NCDHW,
                                                          DataLayout::NDHWC,
                                                          DataLayout::NDHWC,
                                                          DataLayout::NDHWC,
@@ -147,7 +148,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                          DataLayout::NDHWC,
                                                          DataLayout::NDHWC
                                                       }),
-               framework::dataset::make("Expected", { false, false, false, false, false, false, false, false, false, false, true })),
+               make("Expected", { false, false, false, false, false, false, false, false, false, false, true })),
                input_shape, weights_shape, biases_shape, output_shape, conv3d_info, src_data_type, weights_data_type, data_layout, expected)
 {
     TensorInfo input_info   = TensorInfo(input_shape, 1, src_data_type);
@@ -172,25 +173,25 @@ using CLDirectConvolution3DQuantizedFixture = DirectConvolution3DValidationQuant
 TEST_SUITE(NDHWC)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolution3DFixture<half>, framework::DatasetMode::PRECOMMIT,
-                       combine(zip(framework::dataset::make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
+                       combine(zip(make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
                                                                 TensorShape(15U, 7U, 11U, 7U),
                                                                 TensorShape(19U, 5U, 16U, 4U),
                                                                 TensorShape(13U, 5U, 17U, 2U)
                                                               }),
-                       framework::dataset::make("StrideX", { 1, 3, 2, 1 }),
-                       framework::dataset::make("StrideY", { 2, 1, 3, 1 }),
-                       framework::dataset::make("StrideZ", { 3, 2, 1, 1 }),
-                       framework::dataset::make("PadX", { 0, 2, 1, 0 }),
-                       framework::dataset::make("PadY", { 1, 0, 2, 0 }),
-                       framework::dataset::make("PadZ", { 2, 1, 0, 0 }),
-                       framework::dataset::make("KernelWidth", { 3, 7, 5, 1 }),
-                       framework::dataset::make("KernelHeight", { 5, 3, 7, 1 }),
-                       framework::dataset::make("KernelDepth", { 7, 5, 3, 1 }),
-                       framework::dataset::make("NumKernels", { 5, 3, 1, 11 }),
-                       framework::dataset::make("HasBias", { true, true, true, false })),
-                       framework::dataset::make("Activation", ActivationLayerInfo()),
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("DataLayout", DataLayout::NDHWC)))
+                       make("StrideX", { 1, 3, 2, 1 }),
+                       make("StrideY", { 2, 1, 3, 1 }),
+                       make("StrideZ", { 3, 2, 1, 1 }),
+                       make("PadX", { 0, 2, 1, 0 }),
+                       make("PadY", { 1, 0, 2, 0 }),
+                       make("PadZ", { 2, 1, 0, 0 }),
+                       make("KernelWidth", { 3, 7, 5, 1 }),
+                       make("KernelHeight", { 5, 3, 7, 1 }),
+                       make("KernelDepth", { 7, 5, 3, 1 }),
+                       make("NumKernels", { 5, 3, 1, 11 }),
+                       make("HasBias", { true, true, true, false })),
+                       make("Activation", ActivationLayerInfo()),
+                       make("DataType", DataType::F16),
+                       make("DataLayout", DataLayout::NDHWC)))
 {
     validate(CLAccessor(_target), _reference, rel_tolerance_fp16, tolerance_num, abs_tolerance_fp16);
 }
@@ -199,25 +200,25 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolution3DFixture<float>, framework::DatasetMode::PRECOMMIT,
-                       combine(zip(framework::dataset::make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
+                       combine(zip(make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
                                                                 TensorShape(15U, 7U, 11U, 7U),
                                                                 TensorShape(19U, 5U, 16U, 4U),
                                                                 TensorShape(13U, 5U, 17U, 2U)
                                                               }),
-                       framework::dataset::make("StrideX", { 1, 3, 2, 1 }),
-                       framework::dataset::make("StrideY", { 2, 1, 3, 1 }),
-                       framework::dataset::make("StrideZ", { 3, 2, 1, 1 }),
-                       framework::dataset::make("PadX", { 0, 2, 1, 0 }),
-                       framework::dataset::make("PadY", { 1, 0, 2, 0 }),
-                       framework::dataset::make("PadZ", { 2, 1, 0, 0 }),
-                       framework::dataset::make("KernelWidth", { 3, 7, 5, 1 }),
-                       framework::dataset::make("KernelHeight", { 5, 3, 7, 1 }),
-                       framework::dataset::make("KernelDepth", { 7, 5, 3, 1 }),
-                       framework::dataset::make("NumKernels", { 5, 3, 1, 11 }),
-                       framework::dataset::make("HasBias", { true, true, true, false })),
-                       framework::dataset::make("Activation", ActivationLayerInfo()),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataLayout", DataLayout::NDHWC)))
+                       make("StrideX", { 1, 3, 2, 1 }),
+                       make("StrideY", { 2, 1, 3, 1 }),
+                       make("StrideZ", { 3, 2, 1, 1 }),
+                       make("PadX", { 0, 2, 1, 0 }),
+                       make("PadY", { 1, 0, 2, 0 }),
+                       make("PadZ", { 2, 1, 0, 0 }),
+                       make("KernelWidth", { 3, 7, 5, 1 }),
+                       make("KernelHeight", { 5, 3, 7, 1 }),
+                       make("KernelDepth", { 7, 5, 3, 1 }),
+                       make("NumKernels", { 5, 3, 1, 11 }),
+                       make("HasBias", { true, true, true, false })),
+                       make("Activation", ActivationLayerInfo()),
+                       make("DataType", DataType::F32),
+                       make("DataLayout", DataLayout::NDHWC)))
 {
     validate(CLAccessor(_target), _reference, rel_tolerance_fp32, 0.0, abs_tolerance_fp32);
 }
@@ -228,28 +229,28 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolution3DQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-                       combine(zip(framework::dataset::make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
+                       combine(zip(make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
                                                                                                                            TensorShape(15U, 7U, 11U, 7U),
                                                                                                                            TensorShape(19U, 5U, 16U, 4U),
                                                                                                                            TensorShape(13U, 5U, 17U, 2U)
                                                                                                                                                           }),
-                                                                                                                   framework::dataset::make("StrideX", { 1, 3, 2, 1 }),
-                                                                                                               framework::dataset::make("StrideY", { 2, 1, 3, 1 }),
-                                                                                                           framework::dataset::make("StrideZ", { 3, 2, 1, 1 }),
-                                                                                                       framework::dataset::make("PadX", { 0, 2, 1, 0 }),
-                                                                                                   framework::dataset::make("PadY", { 1, 0, 2, 0 }),
-                                                                                               framework::dataset::make("PadZ", { 2, 1, 0, 0 }),
-                                                                                           framework::dataset::make("KernelWidth", { 3, 7, 5, 1 }),
-                                                                                       framework::dataset::make("KernelHeight", { 5, 3, 7, 1 }),
-                                                                                   framework::dataset::make("KernelDepth", { 7, 5, 3, 1 }),
-                                                                               framework::dataset::make("NumKernels", { 5, 3, 1, 11 }),
-                                                                           framework::dataset::make("HasBias", { true, true, true, false })),
-                                                                       framework::dataset::make("Activation", ActivationLayerInfo()),
-                                                               framework::dataset::make("DataType", DataType::QASYMM8),
-                                                       framework::dataset::make("DataLayout", DataLayout::NDHWC),
-                                               framework::dataset::make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
-                                       framework::dataset::make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
-                               framework::dataset::make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
+                                                                                                                   make("StrideX", { 1, 3, 2, 1 }),
+                                                                                                               make("StrideY", { 2, 1, 3, 1 }),
+                                                                                                           make("StrideZ", { 3, 2, 1, 1 }),
+                                                                                                       make("PadX", { 0, 2, 1, 0 }),
+                                                                                                   make("PadY", { 1, 0, 2, 0 }),
+                                                                                               make("PadZ", { 2, 1, 0, 0 }),
+                                                                                           make("KernelWidth", { 3, 7, 5, 1 }),
+                                                                                       make("KernelHeight", { 5, 3, 7, 1 }),
+                                                                                   make("KernelDepth", { 7, 5, 3, 1 }),
+                                                                               make("NumKernels", { 5, 3, 1, 11 }),
+                                                                           make("HasBias", { true, true, true, false })),
+                                                                       make("Activation", ActivationLayerInfo()),
+                                                               make("DataType", DataType::QASYMM8),
+                                                       make("DataLayout", DataLayout::NDHWC),
+                                               make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
+                                       make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
+                               make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
 {
     validate(CLAccessor(_target), _reference, abs_tolerance_qasymm8);
 }
@@ -258,28 +259,28 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolution3DQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT,
-                       combine(zip(framework::dataset::make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
+                       combine(zip(make("InputShape", { TensorShape(7U, 5U, 3U, 13U, 3U),
                                                                                                                            TensorShape(15U, 7U, 11U, 7U),
                                                                                                                            TensorShape(19U, 5U, 16U, 4U),
                                                                                                                            TensorShape(13U, 5U, 17U, 2U)
                                                                                                                                                           }),
-                                                                                                                   framework::dataset::make("StrideX", { 1, 3, 2, 1 }),
-                                                                                                               framework::dataset::make("StrideY", { 2, 1, 3, 1 }),
-                                                                                                           framework::dataset::make("StrideZ", { 3, 2, 1, 1 }),
-                                                                                                       framework::dataset::make("PadX", { 0, 2, 1, 0 }),
-                                                                                                   framework::dataset::make("PadY", { 1, 0, 2, 0 }),
-                                                                                               framework::dataset::make("PadZ", { 2, 1, 0, 0 }),
-                                                                                           framework::dataset::make("KernelWidth", { 3, 7, 5, 1 }),
-                                                                                       framework::dataset::make("KernelHeight", { 5, 3, 7, 1 }),
-                                                                                   framework::dataset::make("KernelDepth", { 7, 5, 3, 1 }),
-                                                                               framework::dataset::make("NumKernels", { 5, 3, 1, 11 }),
-                                                                           framework::dataset::make("HasBias", { true, true, true, false })),
-                                                                       framework::dataset::make("Activation", ActivationLayerInfo()),
-                                                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                       framework::dataset::make("DataLayout", DataLayout::NDHWC),
-                                               framework::dataset::make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
-                                       framework::dataset::make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
-                               framework::dataset::make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
+                                                                                                                   make("StrideX", { 1, 3, 2, 1 }),
+                                                                                                               make("StrideY", { 2, 1, 3, 1 }),
+                                                                                                           make("StrideZ", { 3, 2, 1, 1 }),
+                                                                                                       make("PadX", { 0, 2, 1, 0 }),
+                                                                                                   make("PadY", { 1, 0, 2, 0 }),
+                                                                                               make("PadZ", { 2, 1, 0, 0 }),
+                                                                                           make("KernelWidth", { 3, 7, 5, 1 }),
+                                                                                       make("KernelHeight", { 5, 3, 7, 1 }),
+                                                                                   make("KernelDepth", { 7, 5, 3, 1 }),
+                                                                               make("NumKernels", { 5, 3, 1, 11 }),
+                                                                           make("HasBias", { true, true, true, false })),
+                                                                       make("Activation", ActivationLayerInfo()),
+                                                               make("DataType", DataType::QASYMM8_SIGNED),
+                                                       make("DataLayout", DataLayout::NDHWC),
+                                               make("SrcQuantizationInfo", QuantizationInfo(0.1f, 10)),
+                                       make("WeightsQuantizationInfo", QuantizationInfo(0.3f, 20)),
+                               make("DstQuantizationInfo", QuantizationInfo(0.2f, 5))))
 {
     validate(CLAccessor(_target), _reference, abs_tolerance_qasymm8);
 }

--- a/tests/validation/CL/Copy.cpp
+++ b/tests/validation/CL/Copy.cpp
@@ -40,20 +40,21 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Copy)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Invalid data type combination
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Invalid data type combination
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Mismatching shapes
                                                        TensorInfo(TensorShape(14U, 13U, 2U), 1, DataType::U8),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(32U, 11U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(14U, 13U, 2U), 1, DataType::U8),
                                                      }),
-               framework::dataset::make("Expected", { false, false, true })),
+               make("Expected", { false, false, true })),
                input_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLCopy::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -66,7 +67,7 @@ using CLCopyFixture = CopyFixture<CLTensor, CLAccessor, CLCopy, T>;
 
 TEST_SUITE(FixedSeed)
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<float>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<float>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), make("DataType",
                                                                                             DataType::F32)))
 {
     // Validate output
@@ -75,7 +76,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<float>, framework::DatasetMode::A
 TEST_SUITE_END() // F32
 
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<uint8_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<uint8_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), make("DataType",
                                                                                               DataType::U8)))
 {
     // Validate output
@@ -84,7 +85,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<uint8_t>, framework::DatasetMode:
 TEST_SUITE_END() // U8
 
 TEST_SUITE(U16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<uint16_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLCopyFixture<uint16_t>, framework::DatasetMode::ALL, combine(zip(datasets::SmallShapes(), datasets::SmallShapes()), make("DataType",
                                                                                                DataType::U16)))
 {
     // Validate output

--- a/tests/validation/CL/CropResize.cpp
+++ b/tests/validation/CL/CropResize.cpp
@@ -39,6 +39,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(CropResize)
 
@@ -49,35 +50,35 @@ using CLCropResizeFixture = CropResizeFixture<CLTensor, CLAccessor, CLCropResize
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid box_ind shape.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid output shape.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid output data type.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid output shape.
                                                        TensorInfo(TensorShape(15U, 30U, 40U, 10U), 1, DataType::S32), // Invalid boxes shape.
                                                      }),
-               framework::dataset::make("BoxesInfo",{  TensorInfo(TensorShape(4, 20), 1, DataType::F32),
+               make("BoxesInfo",{  TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4, 20), 1, DataType::F32),
                                                        TensorInfo(TensorShape(3, 20), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("BoxIndInfo",{ TensorInfo(TensorShape(20), 1, DataType::S32),
+               make("BoxIndInfo",{ TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(10), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                        TensorInfo(TensorShape(20), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 10U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(5U, 5, 5, 20U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(15U, 5, 5, 20U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false, false, false})),
+               make("Expected", { true, false, false, false, false, false})),
                input, boxes, box_ind, output, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLCropResize::validate(&input.clone()->set_data_layout(DataLayout::NHWC).set_is_resizable(false),
@@ -95,8 +96,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLCropResizeFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallCropResizeDataset(),
-                               framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::F16)))
+                               make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.01);
@@ -108,8 +109,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLCropResizeFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallCropResizeDataset(),
-                               framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::F32)))
+                               make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.01);
@@ -122,8 +123,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLCropResizeFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallCropResizeDataset(),
-                               framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::U8)))
+                               make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.01);
@@ -135,8 +136,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLCropResizeFixture<uint16_t>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallCropResizeDataset(),
-                               framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::U16)))
+                               make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::U16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.01);
@@ -148,8 +149,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLCropResizeFixture<int16_t>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallCropResizeDataset(),
-                               framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::S16)))
+                               make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::S16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.01);
@@ -161,8 +162,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLCropResizeFixture<uint32_t>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallCropResizeDataset(),
-                               framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::U32)))
+                               make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::U32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.01);
@@ -174,8 +175,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLCropResizeFixture<int32_t>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallCropResizeDataset(),
-                               framework::dataset::make("IsOutOfBounds", { true, false }),
-                                       framework::dataset::make("DataType", DataType::S32)))
+                               make("IsOutOfBounds", { true, false }),
+                                       make("DataType", DataType::S32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.01);

--- a/tests/validation/CL/DeconvolutionLayer.cpp
+++ b/tests/validation/CL/DeconvolutionLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<float>  tolerance_fp32(0.001f);               /**< Tolerance for floating point tests */
@@ -48,39 +49,39 @@ RelativeTolerance<half_float::half> tolerance_f16(half_float::half(0.2)); /**< T
 constexpr AbsoluteTolerance<float>  tolerance_qasymm8(1.0);               /**< Tolerance value for comparing reference's output against implementation's output for quantized data types */
 constexpr float                     tolerance_num = 0.07f;                /**< Tolerance number */
 
-const auto data9x9_small_asymm = framework::dataset::make("InputShape", TensorShape{ 10U, 10U, 1U, 1U }) *framework::dataset::make("StrideX", 2) *framework::dataset::make("StrideY",
+const auto data9x9_small_asymm = make("InputShape", TensorShape{ 10U, 10U, 1U, 1U }) *make("StrideX", 2) *make("StrideY",
                                  2)
-                                 *framework::dataset::make("PadLeft", 3)
-                                 *framework::dataset::make("PadRight", 4) *framework::dataset::make("PadTop", 3) *framework::dataset::make("PadBottom", 4) *framework::dataset::make("NumKernels", { 1 });
+                                 *make("PadLeft", 3)
+                                 *make("PadRight", 4) *make("PadTop", 3) *make("PadBottom", 4) *make("NumKernels", { 1 });
 
-const auto data4x4 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 4, 2) * framework::dataset::make("StrideY", 2, 4) * framework::dataset::make("PadX", 1, 3)
-                     * framework::dataset::make("PadY", 0, 2) * framework::dataset::make("NumKernels", { 3 });
+const auto data4x4 = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 4, 2) * make("StrideY", 2, 4) * make("PadX", 1, 3)
+                     * make("PadY", 0, 2) * make("NumKernels", { 3 });
 
-const auto data3x3 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 2, 4) * framework::dataset::make("StrideY", 1, 4, 2) * framework::dataset::make("PadX", 1, 2)
-                     * framework::dataset::make("PadY", 1, 3) * framework::dataset::make("NumKernels", { 3 });
+const auto data3x3 = datasets::SmallDeconvolutionShapes() * make("StrideX", 2, 4) * make("StrideY", 1, 4, 2) * make("PadX", 1, 2)
+                     * make("PadY", 1, 3) * make("NumKernels", { 3 });
 
-const auto data3x3_asymm = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 2) * framework::dataset::make("StrideY", 1, 2) * framework::dataset::make("PadLeft", 0, 1)
-                           * framework::dataset::make("PadRight", 0, 1) * framework::dataset::make("PadTop", 0, 1) * framework::dataset::make("PadBottom", 0, 1) * framework::dataset::make("NumKernels", { 3 });
+const auto data3x3_asymm = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 2) * make("StrideY", 1, 2) * make("PadLeft", 0, 1)
+                           * make("PadRight", 0, 1) * make("PadTop", 0, 1) * make("PadBottom", 0, 1) * make("NumKernels", { 3 });
 
-const auto data3x3_precommit = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 2) * framework::dataset::make("StrideY", 1, 2) * framework::dataset::make("PadX", 0, 2)
-                               * framework::dataset::make("PadY", 0, 2) * framework::dataset::make("NumKernels", { 3 });
+const auto data3x3_precommit = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 2) * make("StrideY", 1, 2) * make("PadX", 0, 2)
+                               * make("PadY", 0, 2) * make("NumKernels", { 3 });
 
-const auto data3x3_precommit_large_channels = datasets::SmallDeconvolutionShapesWithLargerChannels() * framework::dataset::make("StrideX", 2) * framework::dataset::make("StrideY", 2)
-                                              * framework::dataset::make("PadX", 1)
-                                              * framework::dataset::make("PadY", 2) * framework::dataset::make("NumKernels", { 5 });
+const auto data3x3_precommit_large_channels = datasets::SmallDeconvolutionShapesWithLargerChannels() * make("StrideX", 2) * make("StrideY", 2)
+                                              * make("PadX", 1)
+                                              * make("PadY", 2) * make("NumKernels", { 5 });
 
-const auto data2x2_precommit = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 2) * framework::dataset::make("StrideY", 2) * framework::dataset::make("PadX", 1)
-                               * framework::dataset::make("PadY", 1) * framework::dataset::make("NumKernels", { 3 });
+const auto data2x2_precommit = datasets::SmallDeconvolutionShapes() * make("StrideX", 2) * make("StrideY", 2) * make("PadX", 1)
+                               * make("PadY", 1) * make("NumKernels", { 3 });
 
-const auto data1x1 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 1, 4, 2) * framework::dataset::make("StrideY", 2, 4) * framework::dataset::make("PadX", 0, 1)
-                     * framework::dataset::make("PadY", 0, 1) * framework::dataset::make("NumKernels", { 3 });
+const auto data1x1 = datasets::SmallDeconvolutionShapes() * make("StrideX", 1, 4, 2) * make("StrideY", 2, 4) * make("PadX", 0, 1)
+                     * make("PadY", 0, 1) * make("NumKernels", { 3 });
 
-const auto data5x1 = datasets::SmallDeconvolutionShapes() * framework::dataset::make("StrideX", 2, 4) * framework::dataset::make("StrideY", 1, 4, 2) * framework::dataset::make("PadX", 0, 1)
-                     * framework::dataset::make("PadY", 0, 1) * framework::dataset::make("NumKernels", { 3 });
+const auto data5x1 = datasets::SmallDeconvolutionShapes() * make("StrideX", 2, 4) * make("StrideY", 1, 4, 2) * make("PadX", 0, 1)
+                     * make("PadY", 0, 1) * make("NumKernels", { 3 });
 
-const auto data_layouts_dataset = framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC });
+const auto data_layouts_dataset = make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC });
 
-const auto add_bias_dataset = framework::dataset::make("AddBias", { true, false });
+const auto add_bias_dataset = make("AddBias", { true, false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -88,7 +89,7 @@ TEST_SUITE(DeconvolutionLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",   { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),   // Mismatching data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",   { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),   // Mismatching data type
                                               TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),   // Invalid weights shape
                                               TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),   // Non supported data type
                                               TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),   // Invalid bias shape
@@ -101,7 +102,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                               TensorInfo(TensorShape(4U, 11U, 13U, 3U), 1, DataType::F32, DataLayout::NHWC), // Window shrink
                                               TensorInfo(TensorShape(2U, 16U, 32U), 1, DataType::F32, DataLayout::NHWC),
                                             }),
-    framework::dataset::make("WeightsInfo", { TensorInfo(TensorShape(3U, 3U, 2U, 2U), 1, DataType::F16),
+    make("WeightsInfo", { TensorInfo(TensorShape(3U, 3U, 2U, 2U), 1, DataType::F16),
                                               TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),
                                               TensorInfo(TensorShape(3U, 3U, 2U, 2U), 1, DataType::F16),
                                               TensorInfo(TensorShape(3U, 2U, 2U, 2U), 1, DataType::F32),
@@ -114,7 +115,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                               TensorInfo(TensorShape(4U, 3U, 3U), 1, DataType::F32, DataLayout::NHWC),
                                               TensorInfo(TensorShape(2U, 2U, 2U, 4U), 1, DataType::F32, DataLayout::NHWC),
                                             }),
-    framework::dataset::make("BiasInfo",    { TensorInfo(TensorShape(1U), 1, DataType::F16),
+    make("BiasInfo",    { TensorInfo(TensorShape(1U), 1, DataType::F16),
                                               TensorInfo(TensorShape(1U), 1, DataType::F32),
                                               TensorInfo(TensorShape(1U), 1, DataType::F32),
                                               TensorInfo(TensorShape(25U, 11U), 1, DataType::F32),
@@ -127,7 +128,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                               TensorInfo(TensorShape(1U), 1, DataType::F32, DataLayout::NHWC),
                                               TensorInfo(TensorShape(4U), 1, DataType::F32, DataLayout::NHWC),
                                             }),
-    framework::dataset::make("OutputInfo",  { TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
+    make("OutputInfo",  { TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
                                               TensorInfo(TensorShape(25U, 10U, 2U), 1, DataType::F32),
                                               TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F32),
                                               TensorInfo(TensorShape(13U, 13U, 2U), 1, DataType::F32),
@@ -140,7 +141,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                               TensorInfo(TensorShape(1U, 9U, 11U, 3U), 1, DataType::F32, DataLayout::NHWC),
                                               TensorInfo(TensorShape(4U, 43U, 91U), 1, DataType::F32, DataLayout::NHWC),
                                             }),
-    framework::dataset::make("PadStrideInfo", { PadStrideInfo(1, 1, 0, 0),
+    make("PadStrideInfo", { PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
                                                 PadStrideInfo(1, 1, 0, 0),
@@ -153,7 +154,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                 PadStrideInfo(1, 1, 1, 1),
                                                 PadStrideInfo(3, 3, 2, 2),
                                            }),
-    framework::dataset::make("Expected", { false, false, false, false, false, true,            // NCHW
+    make("Expected", { false, false, false, false, false, true,            // NCHW
                                            false, false, false, false, false, true })),        // NHWC
     input_info, weights_info, bias_info, output_info, pad_info, expected)
 {
@@ -188,7 +189,7 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture4x4<float>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture4x4<float>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType", DataType::F32),
                                                                                                                     data_layouts_dataset,
                                                                                                             add_bias_dataset))
 {
@@ -198,7 +199,7 @@ FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture4x4<float>, framework::Da
 TEST_SUITE_END() // W4x4
 
 TEST_SUITE(W3x3)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, make("DataType",
                                                                                                                    DataType::F32),
                                                                                                                    data_layouts_dataset,
                                                                                                                    add_bias_dataset))
@@ -208,16 +209,16 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture3x3<float>, framewor
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallWithLargeChannels, CLDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit_large_channels,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::F32),
                        data_layouts_dataset,
-                       framework::dataset::make("AddBias", { true })))
+                       make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
 
-FIXTURE_DATA_TEST_CASE(RunAsymm, CLDeconvolutionLayerAsymmFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3_asymm, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunAsymm, CLDeconvolutionLayerAsymmFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3_asymm, make("DataType",
                                                                                                                       DataType::F32),
                                                                                                                       data_layouts_dataset,
                                                                                                                       add_bias_dataset))
@@ -225,9 +226,9 @@ FIXTURE_DATA_TEST_CASE(RunAsymm, CLDeconvolutionLayerAsymmFixture3x3<float>, fra
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3, framework::dataset::make("DataType", DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                 framework::dataset::make("AddBias", { true })))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerFixture3x3<float>, framework::DatasetMode::NIGHTLY, combine(data3x3, make("DataType", DataType::F32),
+                                                                                                                 make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                 make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
@@ -235,7 +236,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerFixture3x3<float>, framewor
 TEST_SUITE_END() // W3x3
 
 TEST_SUITE(W2x2)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture2x2<float>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture2x2<float>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit, make("DataType",
                                                                                                                    DataType::F32),
                                                                                                                    data_layouts_dataset,
                                                                                                                    add_bias_dataset))
@@ -246,19 +247,19 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture2x2<float>, framewor
 TEST_SUITE_END() // W2x2
 
 TEST_SUITE(W1x1)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture1x1<float>, framework::DatasetMode::NIGHTLY, combine(data1x1, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture1x1<float>, framework::DatasetMode::NIGHTLY, combine(data1x1, make("DataType", DataType::F32),
                                                                                                                     data_layouts_dataset,
-                                                                                                            framework::dataset::make("AddBias", { true })))
+                                                                                                            make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
 TEST_SUITE_END() // W1x1
 TEST_SUITE(W9x9)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerAsymmFixture9x9<float>, framework::DatasetMode::ALL, combine(data9x9_small_asymm, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerAsymmFixture9x9<float>, framework::DatasetMode::ALL, combine(data9x9_small_asymm, make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                  framework::dataset::make("AddBias", { false })))
+                                                                                                                  make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                  make("AddBias", { false })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
@@ -266,9 +267,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerAsymmFixture9x9<float>, fra
 TEST_SUITE_END() // W9x9
 
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture5x1<float>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture5x1<float>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType", DataType::F32),
                                                                                                                     data_layouts_dataset,
-                                                                                                            framework::dataset::make("AddBias", { true })))
+                                                                                                            make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
@@ -280,9 +281,9 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture4x4<half>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture4x4<half>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType", DataType::F16),
                                                                                                                    data_layouts_dataset,
-                                                                                                           framework::dataset::make("AddBias", { true })))
+                                                                                                           make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
@@ -290,7 +291,7 @@ FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture4x4<half>, framework::Dat
 TEST_SUITE_END() // W4x4
 
 TEST_SUITE(W3x3)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit, make("DataType",
                                                                                                                   DataType::F16),
                                                                                                                   data_layouts_dataset,
                                                                                                                   add_bias_dataset))
@@ -298,9 +299,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture3x3<half>, framework
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::NIGHTLY, combine(data3x3, framework::dataset::make("DataType", DataType::F16),
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                                                                                                                framework::dataset::make("AddBias", { true })))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerFixture3x3<half>, framework::DatasetMode::NIGHTLY, combine(data3x3, make("DataType", DataType::F16),
+                                                                                                                        make("DataLayout", { DataLayout::NHWC }),
+                                                                                                                make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
@@ -308,7 +309,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerFixture3x3<half>, framework
 TEST_SUITE_END() // W3x3
 
 TEST_SUITE(W2x2)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture2x2<half>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture2x2<half>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit, make("DataType",
                                                                                                                   DataType::F16),
                                                                                                                   data_layouts_dataset,
                                                                                                                   add_bias_dataset))
@@ -319,9 +320,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerFixture2x2<half>, framework
 TEST_SUITE_END() // W2x2
 
 TEST_SUITE(W1x1)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture1x1<half>, framework::DatasetMode::NIGHTLY, combine(data1x1, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture1x1<half>, framework::DatasetMode::NIGHTLY, combine(data1x1, make("DataType", DataType::F16),
                                                                                                                    data_layouts_dataset,
-                                                                                                           framework::dataset::make("AddBias", { true })))
+                                                                                                           make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
@@ -329,9 +330,9 @@ FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture1x1<half>, framework::Dat
 TEST_SUITE_END() // W1x1
 
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture5x1<half>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerFixture5x1<half>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType", DataType::F16),
                                                                                                                    data_layouts_dataset,
-                                                                                                           framework::dataset::make("AddBias", { true })))
+                                                                                                           make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
@@ -375,12 +376,12 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture4x4<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture4x4<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType",
                                                                                                                        DataType::QASYMM8),
                                                                                                                        data_layouts_dataset,
-                                                                                                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
-                                                                                                                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
-                                                                                                                       framework::dataset::make("AddBias", { true })))
+                                                                                                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
+                                                                                                                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
+                                                                                                                       make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -389,22 +390,22 @@ TEST_SUITE_END() // W4x4
 
 TEST_SUITE(W3x3)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedFixture3x3<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8),
                        data_layouts_dataset,
-                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 4) }),
-                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 10), QuantizationInfo(4.f / 255.f, 5) }),
+                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 4) }),
+                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 10), QuantizationInfo(4.f / 255.f, 5) }),
                        add_bias_dataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerQuantizedFixture3x3<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data3x3,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 128) }),
-                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 128), QuantizationInfo(4.f / 255.f, 128) }),
-                       framework::dataset::make("AddBias", { true })))
+                       make("DataType", DataType::QASYMM8),
+                       make("DataLayout", { DataLayout::NHWC }),
+                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 128) }),
+                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 128), QuantizationInfo(4.f / 255.f, 128) }),
+                       make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -413,10 +414,10 @@ TEST_SUITE_END() // W3x3
 
 TEST_SUITE(W2x2)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedFixture2x2<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
-                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 128), QuantizationInfo(2.f / 255.f, 128) }),
-                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 64), QuantizationInfo(4.f / 255.f, 128) }),
+                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 128), QuantizationInfo(2.f / 255.f, 128) }),
+                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 64), QuantizationInfo(4.f / 255.f, 128) }),
                        add_bias_dataset))
 {
     // Validate output
@@ -425,12 +426,12 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedFixture2x2<uint8_t
 TEST_SUITE_END() // W2x2
 
 TEST_SUITE(W1x1)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture1x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture1x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1, make("DataType",
                                                                                                                        DataType::QASYMM8),
                                                                                                                        data_layouts_dataset,
-                                                                                                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 0), QuantizationInfo(2.f / 255.f, 0) }),
-                                                                                                                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 0), QuantizationInfo(4.f / 255.f, 0) }),
-                                                                                                                       framework::dataset::make("AddBias", { true })))
+                                                                                                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 0), QuantizationInfo(2.f / 255.f, 0) }),
+                                                                                                                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 0), QuantizationInfo(4.f / 255.f, 0) }),
+                                                                                                                       make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -438,12 +439,12 @@ FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture1x1<uint8_t>, fr
 TEST_SUITE_END() // W1x1
 
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture5x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture5x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType",
                                                                                                                        DataType::QASYMM8),
                                                                                                                        data_layouts_dataset,
-                                                                                                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
-                                                                                                                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
-                                                                                                                       framework::dataset::make("AddBias", { true })))
+                                                                                                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
+                                                                                                                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
+                                                                                                                       make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -458,12 +459,12 @@ TEST_SUITE(QASYMM8_SIGNED)
 // QASYMM8       : zero-point in range [0   , 255]
 
 TEST_SUITE(W4x4)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture4x4<int8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture4x4<int8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4, make("DataType",
                                                                                                                       DataType::QASYMM8_SIGNED),
                                                                                                                       data_layouts_dataset,
-                                                                                                                      framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
-                                                                                                                      framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
-                                                                                                                      framework::dataset::make("AddBias", { true })))
+                                                                                                                      make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
+                                                                                                                      make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
+                                                                                                                      make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -473,11 +474,11 @@ TEST_SUITE_END() // W4x4
 TEST_SUITE(W3x3)
 // DirectDeconvolution
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedFixture3x3<int8_t>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
-                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 4) }),
-                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 10), QuantizationInfo(4.f / 255.f, 5) }),
+                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 4) }),
+                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 10), QuantizationInfo(4.f / 255.f, 5) }),
                        add_bias_dataset))
 {
     // Validate output
@@ -485,11 +486,11 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedFixture3x3<int8_t>
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDeconvolutionLayerQuantizedFixture3x3<int8_t>, framework::DatasetMode::NIGHTLY, combine(data3x3,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, -10), QuantizationInfo(2.f / 255.f, 127) }),
-                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 64), QuantizationInfo(4.f / 255.f, -128) }),
-                       framework::dataset::make("AddBias", { true })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataLayout", { DataLayout::NHWC }),
+                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, -10), QuantizationInfo(2.f / 255.f, 127) }),
+                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 64), QuantizationInfo(4.f / 255.f, -128) }),
+                       make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -498,10 +499,10 @@ TEST_SUITE_END() // W3x3
 
 TEST_SUITE(W2x2) // GEMMDeconvolution
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedFixture2x2<int8_t>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
-                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127), QuantizationInfo(2.f / 255.f, -128) }),
-                       framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, -10), QuantizationInfo(4.f / 255.f, 64) }),
+                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127), QuantizationInfo(2.f / 255.f, -128) }),
+                       make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, -10), QuantizationInfo(4.f / 255.f, 64) }),
                        add_bias_dataset))
 {
     // Validate output
@@ -511,11 +512,11 @@ TEST_SUITE_END() // W2x2
 
 TEST_SUITE(W1x1) // DirectDeconvolution and GEMMDeconvolution
 FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture1x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1,
-                                                                                                                      framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                      make("DataType", DataType::QASYMM8_SIGNED),
                                                                                                                       data_layouts_dataset,
-                                                                                                                      framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 0), QuantizationInfo(2.f / 255.f, 0) }),
-                                                                                                                      framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 0), QuantizationInfo(4.f / 255.f, 0) }),
-                                                                                                                      framework::dataset::make("AddBias", { true })))
+                                                                                                                      make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 0), QuantizationInfo(2.f / 255.f, 0) }),
+                                                                                                                      make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 0), QuantizationInfo(4.f / 255.f, 0) }),
+                                                                                                                      make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -523,12 +524,12 @@ FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture1x1<int8_t>, fra
 TEST_SUITE_END() // W1x1
 
 TEST_SUITE(W5x1)
-FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture5x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(Run, CLDeconvolutionLayerQuantizedFixture5x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1, make("DataType",
                                                                                                                       DataType::QASYMM8_SIGNED),
                                                                                                                       data_layouts_dataset,
-                                                                                                                      framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
-                                                                                                                      framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
-                                                                                                                      framework::dataset::make("AddBias", { true })))
+                                                                                                                      make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(2.f / 255.f, 5) }),
+                                                                                                                      make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 5), QuantizationInfo(4.f / 255.f, 10) }),
+                                                                                                                      make("AddBias", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -537,32 +538,32 @@ TEST_SUITE_END() // W5x1
 
 TEST_SUITE_END() // QASYMM8_SIGNED
 
-const auto input_qinfo_dataset         = framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10) });
-const auto output_qinfo_dataset        = framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 0) });
-const auto input_signed_qinfo_dataset  = framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, -10) });
-const auto output_signed_qinfo_dataset = framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 10) });
+const auto input_qinfo_dataset         = make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 10) });
+const auto output_qinfo_dataset        = make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 0) });
+const auto input_signed_qinfo_dataset  = make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, -10) });
+const auto output_signed_qinfo_dataset = make("OutputQuantizationInfo", { QuantizationInfo(3.f / 255.f, 10) });
 
 TEST_SUITE(QSYMM8_PER_CHANNEL)
 
 TEST_SUITE(W4x4)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedPerChannelFixture4x4<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
                        output_qinfo_dataset,
-                       framework::dataset::make("AddBias", { true }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { true }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallSigned, CLDeconvolutionLayerQuantizedPerChannelFixture4x4<int8_t>, framework::DatasetMode::NIGHTLY, combine(data4x4,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_dataset,
                        output_signed_qinfo_dataset,
-                       framework::dataset::make("AddBias", { true }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { true }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -571,23 +572,23 @@ TEST_SUITE_END() // W4x4
 
 TEST_SUITE(W3x3)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedPerChannelFixture3x3<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data3x3,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
                        output_qinfo_dataset,
-                       framework::dataset::make("AddBias", { true }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { true }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallSigned, CLDeconvolutionLayerQuantizedPerChannelFixture3x3<int8_t>, framework::DatasetMode::NIGHTLY, combine(data3x3,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_dataset,
                        output_signed_qinfo_dataset,
-                       framework::dataset::make("AddBias", { true }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { true }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -595,12 +596,12 @@ FIXTURE_DATA_TEST_CASE(RunSmallSigned, CLDeconvolutionLayerQuantizedPerChannelFi
 
 FIXTURE_DATA_TEST_CASE(RunSmallSignedPrecommit, CLDeconvolutionLayerQuantizedPerChannelFixture2x2<int8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(data3x3_precommit,
-                                                                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                                       make("DataType", DataType::QASYMM8_SIGNED),
                                                                data_layouts_dataset,
                                                        input_signed_qinfo_dataset,
                                                output_signed_qinfo_dataset,
                                        add_bias_dataset,
-                               framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                               make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -608,12 +609,12 @@ FIXTURE_DATA_TEST_CASE(RunSmallSignedPrecommit, CLDeconvolutionLayerQuantizedPer
 TEST_SUITE_END() // W3x3
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedPerChannelFixture2x2<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data3x3_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
                        output_qinfo_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -621,23 +622,23 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedPerChannelFixture2
 
 TEST_SUITE(W2x2)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedPerChannelFixture2x2<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
                        output_qinfo_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallSigned, CLDeconvolutionLayerQuantizedPerChannelFixture2x2<int8_t>, framework::DatasetMode::PRECOMMIT, combine(data2x2_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_dataset,
                        output_signed_qinfo_dataset,
                        add_bias_dataset,
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -646,23 +647,23 @@ TEST_SUITE_END() // W2x2
 
 TEST_SUITE(W1x1)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedPerChannelFixture1x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
                        output_qinfo_dataset,
-                       framework::dataset::make("AddBias", { false }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { false }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallSigned, CLDeconvolutionLayerQuantizedPerChannelFixture1x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data1x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_dataset,
                        output_signed_qinfo_dataset,
-                       framework::dataset::make("AddBias", { true }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { true }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
@@ -671,23 +672,23 @@ TEST_SUITE_END() // W1x1
 
 TEST_SUITE(W5x1)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDeconvolutionLayerQuantizedPerChannelFixture5x1<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        data_layouts_dataset,
                        input_qinfo_dataset,
                        output_qinfo_dataset,
-                       framework::dataset::make("AddBias", { true }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { true }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallSigned, CLDeconvolutionLayerQuantizedPerChannelFixture5x1<int8_t>, framework::DatasetMode::NIGHTLY, combine(data5x1,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataType", DataType::QASYMM8_SIGNED),
                        data_layouts_dataset,
                        input_signed_qinfo_dataset,
                        output_signed_qinfo_dataset,
-                       framework::dataset::make("AddBias", { false }),
-                       framework::dataset::make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
+                       make("AddBias", { false }),
+                       make("WeightsDataType", { DataType::QSYMM8_PER_CHANNEL })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, tolerance_num);

--- a/tests/validation/CL/DepthConcatenateLayer.cpp
+++ b/tests/validation/CL/DepthConcatenateLayer.cpp
@@ -39,27 +39,28 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(DepthConcatenateLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
                                                   TensorInfo(TensorShape(24U, 27U, 4U), 1, DataType::F32), // Mismatching x dimension
                                                   TensorInfo(TensorShape(23U, 27U, 3U), 1, DataType::F32), // Mismatching total depth
                                                   TensorInfo(TensorShape(16U, 27U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 4U), 1, DataType::F32),
+        make("InputInfo2", {  TensorInfo(TensorShape(23U, 27U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 4U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 6U), 1, DataType::F32)
         }),
-        framework::dataset::make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 9U), 1, DataType::F16),
+        make("OutputInfo", {  TensorInfo(TensorShape(23U, 27U, 9U), 1, DataType::F16),
                                                   TensorInfo(TensorShape(25U, 12U, 9U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(23U, 27U, 8U), 1, DataType::F32),
                                                   TensorInfo(TensorShape(16U, 27U, 12U), 1, DataType::F32)
         }),
-        framework::dataset::make("Expected", { false, false, false, true })),
+        make("Expected", { false, false, false, true })),
         input_info1, input_info2, output_info,expected)
 {
     std::vector<TensorInfo> inputs_vector_info;
@@ -85,17 +86,17 @@ using CLDepthConcatenateLayerFixture = ConcatenateLayerValidationFixture<CLTenso
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConcatenateLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::F16),
-                                                                                                                  framework::dataset::make("Axis", 2)))
+                                                                                                                  make("Axis", 2)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large3DShapes(), datasets::Small4DShapes()),
-                                                                                                                        framework::dataset::make("DataType",
+                                                                                                                        make("DataType",
                                                                                                                                 DataType::F16),
-                                                                                                                framework::dataset::make("Axis", 2)))
+                                                                                                                make("Axis", 2)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -104,16 +105,16 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                   framework::dataset::make("DataType",
+                                                                                                                   make("DataType",
                                                                                                                            DataType::F32),
-                                                                                                                   framework::dataset::make("Axis", 2)))
+                                                                                                                   make("Axis", 2)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                  DataType::F32),
-                                                                                                                 framework::dataset::make("Axis", 2)))
+                                                                                                                 make("Axis", 2)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -124,16 +125,16 @@ TEST_SUITE_END()
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small3DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("Axis", 2)))
+                                                                                                                     make("Axis", 2)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                    DataType::QASYMM8),
-                                                                                                                   framework::dataset::make("Axis", 2)))
+                                                                                                                   make("Axis", 2)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/DepthConvertLayer.cpp
+++ b/tests/validation/CL/DepthConvertLayer.cpp
@@ -41,19 +41,20 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Input data sets **/
-const auto DepthConvertLayerU8toU16Dataset   = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::U16));
-const auto DepthConvertLayerU8toS16Dataset   = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::S16));
-const auto DepthConvertLayerU8toS32Dataset   = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::S32));
-const auto DepthConvertLayerU16toU8Dataset   = combine(framework::dataset::make("DataType", DataType::U16), framework::dataset::make("DataType", DataType::U8));
-const auto DepthConvertLayerU16toU32Dataset  = combine(framework::dataset::make("DataType", DataType::U16), framework::dataset::make("DataType", DataType::U32));
-const auto DepthConvertLayerS16toU8Dataset   = combine(framework::dataset::make("DataType", DataType::S16), framework::dataset::make("DataType", DataType::U8));
-const auto DepthConvertLayerS16toS32Dataset  = combine(framework::dataset::make("DataType", DataType::S16), framework::dataset::make("DataType", DataType::S32));
-const auto DepthConvertLayerF16toF32Dataset  = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F32));
-const auto DepthConvertLayerF32toF16Dataset  = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F16));
-const auto DepthConvertLayerZeroShiftDataset = framework::dataset::make("Shift", 0);
+const auto DepthConvertLayerU8toU16Dataset   = combine(make("DataType", DataType::U8), make("DataType", DataType::U16));
+const auto DepthConvertLayerU8toS16Dataset   = combine(make("DataType", DataType::U8), make("DataType", DataType::S16));
+const auto DepthConvertLayerU8toS32Dataset   = combine(make("DataType", DataType::U8), make("DataType", DataType::S32));
+const auto DepthConvertLayerU16toU8Dataset   = combine(make("DataType", DataType::U16), make("DataType", DataType::U8));
+const auto DepthConvertLayerU16toU32Dataset  = combine(make("DataType", DataType::U16), make("DataType", DataType::U32));
+const auto DepthConvertLayerS16toU8Dataset   = combine(make("DataType", DataType::S16), make("DataType", DataType::U8));
+const auto DepthConvertLayerS16toS32Dataset  = combine(make("DataType", DataType::S16), make("DataType", DataType::S32));
+const auto DepthConvertLayerF16toF32Dataset  = combine(make("DataType", DataType::F16), make("DataType", DataType::F32));
+const auto DepthConvertLayerF32toF16Dataset  = combine(make("DataType", DataType::F32), make("DataType", DataType::F16));
+const auto DepthConvertLayerZeroShiftDataset = make("Shift", 0);
 } // namespace
 
 TEST_SUITE(CL)
@@ -61,29 +62,29 @@ TEST_SUITE(DepthConvertLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8), // Support upcasting from QASYMM8 to S16
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::QASYMM8), // Support upcasting from QASYMM8 to S16
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Mismatching shapes
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::U8),      // Invalid shift
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Shift non zero and FP
                                                        TensorInfo(TensorShape(32U, 32U, 2U), 1, DataType::U8),      // Valid
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 32U, 2U), 1, DataType::U16),
                                                      }),
-               framework::dataset::make("Policy",{ ConvertPolicy::WRAP,
+               make("Policy",{ ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                    ConvertPolicy::WRAP,
                                                      }),
-               framework::dataset::make("Shift",{ 0, 0, 0, 1, 1, 0, }),
-               framework::dataset::make("Expected", { true, false, false, false, false, true})),
+               make("Shift",{ 0, 0, 0, 1, 1, 0, }),
+               make("Expected", { true, false, false, false, false, true})),
                input_info, output_info, policy, shift, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLDepthConvertLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), policy, shift)) == expected, framework::LogLevel::ERRORS);
@@ -108,7 +109,7 @@ using CLDepthConvertLayerToF32Fixture = DepthConvertLayerValidationFixture<CLTen
 
 TEST_SUITE(U8_to_U16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToU16Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toU16Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -116,7 +117,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToU16Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToU16Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toU16Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -126,7 +127,7 @@ TEST_SUITE_END() // U8_to_U16
 
 TEST_SUITE(U8_to_S16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToS16Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toS16Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -134,7 +135,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToS16Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToS16Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toS16Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -143,7 +144,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToS16Fixture<uint8_t>, frame
 TEST_SUITE_END() // U8_to_S16
 TEST_SUITE(U8_to_S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToS32Fixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU8toS32Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -151,7 +152,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToS32Fixture<uint8_t>, frame
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToS32Fixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU8toS32Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -161,14 +162,14 @@ TEST_SUITE_END() // U8_to_S32
 
 TEST_SUITE(U16_to_U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToU8Fixture<uint16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU16toU8Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToU8Fixture<uint16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU16toU8Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -178,14 +179,14 @@ TEST_SUITE_END() // U16_to_U8
 
 TEST_SUITE(U16_to_U32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToU32Fixture<uint16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerU16toU32Dataset,
-                                                                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                        DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToU32Fixture<uint16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerU16toU32Dataset,
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -195,14 +196,14 @@ TEST_SUITE_END() // U16_to_U32
 
 TEST_SUITE(S16_to_U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToU8Fixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerS16toU8Dataset,
-                                                                                                                     framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                     make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                      DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToU8Fixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerS16toU8Dataset,
-                                                                                                                   framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                   make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                    DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
@@ -212,14 +213,14 @@ TEST_SUITE_END() // S16_to_U8
 
 TEST_SUITE(S16_to_S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthConvertLayerToS32Fixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), DepthConvertLayerS16toS32Dataset,
-                                                                                                                      framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                      make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                       DepthConvertLayerZeroShiftDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthConvertLayerToS32Fixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), DepthConvertLayerS16toS32Dataset,
-                                                                                                                    framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
+                                                                                                                    make("ConvertPolicy", { ConvertPolicy::SATURATE, ConvertPolicy::WRAP }),
                                                                                                                     DepthConvertLayerZeroShiftDataset))
 {
     // Validate output

--- a/tests/validation/CL/DepthToSpaceLayer.cpp
+++ b/tests/validation/CL/DepthToSpaceLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(DepthToSpaceLayer)
 
@@ -49,20 +50,20 @@ using CLDepthToSpaceLayerFixture = DepthToSpaceLayerValidationFixture<CLTensor, 
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 4U, 4U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(16U, 8U, 4U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 8U, 4U, 4U), 1, DataType::F32),   // block < 2
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),    // Negative block shape
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 4U, 4U), 1, DataType::F32), // Wrong tensor shape
                                                      }),
-               framework::dataset::make("BlockShape", { 2, 1, 2, 2, 2 }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 1U, 4U), 1, DataType::F32),
+               make("BlockShape", { 2, 1, 2, 2, 2 }),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 16U, 1U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 16U, 1U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 1U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false, false})),
+               make("Expected", { true, false, false, false, false})),
                input_info, block_shape, output_info, expected)
 {
     bool has_error = bool(CLDepthToSpaceLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), block_shape));
@@ -73,16 +74,16 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthToSpaceLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                        DataType::F32),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthToSpaceLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                      DataType::F32),
-                                                                                                             framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                             make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -90,16 +91,16 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthToSpaceLayerFixture<float>, framework::D
 TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDepthToSpaceLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                       DataType::F16),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDepthToSpaceLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDepthToSpaceLayerDataset(), make("DataType",
                                                                                                                     DataType::F16),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/DepthwiseConvolutionLayer.cpp
+++ b/tests/validation/CL/DepthwiseConvolutionLayer.cpp
@@ -42,6 +42,7 @@ namespace test
 namespace validation
 {
 
+using framework::dataset::concat;
 using framework::dataset::make;
 
 namespace
@@ -199,7 +200,7 @@ TEST_SUITE(W3x3)
 TEST_SUITE(NCHW)
 FIXTURE_DATA_TEST_CASE_NEW(RunSmall, CLDepthwiseConvolutionLayerFixture<half>, framework::DatasetMode::ALL,
     combine(
-        framework::dataset::concat(datasets::SmallDepthwiseConvolutionLayerDataset3x3(),
+        concat(datasets::SmallDepthwiseConvolutionLayerDataset3x3(),
                                         datasets::SmallDepthwiseConvolutionLayerDataset3x3NCHW()),
         depth_multipliers,
         make("DataType", DataType::F16),
@@ -342,7 +343,7 @@ TEST_SUITE(FP32)
 TEST_SUITE(W3x3)
 TEST_SUITE(NCHW)
 FIXTURE_DATA_TEST_CASE_NEW(RunSmall, CLDepthwiseConvolutionLayerFixture<float>, framework::DatasetMode::ALL,
-                           combine(framework::dataset::concat(datasets::SmallDepthwiseConvolutionLayerDataset3x3(),
+                           combine(concat(datasets::SmallDepthwiseConvolutionLayerDataset3x3(),
                                                                                       datasets::SmallDepthwiseConvolutionLayerDataset3x3NCHW()),
                                                            depth_multipliers,
                                                    make("DataType",

--- a/tests/validation/CL/DequantizationLayer.cpp
+++ b/tests/validation/CL/DequantizationLayer.cpp
@@ -41,51 +41,52 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 const auto dataset_quant_f32 = combine(datasets::SmallShapes(), datasets::QuantizedTypes(),
-                                               framework::dataset::make("DataType", DataType::F32),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                               make("DataType", DataType::F32),
+                                       make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_f16 = combine(datasets::SmallShapes(), datasets::QuantizedTypes(),
-                                               framework::dataset::make("DataType", DataType::F16),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                               make("DataType", DataType::F16),
+                                       make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_per_channel_f32 = combine(datasets::SmallShapes(), datasets::QuantizedPerChannelTypes(),
-                                                           framework::dataset::make("DataType", DataType::F32),
-                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                           make("DataType", DataType::F32),
+                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 const auto dataset_quant_per_channel_f16 = combine(datasets::SmallShapes(), datasets::QuantizedPerChannelTypes(),
-                                                           framework::dataset::make("DataType", DataType::F16),
-                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                           make("DataType", DataType::F16),
+                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 const auto dataset_quant_nightly_f32 = combine(datasets::LargeShapes(), datasets::QuantizedTypes(),
-                                                       framework::dataset::make("DataType", DataType::F32),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                                       make("DataType", DataType::F32),
+                                               make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_nightly_f16 = combine(datasets::LargeShapes(), datasets::QuantizedTypes(),
-                                                       framework::dataset::make("DataType", DataType::F16),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }));
+                                                       make("DataType", DataType::F16),
+                                               make("DataLayout", { DataLayout::NCHW }));
 const auto dataset_quant_per_channel_nightly_f32 = combine(datasets::LargeShapes(), datasets::QuantizedPerChannelTypes(),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                                   make("DataType", DataType::F32),
+                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 const auto dataset_quant_per_channel_nightly_f16 = combine(datasets::LargeShapes(), datasets::QuantizedPerChannelTypes(),
-                                                                   framework::dataset::make("DataType", DataType::F16),
-                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
+                                                                   make("DataType", DataType::F16),
+                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }));
 } // namespace
 TEST_SUITE(CL)
 TEST_SUITE(DequantizationLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),      // Wrong input data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),      // Wrong input data type
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Wrong output data type
                                                        TensorInfo(TensorShape(16U, 16U, 2U, 5U), 1, DataType::QASYMM8),   // Missmatching shapes
                                                        TensorInfo(TensorShape(17U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Valid
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Valid
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(17U, 16U, 16U, 5U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { false, false, false, true, true})),
+               make("Expected", { false, false, false, true, true})),
                input_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLDequantizationLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);

--- a/tests/validation/CL/DilatedConvolutionLayer.cpp
+++ b/tests/validation/CL/DilatedConvolutionLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float>            rel_tolerance_f32(0.05f);                 /**< Relative tolerance value for comparing reference's output against implementation's output for DataType::F32 */
@@ -51,7 +52,7 @@ constexpr float                     abs_tolerance_f16 = 0.3f;                 /*
 constexpr float                     tolerance_num_f16 = 0.07f;                /**< Tolerance number for FP16 */
 
 /** CNN data types */
-const auto CNNDataTypes = framework::dataset::make("DataType",
+const auto CNNDataTypes = make("DataType",
 {
     DataType::F16,
     DataType::F32,
@@ -62,44 +63,44 @@ const auto CNNDataTypes = framework::dataset::make("DataType",
 TEST_SUITE(CL)
 TEST_SUITE(DilatedConvolutionLayer)
 
-DATA_TEST_CASE(ValidateConvolutionMethod, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(17U, 31U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(ValidateConvolutionMethod, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(17U, 31U, 2U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(17U, 31U, 2U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(23U, 27U, 23U, 4U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(3U, 3U, 2U, 1U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(33U, 27U, 7U, 4U), 1, DataType::F32)
                                                                                                                                      }),
-                                                                                               framework::dataset::make("WeightsInfo", { TensorInfo(TensorShape(5U, 5U, 2U, 19U), 1, DataType::F32),
+                                                                                               make("WeightsInfo", { TensorInfo(TensorShape(5U, 5U, 2U, 19U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(5U, 5U, 2U, 19U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(3U, 3U, 23U, 21U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(3U, 3U, 5U, 21U), 1, DataType::F32),
                                                                                                                         TensorInfo(TensorShape(5U, 5U, 7U, 16U), 1, DataType::F16)
                                                                                                                                        }),
-                                                                                           framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(15U, 15U, 19U), 1, DataType::F32),
+                                                                                           make("OutputInfo", { TensorInfo(TensorShape(15U, 15U, 19U), 1, DataType::F32),
                                                                                                                     TensorInfo(TensorShape(15U, 15U, 19U), 1, DataType::F32),
                                                                                                                     TensorInfo(TensorShape(21U, 25U, 21U, 4U), 1, DataType::F32),
                                                                                                                     TensorInfo(TensorShape(11U, 25U, 21U), 1, DataType::F32),
                                                                                                                     TensorInfo(TensorShape(11U, 12U, 16U, 4U), 1, DataType::F32)
                                                                                                                                   }),
-                                                                                       framework::dataset::make("ConvInfo", { PadStrideInfo(1, 2, 1, 1),
+                                                                                       make("ConvInfo", { PadStrideInfo(1, 2, 1, 1),
                                                                                                                 PadStrideInfo(1, 2, 1, 1),
                                                                                                                 PadStrideInfo(1, 1, 0, 0),
                                                                                                                 PadStrideInfo(2, 1, 0, 0),
                                                                                                                 PadStrideInfo(3, 2, 1, 0)
                                                                                                                             }),
-                                                                                   framework::dataset::make("GpuTarget", { GPUTarget::BIFROST,
+                                                                                   make("GpuTarget", { GPUTarget::BIFROST,
                                                                                                             GPUTarget::MIDGARD,
                                                                                                             GPUTarget::G71,
                                                                                                             GPUTarget::MIDGARD,
                                                                                                             GPUTarget::BIFROST
                                                                                                                          }),
-                                                                               framework::dataset::make("Dilation", { Size2D(1U, 1U),
+                                                                               make("Dilation", { Size2D(1U, 1U),
                                                                                                                       Size2D(1U, 1U),
                                                                                                                       Size2D(1U, 1U),
                                                                                                                       Size2D(2U, 2U),
                                                                                                                       Size2D(3U, 3U)
                                                                                                                     }),
 
-                                                                           framework::dataset::make("Expected", { ConvolutionMethod::GEMM, ConvolutionMethod::GEMM, ConvolutionMethod::WINOGRAD, ConvolutionMethod::GEMM, ConvolutionMethod::GEMM })),
+                                                                           make("Expected", { ConvolutionMethod::GEMM, ConvolutionMethod::GEMM, ConvolutionMethod::WINOGRAD, ConvolutionMethod::GEMM, ConvolutionMethod::GEMM })),
                input_info, weights_info, output_info, conv_info, gpu_target, dilation, expected)
 {
     ConvolutionMethod is_valid = CLConvolutionLayer::get_convolution_method(&input_info.clone()->set_is_resizable(true),
@@ -118,20 +119,20 @@ using CLGEMMDilatedConvolutionLayerFixture = ConvolutionValidationFixture<CLTens
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMDilatedConvolutionLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDilatedConvolutionLayerDataset(),
-                                                                                                                        framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                        framework::dataset::make("DataType", DataType::F16),
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                        framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                                                                                        make("ReshapeWeights", { true }),
+                                                                                                                        make("DataType", DataType::F16),
+                                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                        make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, rel_tolerance_f16, 0.0f, abs_tolerance_f16);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMDilatedConvolutionLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDilatedConvolutionLayerDataset(),
-                                                                                                                      framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                      framework::dataset::make("DataType", DataType::F16),
-                                                                                                                      framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                      framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                                                                                      make("ReshapeWeights", { true }),
+                                                                                                                      make("DataType", DataType::F16),
+                                                                                                                      make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                      make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, rel_tolerance_f16, tolerance_num_f16);
@@ -141,20 +142,20 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMDilatedConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallDilatedConvolutionLayerDataset(),
-                       framework::dataset::make("ReshapeWeights", { true }),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                       framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                       make("ReshapeWeights", { true }),
+                       make("DataType", DataType::F32),
+                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                       make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, rel_tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMDilatedConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeDilatedConvolutionLayerDataset(),
-                                                                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                                                                                       framework::dataset::make("DataType", DataType::F32),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                       framework::dataset::make("ActivationLayerInfo", ActivationLayerInfo())))
+                                                                                                                       make("ReshapeWeights", { true }),
+                                                                                                                       make("DataType", DataType::F32),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                       make("ActivationLayerInfo", ActivationLayerInfo())))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, rel_tolerance_f32, 0.f, abs_tolerance_f32);
@@ -174,11 +175,11 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMDilatedConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallDilatedConvolutionLayerDataset(),
-                                                               framework::dataset::make("ReshapeWeights", { true }),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                       framework::dataset::make("IgnoredQuantizationInfo", { QuantizationInfo() }),
-                               framework::dataset::make("ActivationLayerInfo", { ActivationLayerInfo() })))
+                                                               make("ReshapeWeights", { true }),
+                                                       make("DataType", DataType::QASYMM8),
+                                               make("DataLayout", { DataLayout::NCHW }),
+                                       make("IgnoredQuantizationInfo", { QuantizationInfo() }),
+                               make("ActivationLayerInfo", { ActivationLayerInfo() })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, abs_tolerance_qasymm8);
@@ -186,11 +187,11 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMDilatedConvolutionLayerQuantizedFixture<u
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMDilatedConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeDilatedConvolutionLayerDataset(),
-                                                               framework::dataset::make("ReshapeWeights", { true }),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                       framework::dataset::make("IgnoredQuantizationInfo", { QuantizationInfo() }),
-                               framework::dataset::make("ActivationLayerInfo", { ActivationLayerInfo() })))
+                                                               make("ReshapeWeights", { true }),
+                                                       make("DataType", DataType::QASYMM8),
+                                               make("DataLayout", { DataLayout::NCHW }),
+                                       make("IgnoredQuantizationInfo", { QuantizationInfo() }),
+                               make("ActivationLayerInfo", { ActivationLayerInfo() })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, abs_tolerance_qasymm8);

--- a/tests/validation/CL/DirectConvolutionLayer.cpp
+++ b/tests/validation/CL/DirectConvolutionLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<half>  tolerance_fp16(half(0.2));  /**< Tolerance for floating point tests */
@@ -50,16 +51,16 @@ constexpr float          abs_tolerance_f32(0.0001f); /**< Absolute tolerance for
 constexpr float                      tolerance_num = 0.07f; /**< Tolerance number */
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);  /**< Tolerance for quantized tests */
 
-const auto data_strides          = combine(framework::dataset::make("StrideX", 1, 3), framework::dataset::make("StrideY", 1, 3));
-const auto data_strides_small    = combine(framework::dataset::make("StrideX", 1), framework::dataset::make("StrideY", 1));
-const auto data_ksize_one        = combine(framework::dataset::make("PadX", 0, 1), framework::dataset::make("PadY", 0, 1), framework::dataset::make("KernelSize", 1));
-const auto data_ksize_one_small  = combine(framework::dataset::make("PadX", 0), framework::dataset::make("PadY", 0), framework::dataset::make("KernelSize", 1));
-const auto data_ksize_three      = combine(framework::dataset::make("PadX", 0, 2), framework::dataset::make("PadY", 0, 2), framework::dataset::make("KernelSize", 3));
-const auto data_ksize_five       = combine(framework::dataset::make("PadX", 0, 3), framework::dataset::make("PadY", 0, 3), framework::dataset::make("KernelSize", 5));
-const auto data_ksize_nine       = combine(framework::dataset::make("PadX", 0, 3), framework::dataset::make("PadY", 0, 3), framework::dataset::make("KernelSize", 9));
-const auto data_ksize_nine_small = combine(framework::dataset::make("PadX", 0, 1), framework::dataset::make("PadY", 0, 1), framework::dataset::make("KernelSize", 9));
+const auto data_strides          = combine(make("StrideX", 1, 3), make("StrideY", 1, 3));
+const auto data_strides_small    = combine(make("StrideX", 1), make("StrideY", 1));
+const auto data_ksize_one        = combine(make("PadX", 0, 1), make("PadY", 0, 1), make("KernelSize", 1));
+const auto data_ksize_one_small  = combine(make("PadX", 0), make("PadY", 0), make("KernelSize", 1));
+const auto data_ksize_three      = combine(make("PadX", 0, 2), make("PadY", 0, 2), make("KernelSize", 3));
+const auto data_ksize_five       = combine(make("PadX", 0, 3), make("PadY", 0, 3), make("KernelSize", 5));
+const auto data_ksize_nine       = combine(make("PadX", 0, 3), make("PadY", 0, 3), make("KernelSize", 9));
+const auto data_ksize_nine_small = combine(make("PadX", 0, 1), make("PadY", 0, 1), make("KernelSize", 9));
 
-const auto data_all_kernels = concat(concat(data_ksize_one, data_ksize_three), data_ksize_five);
+const auto data_all_kernels = concat(data_ksize_one, data_ksize_three, data_ksize_five);
 
 const auto data          = combine(datasets::SmallDirectConvolutionShapes(), data_strides, data_all_kernels);
 const auto data9x9       = combine(datasets::SmallDirectConvolutionShapes(), data_strides, data_ksize_nine);
@@ -67,22 +68,22 @@ const auto data_small    = combine(datasets::SmallDirectConvolutionShapes(), dat
 const auto data_small9x9 = combine(datasets::SmallDirectConvolutionShapes(), data_strides_small, data_ksize_nine_small);
 
 /** Direct convolution nightly data set. */
-const auto data_nightly         = combine(data, framework::dataset::make("NumKernels", { 1, 4 }));
-const auto data_nightly_9x9     = combine(data9x9, framework::dataset::make("NumKernels", { 1, 4 }));
-const auto data_nightly_usecase = combine(framework::dataset::make("InputShape", { TensorShape{ 3U, 800U, 800U } }),
-                                          framework::dataset::make("StrideX", { 1 }),
-                                                  framework::dataset::make("StrideY", { 1 }),
-                                                          framework::dataset::make("PadX", { 4 }),
-                                                                  framework::dataset::make("PadY", { 4 }),
-                                                                          framework::dataset::make("KernelSize", 9),
-                                                                                  framework::dataset::make("NumKernels", { 16 }));
+const auto data_nightly         = combine(data, make("NumKernels", { 1, 4 }));
+const auto data_nightly_9x9     = combine(data9x9, make("NumKernels", { 1, 4 }));
+const auto data_nightly_usecase = combine(make("InputShape", { TensorShape{ 3U, 800U, 800U } }),
+                                          make("StrideX", { 1 }),
+                                                  make("StrideY", { 1 }),
+                                                          make("PadX", { 4 }),
+                                                                  make("PadY", { 4 }),
+                                                                          make("KernelSize", 9),
+                                                                                  make("NumKernels", { 16 }));
 
 /** Direct convolution precommit data set. */
-const auto data_precommit     = combine(data_small, framework::dataset::make("NumKernels", { 1 }));
-const auto data_precommit_9x9 = combine(data_small9x9, framework::dataset::make("NumKernels", { 1 }));
+const auto data_precommit     = combine(data_small, make("NumKernels", { 1 }));
+const auto data_precommit_9x9 = combine(data_small9x9, make("NumKernels", { 1 }));
 
 /** Activation function Dataset*/
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 0.5f) });
 } // namespace
 
@@ -184,7 +185,7 @@ TEST_CASE(NonSquareKernel, framework::DatasetMode::PRECOMMIT)
 }
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid: Mismatching data type input/weights
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid: Mismatching data type input/weights
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid: Mismatching input feature maps
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid weights dimensions
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Unsupported biases size
@@ -192,7 +193,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Invalid output size
                                                        TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("WeightsInfo",{ TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F16),
+               make("WeightsInfo",{ TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(3U, 3U, 3U, 4U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(3U, 3U, 2U, 4U, 3U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),
@@ -200,7 +201,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                         TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(1U, 1U, 2U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("BiasesInfo",{ TensorInfo(TensorShape(4U), 1, DataType::F32),
+               make("BiasesInfo",{ TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(3U), 1, DataType::F32),
@@ -208,7 +209,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32),
@@ -216,7 +217,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(26U, 11U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("ConvInfo",  { PadStrideInfo(1, 1, 0, 0),
+               make("ConvInfo",  { PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(1, 1, 0, 0),
@@ -224,7 +225,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(1, 1, 0, 0),
                                                       }),
-                       framework::dataset::make("ActivationInfo",
+                       make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -234,7 +235,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU)
 }),
-               framework::dataset::make("Expected", { false, false, false, false, false, false, true })),
+               make("Expected", { false, false, false, false, false, false, true })),
                input_info, weights_info, biases_info, output_info, conv_info, act_info, expected)
 {
     bool is_valid = bool(CLDirectConvolutionLayer::validate(&input_info.clone()->set_is_resizable(false), &weights_info.clone()->set_is_resizable(false), &biases_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), conv_info, act_info));
@@ -259,38 +260,38 @@ using CLDirectConvolutionValidationWithTensorShapesQuantizedFixture = DirectConv
 TEST_SUITE(NHWC)
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", {
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", {
                                                        TensorInfo(TensorShape(2U, 27U, 13U), 1, DataType::F32, DataLayout::NHWC), // Arbitrary weight sizes for NHWC are supported
                                                        TensorInfo(TensorShape(2U, 27U, 13U), 1, DataType::F32, DataLayout::NHWC), // Non-rectangular weights dimensions for NHWC are supported
                                                        TensorInfo(TensorShape(2U, 27U, 13U), 1, DataType::F32, DataLayout::NHWC), // Strides > 2 for any kernel sizes for NHWC are supported
                                                      }),
-               framework::dataset::make("WeightsInfo",{
+               make("WeightsInfo",{
                                                         TensorInfo(TensorShape(2U, 13U, 13U, 4U), 1, DataType::F32, DataLayout::NHWC),
                                                         TensorInfo(TensorShape(2U, 5U, 3U, 4U), 1, DataType::F32, DataLayout::NHWC),
                                                         TensorInfo(TensorShape(2U, 3U, 3U, 4U), 1, DataType::F32, DataLayout::NHWC),
                                                      }),
-               framework::dataset::make("BiasesInfo",{
+               make("BiasesInfo",{
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32, DataLayout::NHWC),
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32, DataLayout::NHWC),
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32, DataLayout::NHWC),
                                                      }),
-               framework::dataset::make("OutputInfo",{
+               make("OutputInfo",{
                                                        TensorInfo(TensorShape(4U, 15U, 1U), 1, DataType::F32, DataLayout::NHWC),
                                                        TensorInfo(TensorShape(4U, 23U, 11U), 1, DataType::F32, DataLayout::NHWC),
                                                        TensorInfo(TensorShape(4U, 9U, 4U), 1, DataType::F32, DataLayout::NHWC),
                                                      }),
-               framework::dataset::make("ConvInfo",  {
+               make("ConvInfo",  {
                                                        PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(3, 3, 0, 0),
                                                       }),
-                       framework::dataset::make("ActivationInfo",
+                       make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
 }),
-               framework::dataset::make("Expected", { true, true, true })),
+               make("Expected", { true, true, true })),
                input_info, weights_info, biases_info, output_info, conv_info, act_info, expected)
 {
     bool is_valid = bool(CLDirectConvolutionLayer::validate(&input_info.clone()->set_is_resizable(false), &weights_info.clone()->set_is_resizable(false), &biases_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), conv_info, act_info));
@@ -298,34 +299,34 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 }
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1, 3, 1, 1 }),
-               framework::dataset::make("StrideY", { 1, 3, 2, 1 }),
-               framework::dataset::make("PadX", { 1, 3, 0, 4 }),
-               framework::dataset::make("PadY", { 1, 3, 0, 4 }),
-               framework::dataset::make("KernelSize", { 3, 8, 1, 9 }),
-               framework::dataset::make("NumKernels", { 17, 3, 1, 19 })),
-               framework::dataset::make("DataType",  DataType::F16),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1, 3, 1, 1 }),
+               make("StrideY", { 1, 3, 2, 1 }),
+               make("PadX", { 1, 3, 0, 4 }),
+               make("PadY", { 1, 3, 0, 4 }),
+               make("KernelSize", { 3, 8, 1, 9 }),
+               make("NumKernels", { 17, 3, 1, 19 })),
+               make("DataType",  DataType::F16),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp16, tolerance_num);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerFixture<half>, framework::DatasetMode::NIGHTLY,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(800U, 800U, 3U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 1 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 9 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::F16),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               combine(zip(make("InputShape", { TensorShape(800U, 800U, 3U) } ),
+               make("StrideX", { 1 }),
+               make("StrideY", { 1 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 9 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::F16),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp16, tolerance_num);
 }
@@ -334,50 +335,50 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1, 3, 1, 1 }),
-               framework::dataset::make("StrideY", { 1, 3, 2, 1 }),
-               framework::dataset::make("PadX", { 1, 3, 0, 4 }),
-               framework::dataset::make("PadY", { 1, 3, 0, 4 }),
-               framework::dataset::make("KernelSize", { 3, 8, 1, 9 }),
-               framework::dataset::make("NumKernels", { 17, 3, 1, 19 })),
-               framework::dataset::make("DataType",  DataType::F32),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1, 3, 1, 1 }),
+               make("StrideY", { 1, 3, 2, 1 }),
+               make("PadX", { 1, 3, 0, 4 }),
+               make("PadY", { 1, 3, 0, 4 }),
+               make("KernelSize", { 3, 8, 1, 9 }),
+               make("NumKernels", { 17, 3, 1, 19 })),
+               make("DataType",  DataType::F32),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLDirectConvolutionLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 2 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 3 }),
-               framework::dataset::make("KernelSize", { 3 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::F32),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1 }),
+               make("StrideY", { 2 }),
+               make("PadX", { 1 }),
+               make("PadY", { 3 }),
+               make("KernelSize", { 3 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::F32),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(800U, 800U, 3U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 1 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 9 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::F32),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               combine(zip(make("InputShape", { TensorShape(800U, 800U, 3U) } ),
+               make("StrideX", { 1 }),
+               make("StrideY", { 1 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 9 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::F32),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
@@ -386,53 +387,53 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1, 3, 1, 1 }),
-               framework::dataset::make("StrideY", { 1, 3, 2, 1 }),
-               framework::dataset::make("PadX", { 1, 3, 0, 4 }),
-               framework::dataset::make("PadY", { 1, 3, 0, 4 }),
-               framework::dataset::make("KernelSize", { 3, 8, 1, 9 }),
-               framework::dataset::make("NumKernels", { 7, 3, 1, 3 })),
-               framework::dataset::make("DataType",  DataType::QASYMM8),
-               framework::dataset::make("QuantizationInfo", QuantizationInfo(1.1f / 255, 10)),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1, 3, 1, 1 }),
+               make("StrideY", { 1, 3, 2, 1 }),
+               make("PadX", { 1, 3, 0, 4 }),
+               make("PadY", { 1, 3, 0, 4 }),
+               make("KernelSize", { 3, 8, 1, 9 }),
+               make("NumKernels", { 7, 3, 1, 3 })),
+               make("DataType",  DataType::QASYMM8),
+               make("QuantizationInfo", QuantizationInfo(1.1f / 255, 10)),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLDirectConvolutionLayerQuantizedMixedDataLayoutFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 2 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 3 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::QASYMM8),
-               framework::dataset::make("QuantizationInfo", QuantizationInfo(1.1f / 255, 10)),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1 }),
+               make("StrideY", { 2 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 3 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::QASYMM8),
+               make("QuantizationInfo", QuantizationInfo(1.1f / 255, 10)),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(800U, 800U, 3U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 1 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 9 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::QASYMM8),
-               framework::dataset::make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               combine(zip(make("InputShape", { TensorShape(800U, 800U, 3U) } ),
+               make("StrideX", { 1 }),
+               make("StrideY", { 1 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 9 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::QASYMM8),
+               make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
@@ -440,53 +441,53 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerQuantizedFixture<uint8_
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1, 3, 1, 1 }),
-               framework::dataset::make("StrideY", { 1, 3, 2, 1 }),
-               framework::dataset::make("PadX", { 1, 3, 0, 4 }),
-               framework::dataset::make("PadY", { 1, 3, 0, 4 }),
-               framework::dataset::make("KernelSize", { 3, 8, 1, 9 }),
-               framework::dataset::make("NumKernels", { 7, 3, 1, 3 })),
-               framework::dataset::make("DataType",  DataType::QASYMM8_SIGNED),
-               framework::dataset::make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1, 3, 1, 1 }),
+               make("StrideY", { 1, 3, 2, 1 }),
+               make("PadX", { 1, 3, 0, 4 }),
+               make("PadY", { 1, 3, 0, 4 }),
+               make("KernelSize", { 3, 8, 1, 9 }),
+               make("NumKernels", { 7, 3, 1, 3 })),
+               make("DataType",  DataType::QASYMM8_SIGNED),
+               make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLDirectConvolutionLayerQuantizedMixedDataLayoutFixture<int8_t>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 1 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 3 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::QASYMM8_SIGNED),
-               framework::dataset::make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1 }),
+               make("StrideY", { 1 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 3 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::QASYMM8_SIGNED),
+               make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::NIGHTLY,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(800U, 800U, 3U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 1 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 9 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::QASYMM8_SIGNED),
-               framework::dataset::make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               combine(zip(make("InputShape", { TensorShape(800U, 800U, 3U) } ),
+               make("StrideX", { 1 }),
+               make("StrideY", { 1 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 9 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::QASYMM8_SIGNED),
+               make("QuantizationInfo", QuantizationInfo(2.f / 255, 10)),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
@@ -495,38 +496,38 @@ TEST_SUITE_END() // Quantized
 TEST_SUITE_END() // NHWC
 
 TEST_SUITE(NCHW)
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", {
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", {
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32, DataLayout::NCHW), // Unsupported kernel width
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32, DataLayout::NCHW), // Non-rectangular weights dimensions are unsupported
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32, DataLayout::NCHW)  // Unsupported stride
                                                      }),
-               framework::dataset::make("WeightsInfo",{
+               make("WeightsInfo",{
                                                         TensorInfo(TensorShape(11U, 11U, 2U, 4U), 1, DataType::F32, DataLayout::NCHW),
                                                         TensorInfo(TensorShape(5U, 3U, 2U, 4U), 1, DataType::F32, DataLayout::NCHW),
                                                         TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32, DataLayout::NCHW)
                                                      }),
-               framework::dataset::make("BiasesInfo",{
+               make("BiasesInfo",{
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32, DataLayout::NCHW),
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32, DataLayout::NCHW),
                                                        TensorInfo(TensorShape(4U), 1, DataType::F32, DataLayout::NCHW)
                                                      }),
-               framework::dataset::make("OutputInfo",{
+               make("OutputInfo",{
                                                        TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32, DataLayout::NCHW),
                                                        TensorInfo(TensorShape(23U, 11U, 4U), 1, DataType::F32, DataLayout::NCHW),
                                                        TensorInfo(TensorShape(25U, 11U, 4U), 1, DataType::F32, DataLayout::NCHW)
                                                      }),
-               framework::dataset::make("ConvInfo",  {
+               make("ConvInfo",  {
                                                        PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(1, 1, 0, 0),
                                                        PadStrideInfo(3, 3, 0, 0)
                                                       }),
-                       framework::dataset::make("ActivationInfo",
+                       make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU)
 }),
-               framework::dataset::make("Expected", { false, false, false})),
+               make("Expected", { false, false, false})),
                input_info, weights_info, biases_info, output_info, conv_info, act_info, expected)
 {
     bool is_valid = bool(CLDirectConvolutionLayer::validate(&input_info.clone()->set_is_resizable(false), &weights_info.clone()->set_is_resizable(false), &biases_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), conv_info, act_info));
@@ -537,16 +538,16 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(data_precommit, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(data_precommit, make("DataType", DataType::F16),
                                                                                                                    ActivationFunctionsDataset,
-                                                                                                                   framework::dataset::make("DataLayout", DataLayout::NCHW)))
+                                                                                                                   make("DataLayout", DataLayout::NCHW)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp16, tolerance_num);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(data_nightly, framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(data_nightly, make("DataType", DataType::F16),
                                                                                                                  ActivationFunctionsDataset,
-                                                                                                                 framework::dataset::make("DataLayout", DataLayout::NCHW)))
+                                                                                                                 make("DataLayout", DataLayout::NCHW)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp16, tolerance_num);
@@ -554,24 +555,24 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerFixture<half>, framewor
 TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit, make("DataType",
                                                                                                                     DataType::F32),
                                                                                                                     ActivationFunctionsDataset,
-                                                                                                                    framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                                                                                                                    make("DataLayout", { DataLayout::NCHW })))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLDirectConvolutionLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::F32),
                        ActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(data_nightly, framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(data_nightly, make("DataType", DataType::F32),
                                                                                                                   ActivationFunctionsDataset,
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                                                                                                                  make("DataLayout", { DataLayout::NCHW })))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
@@ -579,7 +580,7 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP32_CustomDataset)
 FIXTURE_DATA_TEST_CASE(Run, CLDirectConvolutionValidationWithTensorShapesFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::DirectConvolutionLayerDataset(),
-                       framework::dataset::make("DataType", DataType::F32),
+                       make("DataType", DataType::F32),
                        ActivationFunctionsDataset))
 {
     // Validate output
@@ -593,131 +594,131 @@ TEST_SUITE_END() // Float
 /// fixture generates separate quantization info for each input and the output tensor.
 /// When we can also support dynamic quantization with the presence of activation, these two versions should be merged
 /// again, with the explicitly specified quantization info removed
-const auto QuantizedActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto QuantizedActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 6.f)
 });
-const auto NoActivation = framework::dataset::make("ActivationInfo",
+const auto NoActivation = make("ActivationInfo",
 {
     ActivationLayerInfo()
 });
-const auto IgnoredQuantizationInfo = framework::dataset::make("IgnoredQuantizationInfo",
+const auto IgnoredQuantizationInfo = make("IgnoredQuantizationInfo",
 {
     QuantizationInfo()
 });
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLDirectConvolutionLayerQuantizedMixedDataLayoutFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        IgnoredQuantizationInfo,
                        NoActivation,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayoutWithActivation, CLDirectConvolutionLayerQuantizedMixedDataLayoutFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10) }),
+                       make("DataType", DataType::QASYMM8),
+                       make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10) }),
                        QuantizedActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
+                       make("DataType", DataType::QASYMM8),
                        IgnoredQuantizationInfo,
                        NoActivation,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallWithActivation, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data_precommit,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, 10) }),
+                       make("DataType", DataType::QASYMM8),
+                       make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, 10) }),
                        QuantizedActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall9x9, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data_precommit_9x9,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8),
                        IgnoredQuantizationInfo,
                        NoActivation,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall9x9WithActivation, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(data_precommit_9x9,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(3.f / 255, 10), QuantizationInfo(1.1f, 10) }),
+                       make("QuantizationInfo", { QuantizationInfo(3.f / 255, 10), QuantizationInfo(1.1f, 10) }),
                        QuantizedActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data_nightly, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data_nightly, make("DataType",
                        DataType::QASYMM8),
                        IgnoredQuantizationInfo,
                        NoActivation,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
-FIXTURE_DATA_TEST_CASE(RunLargeWithActivation, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data_nightly, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLargeWithActivation, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data_nightly, make("DataType",
                        DataType::QASYMM8),
-                       framework::dataset::make("QuantizationInfoIf", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, 10) }),
+                       make("QuantizationInfoIf", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, 10) }),
                        QuantizedActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge9x9, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data_nightly_9x9,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8),
                        IgnoredQuantizationInfo,
                        NoActivation,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge9x9WithActivation, CLDirectConvolutionLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(data_nightly_9x9,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(3.f / 255, 10), QuantizationInfo(1.1f, 10) }),
+                       make("QuantizationInfo", { QuantizationInfo(3.f / 255, 10), QuantizationInfo(1.1f, 10) }),
                        QuantizedActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(CustomDataset, CLDirectConvolutionValidationWithTensorShapesQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::DirectConvolutionLayerDataset(),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8),
+                                                       make("DataType", DataType::QASYMM8),
                                                IgnoredQuantizationInfo,
                                        NoActivation,
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                               make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(CustomDatasetWithActivation, CLDirectConvolutionValidationWithTensorShapesQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::DirectConvolutionLayerDataset(),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255, 127), QuantizationInfo(1.1f, 10) }),
+                                                       make("DataType", DataType::QASYMM8),
+                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255, 127), QuantizationInfo(1.1f, 10) }),
                                        QuantizedActivationFunctionsDataset,
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                               make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -726,60 +727,60 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit, make("DataType",
                                                                                                                         DataType::QASYMM8_SIGNED),
                                                                                                                         IgnoredQuantizationInfo,
                                                                                                                         NoActivation,
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
-FIXTURE_DATA_TEST_CASE(RunSmallWithActivation, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmallWithActivation, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit, make("DataType",
                                                                                                                         DataType::QASYMM8_SIGNED),
-                                                                                                                        framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, -10) }),
+                                                                                                                        make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, -10) }),
                                                                                                                         QuantizedActivationFunctionsDataset,
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLDirectConvolutionLayerQuantizedMixedDataLayoutFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8_SIGNED),
                        IgnoredQuantizationInfo,
                        NoActivation,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayoutWithActivation, CLDirectConvolutionLayerQuantizedMixedDataLayoutFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.1f, -10) }),
+                       make("QuantizationInfo", { QuantizationInfo(1.1f, -10) }),
                        QuantizedActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall9x9, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit_9x9,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8_SIGNED),
                        IgnoredQuantizationInfo,
                        NoActivation,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall9x9WithActivation, CLDirectConvolutionLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(data_precommit_9x9,
-                       framework::dataset::make("DataType",
+                       make("DataType",
                                                 DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, 10) }),
+                       make("QuantizationInfo", { QuantizationInfo(2.f / 255, 10), QuantizationInfo(1.1f, 10) }),
                        QuantizedActivationFunctionsDataset,
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -787,10 +788,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall9x9WithActivation, CLDirectConvolutionLayerQuanti
 
 FIXTURE_DATA_TEST_CASE(RunCustomDataset, CLDirectConvolutionValidationWithTensorShapesQuantizedFixture<int8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::DirectConvolutionLayerDataset(),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                       make("DataType", DataType::QASYMM8_SIGNED),
                                                IgnoredQuantizationInfo,
                                        NoActivation,
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                               make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -798,10 +799,10 @@ FIXTURE_DATA_TEST_CASE(RunCustomDataset, CLDirectConvolutionValidationWithTensor
 
 FIXTURE_DATA_TEST_CASE(RunCustomDatasetWithActivation, CLDirectConvolutionValidationWithTensorShapesQuantizedFixture<int8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::DirectConvolutionLayerDataset(),
-                                                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                               framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255, 127), QuantizationInfo(1.1f, 10) }),
+                                                       make("DataType", DataType::QASYMM8_SIGNED),
+                                               make("QuantizationInfo", { QuantizationInfo(2.f / 255, 127), QuantizationInfo(1.1f, 10) }),
                                        QuantizedActivationFunctionsDataset,
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                               make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/CL/ElementwiseMax.cpp
+++ b/tests/validation/CL/ElementwiseMax.cpp
@@ -41,38 +41,39 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
 RelativeTolerance<float> tolerance_fp16(0.001f);
 
 /** Input data sets **/
-const auto ElementwiseMaxU8Dataset = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType",
+const auto ElementwiseMaxU8Dataset = combine(make("DataType", DataType::U8), make("DataType", DataType::U8), make("DataType",
                                              DataType::U8));
-const auto ElementwiseMaxQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                                  framework::dataset::make("DataType",
+const auto ElementwiseMaxQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                                  make("DataType",
                                                                            DataType::QASYMM8));
-const auto ElementwiseMaxQASYMM8SignedDataset = combine(framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                        framework::dataset::make("DataType",
+const auto ElementwiseMaxQASYMM8SignedDataset = combine(make("DataType", DataType::QASYMM8_SIGNED), make("DataType", DataType::QASYMM8_SIGNED),
+                                                        make("DataType",
                                                                                  DataType::QASYMM8_SIGNED));
-const auto ElementwiseMaxQSYMM16Dataset = combine(framework::dataset::make("DataType", DataType::QSYMM16), framework::dataset::make("DataType", DataType::QSYMM16),
-                                                  framework::dataset::make("DataType",
+const auto ElementwiseMaxQSYMM16Dataset = combine(make("DataType", DataType::QSYMM16), make("DataType", DataType::QSYMM16),
+                                                  make("DataType",
                                                                            DataType::QSYMM16));
-const auto ElementwiseMaxS16Dataset = combine(framework::dataset::make("DataType", { DataType::S16 }), framework::dataset::make("DataType", DataType::S16),
-                                              framework::dataset::make("DataType", DataType::S16));
-const auto ElementwiseMaxFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                               framework::dataset::make("DataType", DataType::F16));
-const auto ElementwiseMaxFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                               framework::dataset::make("DataType", DataType::F32));
-const auto EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ElementwiseMaxS16Dataset = combine(make("DataType", { DataType::S16 }), make("DataType", DataType::S16),
+                                              make("DataType", DataType::S16));
+const auto ElementwiseMaxFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                               make("DataType", DataType::F16));
+const auto ElementwiseMaxFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                               make("DataType", DataType::F32));
+const auto EmptyActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -80,19 +81,19 @@ TEST_SUITE(ElementwiseMax)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("OutputInfo",{TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false})),
+               make("Expected", { true, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLElementwiseMax::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -130,9 +131,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseMaxQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                        ElementwiseMaxQASYMM8Dataset,
-                                                                                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                       make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                                                                                                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -142,9 +143,9 @@ TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseMaxQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                       ElementwiseMaxQASYMM8SignedDataset,
-                                                                                                                      framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                      framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                      framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                                      make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                      make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                      make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                                                                                                       OutOfPlaceDataSet))
 {
     // Validate output
@@ -154,9 +155,9 @@ TEST_SUITE_END()
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseMaxQuantizedFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                        ElementwiseMaxQSYMM16Dataset,
-                                                                                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                                                                                                                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                                                                                                                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                                       make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                                                                                                                        OutOfPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/CL/ElementwiseMin.cpp
+++ b/tests/validation/CL/ElementwiseMin.cpp
@@ -41,38 +41,39 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
 RelativeTolerance<float> tolerance_fp16(0.001f);
 
 /** Input data sets **/
-const auto ElementwiseMinU8Dataset = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType",
+const auto ElementwiseMinU8Dataset = combine(make("DataType", DataType::U8), make("DataType", DataType::U8), make("DataType",
                                              DataType::U8));
-const auto ElementwiseMinQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                                  framework::dataset::make("DataType",
+const auto ElementwiseMinQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                                  make("DataType",
                                                                            DataType::QASYMM8));
-const auto ElementwiseMinQASYMM8SignedDataset = combine(framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                        framework::dataset::make("DataType",
+const auto ElementwiseMinQASYMM8SignedDataset = combine(make("DataType", DataType::QASYMM8_SIGNED), make("DataType", DataType::QASYMM8_SIGNED),
+                                                        make("DataType",
                                                                                  DataType::QASYMM8_SIGNED));
-const auto ElementwiseMinQSYMM16Dataset = combine(framework::dataset::make("DataType", DataType::QSYMM16), framework::dataset::make("DataType", DataType::QSYMM16),
-                                                  framework::dataset::make("DataType",
+const auto ElementwiseMinQSYMM16Dataset = combine(make("DataType", DataType::QSYMM16), make("DataType", DataType::QSYMM16),
+                                                  make("DataType",
                                                                            DataType::QSYMM16));
-const auto ElementwiseMinS16Dataset = combine(framework::dataset::make("DataType", { DataType::S16 }), framework::dataset::make("DataType", DataType::S16),
-                                              framework::dataset::make("DataType", DataType::S16));
-const auto ElementwiseMinFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                               framework::dataset::make("DataType", DataType::F16));
-const auto ElementwiseMinFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                               framework::dataset::make("DataType", DataType::F32));
-const auto EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ElementwiseMinS16Dataset = combine(make("DataType", { DataType::S16 }), make("DataType", DataType::S16),
+                                              make("DataType", DataType::S16));
+const auto ElementwiseMinFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                               make("DataType", DataType::F16));
+const auto ElementwiseMinFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                               make("DataType", DataType::F32));
+const auto EmptyActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -80,19 +81,19 @@ TEST_SUITE(ElementwiseMin)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false})),
+               make("Expected", { true, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLElementwiseMin::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -130,9 +131,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseMinQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                        ElementwiseMinQASYMM8Dataset,
-                                                                                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                       make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                                                                                                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -142,9 +143,9 @@ TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseMinQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                       ElementwiseMinQASYMM8SignedDataset,
-                                                                                                                      framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                      framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                      framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                                      make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                      make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                      make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                                                                                                       OutOfPlaceDataSet))
 {
     // Validate output
@@ -154,9 +155,9 @@ TEST_SUITE_END()
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseMinQuantizedFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                        ElementwiseMinQSYMM16Dataset,
-                                                                                                                       framework::dataset::make("SrcQInfo0", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                                                                                                                       framework::dataset::make("SrcQInfo1", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                                                                                                                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                                       make("SrcQInfo0", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                                       make("SrcQInfo1", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                                                                                                                        OutOfPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/CL/ElementwisePower.cpp
+++ b/tests/validation/CL/ElementwisePower.cpp
@@ -40,25 +40,26 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
 RelativeTolerance<float> tolerance_fp16(0.001f);
 
 /** Input data sets **/
-const auto ElementwisePowerFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                                 framework::dataset::make("DataType", DataType::F16));
-const auto ElementwisePowerFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                                 framework::dataset::make("DataType", DataType::F32));
-const auto EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ElementwisePowerFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                                 make("DataType", DataType::F16));
+const auto ElementwisePowerFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                                 make("DataType", DataType::F32));
+const auto EmptyActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -66,22 +67,22 @@ TEST_SUITE(ElementwisePower)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, true, false, false})),
+               make("Expected", { true, true, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLElementwisePower::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);

--- a/tests/validation/CL/ElementwiseSquaredDiff.cpp
+++ b/tests/validation/CL/ElementwiseSquaredDiff.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -48,30 +49,30 @@ RelativeTolerance<float> tolerance_fp16(0.001f);
 AbsoluteTolerance<float> tolerance_qsymm16(1);
 
 /** Input data sets **/
-const auto ElementwiseSquaredDiffU8Dataset = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::U8),
-                                                     framework::dataset::make("DataType",
+const auto ElementwiseSquaredDiffU8Dataset = combine(make("DataType", DataType::U8), make("DataType", DataType::U8),
+                                                     make("DataType",
                                                                               DataType::U8));
-const auto ElementwiseSquaredDiffQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                                          framework::dataset::make("DataType",
+const auto ElementwiseSquaredDiffQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                                          make("DataType",
                                                                                    DataType::QASYMM8));
-const auto ElementwiseSquaredDiffQSYMM16Dataset = combine(framework::dataset::make("DataType", DataType::QSYMM16), framework::dataset::make("DataType", DataType::QSYMM16),
-                                                          framework::dataset::make("DataType",
+const auto ElementwiseSquaredDiffQSYMM16Dataset = combine(make("DataType", DataType::QSYMM16), make("DataType", DataType::QSYMM16),
+                                                          make("DataType",
                                                                                    DataType::QSYMM16));
-const auto ElementwiseSquaredDiffS16Dataset = combine(framework::dataset::make("DataType", { DataType::S16 }), framework::dataset::make("DataType", DataType::S16),
-                                                      framework::dataset::make("DataType", DataType::S16));
-const auto ElementwiseSquaredDiffFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                                       framework::dataset::make("DataType", DataType::F16));
-const auto ElementwiseSquaredDiffFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                                       framework::dataset::make("DataType", DataType::F32));
-const auto EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ElementwiseSquaredDiffS16Dataset = combine(make("DataType", { DataType::S16 }), make("DataType", DataType::S16),
+                                                      make("DataType", DataType::S16));
+const auto ElementwiseSquaredDiffFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                                       make("DataType", DataType::F16));
+const auto ElementwiseSquaredDiffFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                                       make("DataType", DataType::F32));
+const auto EmptyActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet    = framework::dataset::make("InPlace", { false, true });
-const auto OutOfPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet    = make("InPlace", { false, true });
+const auto OutOfPlaceDataSet = make("InPlace", { false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -79,19 +80,19 @@ TEST_SUITE(ElementwiseSquaredDiff)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false})),
+               make("Expected", { true, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLElementwiseSquaredDiff::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -129,9 +130,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseSquaredDiffQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        ElementwiseSquaredDiffQASYMM8Dataset,
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                       make("OutQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                        OutOfPlaceDataSet))
 {
     // Validate output
@@ -141,9 +142,9 @@ TEST_SUITE_END()
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLElementwiseSquaredDiffQuantizedFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                        ElementwiseSquaredDiffQSYMM16Dataset,
-                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                       framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
-                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0), QuantizationInfo(5.f / 32768.f, 0) }),
+                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                        OutOfPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/CL/ExpLayer.cpp
+++ b/tests/validation/CL/ExpLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Arm Limited.
+ * Copyright (c) 2018-2019, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -52,13 +53,13 @@ using CLExpLayerFixture = ExpValidationFixture<CLTensor, CLAccessor, CLExpLayer,
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLExpLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLExpLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp16);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLExpLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLExpLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     // Validate output
@@ -67,13 +68,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLExpLayerFixture<half>, framework::DatasetMode
 
 TEST_SUITE_END() // FP16
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLExpLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLExpLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLExpLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLExpLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output

--- a/tests/validation/CL/FFT.cpp
+++ b/tests/validation/CL/FFT.cpp
@@ -40,10 +40,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-const auto data_types = framework::dataset::make("DataType", { DataType::F32 });
-const auto shapes_1d  = framework::dataset::make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 2U, 3U),
+const auto data_types = make("DataType", { DataType::F32 });
+const auto shapes_1d  = make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 2U, 3U),
                                                                   TensorShape(4U, 2U, 3U), TensorShape(5U, 2U, 3U),
                                                                   TensorShape(7U, 2U, 3U), TensorShape(8U, 2U, 3U),
                                                                   TensorShape(9U, 2U, 3U), TensorShape(25U, 2U, 3U),
@@ -51,14 +52,14 @@ const auto shapes_1d  = framework::dataset::make("TensorShape", { TensorShape(2U
                                                                   TensorShape(16U, 2U, 3U), TensorShape(32U, 2U, 3U),
                                                                   TensorShape(96U, 2U, 2U)
                                                                 });
-const auto shapes_2d = framework::dataset::make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 6U, 3U),
+const auto shapes_2d = make("TensorShape", { TensorShape(2U, 2U, 3U), TensorShape(3U, 6U, 3U),
                                                                  TensorShape(4U, 5U, 3U), TensorShape(5U, 7U, 3U),
                                                                  TensorShape(7U, 25U, 3U), TensorShape(8U, 2U, 3U),
                                                                  TensorShape(9U, 16U, 3U), TensorShape(25U, 32U, 3U),
                                                                  TensorShape(192U, 128U, 2U)
                                                                });
 
-const auto ActivationFunctionsSmallDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsSmallDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 0.5f)
@@ -75,22 +76,22 @@ TEST_SUITE(FFT1D)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Mismatching data types
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Mismatching data types
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Mismatching shapes
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 3, DataType::F32), // Invalid channels
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Unsupported axis
                                                 TensorInfo(TensorShape(11U, 13U, 2U), 2, DataType::F32), // Undecomposable FFT
                                                 TensorInfo(TensorShape(25U, 13U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F16),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F16),
                                                 TensorInfo(TensorShape(16U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(11U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(25U, 13U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("Axis", { 0, 0, 0, 2, 0, 0 }),
-        framework::dataset::make("Expected", { false, false, false, false, false, true })),
+        make("Axis", { 0, 0, 0, 2, 0, 0 }),
+        make("Expected", { false, false, false, false, false, true })),
         input_info, output_info, axis, expected)
 {
     FFT1DInfo desc;
@@ -106,14 +107,14 @@ using CLFFT1DFixture = FFTValidationFixture<CLTensor, CLAccessor, CLFFT1D, FFT1D
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT1DFixture<float>, framework::DatasetMode::ALL, combine(shapes_1d, framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT1DFixture<float>, framework::DatasetMode::ALL, combine(shapes_1d, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, tolerance_num_f32);
 }
 TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT1DFixture<half>, framework::DatasetMode::ALL, combine(shapes_1d, framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT1DFixture<half>, framework::DatasetMode::ALL, combine(shapes_1d, make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num_f16);
@@ -127,19 +128,19 @@ TEST_SUITE(FFT2D)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32), // Mismatching data types
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32), // Mismatching data types
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32), // Mismatching shapes
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 3, DataType::F32), // Invalid channels
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32), // Undecomposable FFT
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F16),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F16),
                                                 TensorInfo(TensorShape(16U, 25U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 2, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 25U, 2U), 2, DataType::F32),
         }),
-        framework::dataset::make("Expected", { false, false, false, false, true })),
+        make("Expected", { false, false, false, false, true })),
                input_info, output_info, expected)
 {
     const Status s = CLFFT2D::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), FFT2DInfo());
@@ -153,14 +154,14 @@ using CLFFT2DFixture = FFTValidationFixture<CLTensor, CLAccessor, CLFFT2D, FFT2D
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT2DFixture<float>, framework::DatasetMode::ALL, combine(shapes_2d, framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT2DFixture<float>, framework::DatasetMode::ALL, combine(shapes_2d, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, tolerance_num_f32);
 }
 TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT2DFixture<half>, framework::DatasetMode::ALL, combine(shapes_2d, framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFFT2DFixture<half>, framework::DatasetMode::ALL, combine(shapes_2d, make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num_f16);
@@ -179,16 +180,16 @@ using CLFFTConvolutionLayerMixedDataLayoutFixture = FFTConvolutionValidationFixt
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLFFTConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallFFTConvolutionLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                 make("DataType", DataType::F32),
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                                                                                  ActivationFunctionsSmallDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, tolerance_num_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLFFTConvolutionLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallFFTConvolutionLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F32),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                 make("DataType", DataType::F32),
+                                                                                                                 make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                                                                                  ActivationFunctionsSmallDataset))
 {
     // Validate output
@@ -197,8 +198,8 @@ FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLFFTConvolutionLayerMixedDataLayoutF
 TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLFFTConvolutionLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallFFTConvolutionLayerDataset(),
-                                                                                                                        framework::dataset::make("DataType", DataType::F16),
-                                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                        make("DataType", DataType::F16),
+                                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
                                                                                                                 ActivationFunctionsSmallDataset))
 {
     // Validate output

--- a/tests/validation/CL/Fill.cpp
+++ b/tests/validation/CL/Fill.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Arm Limited.
+ * Copyright (c) 2019-2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -38,6 +38,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Fill)
 
@@ -45,7 +46,7 @@ template <typename T>
 using CLFillFixture = FillFixture<CLTensor, CLAccessor, CLFill, T>;
 
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::U8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -53,7 +54,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint8_t>, framework::DatasetMode:
 TEST_SUITE_END() // U8
 
 TEST_SUITE(S8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::S8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::S8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -61,7 +62,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int8_t>, framework::DatasetMode::
 TEST_SUITE_END() // S8
 
 TEST_SUITE(QASYMM8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::QASYMM8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -69,7 +70,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint8_t>, framework::DatasetMode:
 TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(U16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::U16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::U16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -77,7 +78,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint16_t>, framework::DatasetMode
 TEST_SUITE_END() // U16
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::S16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::S16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -85,7 +86,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int16_t>, framework::DatasetMode:
 TEST_SUITE_END() // S16
 
 TEST_SUITE(F16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -93,7 +94,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<half>, framework::DatasetMode::AL
 TEST_SUITE_END() // F16
 
 TEST_SUITE(U32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::U32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::U32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -101,7 +102,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<uint32_t>, framework::DatasetMode
 TEST_SUITE_END() // U32
 
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::S32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int32_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::S32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -109,7 +110,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<int32_t>, framework::DatasetMode:
 TEST_SUITE_END() // S32
 
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFillFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/FillBorder.cpp
+++ b/tests/validation/CL/FillBorder.cpp
@@ -37,23 +37,24 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(FillBorder)
 
 // *INDENT-OFF*
 // clang-format off
-const auto PaddingSizesDataset = concat(concat(
-                                 framework::dataset::make("PaddingSize", PaddingSize{ 0 }),
-                                 framework::dataset::make("PaddingSize", PaddingSize{ 1, 0, 1, 2 })),
-                                 framework::dataset::make("PaddingSize", PaddingSize{ 10 }));
+const auto PaddingSizesDataset = concat(
+                                 make("PaddingSize", PaddingSize{ 0 }),
+                                 make("PaddingSize", PaddingSize{ 1, 0, 1, 2 }),
+                                 make("PaddingSize", PaddingSize{ 10 }));
 
-const auto BorderSizesDataset  = framework::dataset::make("BorderSize", 0, 6);
+const auto BorderSizesDataset  = make("BorderSize", 0, 6);
 
 DATA_TEST_CASE(FillBorder, framework::DatasetMode::ALL, combine(datasets::SmallShapes(),
                datasets::BorderModes(),
                BorderSizesDataset,
                PaddingSizesDataset,
-               framework::dataset::make("DataType", DataType::U8)),
+               make("DataType", DataType::U8)),
                shape, border_mode, size, padding, data_type)
 // clang-format on
 // *INDENT-ON*

--- a/tests/validation/CL/Flatten.cpp
+++ b/tests/validation/CL/Flatten.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Arm Limited.
+ * Copyright (c) 2017-2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,6 +40,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::concat;
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(FlattenLayer)
 
@@ -48,14 +50,14 @@ using CLFlattenLayerFixture = FlattenLayerValidationFixture<CLTensor, CLAccessor
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFlattenLayerFixture<float>, framework::DatasetMode::ALL, combine(framework::dataset::concat(datasets::Small3DShapes(), datasets::Small4DShapes()),
-                                                                                                    framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFlattenLayerFixture<float>, framework::DatasetMode::ALL, combine(concat(datasets::Small3DShapes(), datasets::Small4DShapes()),
+                                                                                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLFlattenLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(framework::dataset::concat(datasets::Large3DShapes(), datasets::Large4DShapes()),
-                                                                                                        framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLFlattenLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large3DShapes(), datasets::Large4DShapes()),
+                                                                                                        make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -63,14 +65,14 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLFlattenLayerFixture<float>, framework::Datase
 TEST_SUITE_END()
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFlattenLayerFixture<half>, framework::DatasetMode::ALL, combine(framework::dataset::concat(datasets::Small3DShapes(), datasets::Small4DShapes()),
-                                                                                                   framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFlattenLayerFixture<half>, framework::DatasetMode::ALL, combine(concat(datasets::Small3DShapes(), datasets::Small4DShapes()),
+                                                                                                   make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLFlattenLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(framework::dataset::concat(datasets::Large3DShapes(), datasets::Large4DShapes()),
-                                                                                                       framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLFlattenLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large3DShapes(), datasets::Large4DShapes()),
+                                                                                                       make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/Floor.cpp
+++ b/tests/validation/CL/Floor.cpp
@@ -40,22 +40,23 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Floor)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Wrong data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),  // Wrong data type
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Invalid data type combination
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32), // Mismatching shapes
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                                                 TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("Expected", { false, false, false, true })),
+        make("Expected", { false, false, false, true })),
         input_info, output_info, expected)
 {
     const Status status = CLFloor::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false));
@@ -69,12 +70,12 @@ using CLFloorFixture = FloorValidationFixture<CLTensor, CLAccessor, CLFloor, T>;
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFloorFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFloorFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLFloorFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLFloorFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -82,12 +83,12 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLFloorFixture<half>, framework::DatasetMode::N
 TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLFloorFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLFloorFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLFloorFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLFloorFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/FullyConnectedLayer.cpp
+++ b/tests/validation/CL/FullyConnectedLayer.cpp
@@ -80,9 +80,9 @@ const auto NoActivationFunctionsQuantizedDataset = make("ActivationInfo",
     ActivationLayerInfo()
 });
 
-const auto ActivationFunctionsQuantizedDataset = concat(concat(
+const auto ActivationFunctionsQuantizedDataset = concat(
                                                         make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU)),
-                                                        make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.5f))),
+                                                        make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.5f)),
                                                         make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 0.75f, 0.25f)));
 } // namespace
 

--- a/tests/validation/CL/FuseBatchNormalization.cpp
+++ b/tests/validation/CL/FuseBatchNormalization.cpp
@@ -36,6 +36,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 AbsoluteTolerance<float> absolute_tolerance_f32(0.001f);
@@ -57,19 +58,19 @@ const auto shape_conv_values_precommit = concat(datasets::Small4DShapes(), datas
 const auto shape_conv_values_nightly = concat(datasets::Large4DShapes(), datasets::Large3DShapes());
 
 /** Data layout to test */
-const auto data_layout_values = framework::dataset::make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW });
+const auto data_layout_values = make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW });
 
 /** In-place flags to test */
-const auto in_place_values = framework::dataset::make("InPlace", { true, false });
+const auto in_place_values = make("InPlace", { true, false });
 
 /** With bias flags to test */
-const auto with_bias_values = framework::dataset::make("WithBias", { true, false });
+const auto with_bias_values = make("WithBias", { true, false });
 
 /** With gamma flags to test */
-const auto with_gamma_values = framework::dataset::make("WithGamma", { true, false });
+const auto with_gamma_values = make("WithGamma", { true, false });
 
 /** With beta flags to test */
-const auto with_beta_values = framework::dataset::make("WithBeta", { true, false });
+const auto with_beta_values = make("WithBeta", { true, false });
 
 TEST_SUITE(CL)
 TEST_SUITE(FuseBatchNormalization)
@@ -78,7 +79,7 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationConvFixture<float>, framework::DatasetMode::PRECOMMIT,
                                         combine(shape_conv_values_precommit,
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -92,7 +93,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationConvFixture<float>, fra
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLFuseBatchNormalizationConvFixture<float>, framework::DatasetMode::NIGHTLY,
                                         combine(shape_conv_values_nightly,
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -109,7 +110,7 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationConvFixture<half>, framework::DatasetMode::PRECOMMIT,
                                         combine(shape_conv_values_precommit,
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -123,7 +124,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationConvFixture<half>, fram
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLFuseBatchNormalizationConvFixture<half>, framework::DatasetMode::NIGHTLY,
                                         combine(shape_conv_values_nightly,
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -144,7 +145,7 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationDWCFixture<float>, framework::DatasetMode::PRECOMMIT,
                                         combine(datasets::Small3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -158,7 +159,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationDWCFixture<float>, fram
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLFuseBatchNormalizationDWCFixture<float>, framework::DatasetMode::NIGHTLY,
                                         combine(datasets::Large3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F32 }),
+                                                        make("DataType", { DataType::F32 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -175,7 +176,7 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationDWCFixture<half>, framework::DatasetMode::PRECOMMIT,
                                         combine(datasets::Small3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,
@@ -189,7 +190,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLFuseBatchNormalizationDWCFixture<half>, frame
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLFuseBatchNormalizationDWCFixture<half>, framework::DatasetMode::NIGHTLY,
                                         combine(datasets::Large3DShapes(),
-                                                        framework::dataset::make("DataType", { DataType::F16 }),
+                                                        make("DataType", { DataType::F16 }),
                                                         data_layout_values,
                                                         in_place_values,
                                                         with_bias_values,

--- a/tests/validation/CL/GEMM.cpp
+++ b/tests/validation/CL/GEMM.cpp
@@ -53,7 +53,7 @@ RelativeTolerance<half_float::half> tolerance_f16(half(0.2)); /**< Tolerance val
 constexpr float                     tolerance_num = 0.02f;    /**< Tolerance number */
 
 /** CNN data types */
-const auto CNNDataTypes = framework::dataset::make("DataType",
+const auto CNNDataTypes = make("DataType",
 {
     DataType::F16,
     DataType::F32,
@@ -65,16 +65,16 @@ TEST_SUITE(GEMM)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("LhsInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::S32), // Unsupported data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("LhsInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::S32), // Unsupported data type
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("RhsInfo",{ TensorInfo(TensorShape(8U, 27U), 1, DataType::S32),
+               make("RhsInfo",{ TensorInfo(TensorShape(8U, 27U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(8U, 27U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(8U, 13U), 1, DataType::S32),
+               make("OutputInfo",{ TensorInfo(TensorShape(8U, 13U), 1, DataType::S32),
                                                         TensorInfo(TensorShape(8U, 13U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { false, true })),
+               make("Expected", { false, true })),
                lhs_info, rhs_info, output_info, expected)
 {
     constexpr float alpha = 1.0;
@@ -122,15 +122,15 @@ using CLBatchedMatMulFixture = GEMMValidationFixture<CLTensor, CLAccessor, CLGEM
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallGEMMDataset(),
-                                                                                                         framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                 framework::dataset::make("DataType", DataType::F16)))
+                                                                                                         make("ReshapeWeights", { true, false }),
+                                                                                                 make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeGEMMDataset(),
-                                                                                                       framework::dataset::make("ReshapeWeights", { true }),
-                                                                                               framework::dataset::make("DataType", DataType::F16)))
+                                                                                                       make("ReshapeWeights", { true }),
+                                                                                               make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
@@ -139,15 +139,15 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallGEMMDataset(),
-                                                                                                          framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                  framework::dataset::make("DataType", DataType::F32)))
+                                                                                                          make("ReshapeWeights", { true, false }),
+                                                                                                  make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeGEMMDataset(),
-                                                                                                        framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                framework::dataset::make("DataType", DataType::F32)))
+                                                                                                        make("ReshapeWeights", { true, false }),
+                                                                                                make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
@@ -159,15 +159,15 @@ TEST_SUITE(INPUT_OUTPUT_3D)
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMInputOutput3DFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallGEMMInputOutput3DDataset(),
-                                                                                                                       framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                               framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                       make("ReshapeWeights", { true, false }),
+                                                                                                               make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMInputOutput3DFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeGEMMInputOutput3DDataset(),
-                                                                                                                     framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                             framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                     make("ReshapeWeights", { true, false }),
+                                                                                                             make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
@@ -176,15 +176,15 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMInputOutput3DFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallGEMMInputOutput3DDataset(),
-                                                                                                                      framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                              framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                      make("ReshapeWeights", { true, false }),
+                                                                                                              make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMInputOutput3DFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeGEMMInputOutput3DDataset(),
-                                                                                                                    framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                            framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                    make("ReshapeWeights", { true, false }),
+                                                                                                            make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
@@ -198,15 +198,15 @@ TEST_SUITE(OUTPUT_3D)
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMOutput3DFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallGEMMOutput3DDataset(),
-                                                                                                                  framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                          framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                  make("ReshapeWeights", { true, false }),
+                                                                                                          make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMOutput3DFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeGEMMOutput3DDataset(),
-                                                                                                                framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                        framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                make("ReshapeWeights", { true, false }),
+                                                                                                        make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
@@ -215,15 +215,15 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMOutput3DFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallGEMMOutput3DDataset(),
-                                                                                                                 framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                         framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                 make("ReshapeWeights", { true, false }),
+                                                                                                         make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMOutput3DFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeGEMMOutput3DDataset(),
-                                                                                                               framework::dataset::make("ReshapeWeights", { true, false }),
-                                                                                                       framework::dataset::make("DataType", DataType::F16)))
+                                                                                                               make("ReshapeWeights", { true, false }),
+                                                                                                       make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);
@@ -236,8 +236,8 @@ TEST_SUITE(BATCHED_MATMUL)
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchedMatMulFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchedMatMulDataset(),
-                                                                                                                   framework::dataset::make("ReshapeWeights", { false }),
-                                                                                                           framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                   make("ReshapeWeights", { false }),
+                                                                                                           make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, tolerance_num);
@@ -246,8 +246,8 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLBatchedMatMulFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallBatchedMatMulDataset(),
-                                                                                                                  framework::dataset::make("ReshapeWeights", { false }),
-                                                                                                          framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                  make("ReshapeWeights", { false }),
+                                                                                                          make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, tolerance_num);

--- a/tests/validation/CL/GEMMLowpMatrixMultiplyNative.cpp
+++ b/tests/validation/CL/GEMMLowpMatrixMultiplyNative.cpp
@@ -38,6 +38,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 
 // Create function for CLGEMMMatrixMultiplyNativeKernel
@@ -59,42 +60,42 @@ namespace
  *  3: Non multiples of processor size in both dimensions
 */
 const auto m_n_values = zip(
-    framework::dataset::make("M", {1, 16, 37}),
-    framework::dataset::make("N", {1, 16, 51})
+    make("M", {1, 16, 37}),
+    make("N", {1, 16, 51})
     );
 
 /** M_W values to test */
-const auto m_w_values = framework::dataset::make("M_W", 5);
+const auto m_w_values = make("M_W", 5);
 
 /** M_H values to test */
-const auto m_h_values = framework::dataset::make("M_H", 7);
+const auto m_h_values = make("M_H", 7);
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", 51);
+const auto n_values = make("N", 51);
 
 /** K values to test */
-const auto k_values = framework::dataset::make("K", 23);
+const auto k_values = make("K", 23);
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", 1, 3);
+const auto b_values = make("batch_size", 1, 3);
 
 /** M0 values to test - Precommit */
-const auto m0_values_precommit = framework::dataset::make("M0", {4, 6});
+const auto m0_values_precommit = make("M0", {4, 6});
 
 /** N0 values to test - Precommit */
-const auto n0_values_precommit = framework::dataset::make("N0", { 4 });
+const auto n0_values_precommit = make("N0", { 4 });
 
 /** K0 values to test - Precommit */
-const auto k0_values_precommit = framework::dataset::make("K0", { 16 });
+const auto k0_values_precommit = make("K0", { 16 });
 
 /** M0 values to test - Nightly */
-const auto m0_values_nightly = framework::dataset::make("M0", {1, 2, 7});
+const auto m0_values_nightly = make("M0", {1, 2, 7});
 
 /** N0 values to test - Nightly */
-const auto n0_values_nightly = framework::dataset::make("N0", { 1, 2, 3, 4, 8 });
+const auto n0_values_nightly = make("N0", { 1, 2, 3, 4, 8 });
 
 /** K0 values to test - Nightly */
-const auto k0_values_nightly = framework::dataset::make("K0", { 1, 2, 3, 4, 8, 16 });
+const auto k0_values_nightly = make("K0", { 1, 2, 3, 4, 8, 16 });
 } // namespace
 
 TEST_SUITE(CL)

--- a/tests/validation/CL/GEMMLowpMatrixMultiplyReshaped.cpp
+++ b/tests/validation/CL/GEMMLowpMatrixMultiplyReshaped.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 
 // Create function for ClGemmReshapeLhsMatrixKernel
@@ -69,64 +70,64 @@ namespace
  *  3: Non multiples of processor size in both dimensions
 */
 const auto m_n_values = zip(
-    framework::dataset::make("M", {1, 16, 37}),
-    framework::dataset::make("N", {1, 16, 51})
+    make("M", {1, 16, 37}),
+    make("N", {1, 16, 51})
     );
 
 /** M values to test */
-const auto m_values = framework::dataset::make("M", {1, 37});
+const auto m_values = make("M", {1, 37});
 
 /** M_W values to test */
-const auto m_w_values = framework::dataset::make("M_W", 5);
+const auto m_w_values = make("M_W", 5);
 
 /** M_H values to test */
-const auto m_h_values = framework::dataset::make("M_H", 7);
+const auto m_h_values = make("M_H", 7);
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", {1, 51});
+const auto n_values = make("N", {1, 51});
 
 /** K values to test */
-const auto k_values = framework::dataset::make("K", 23);
+const auto k_values = make("K", 23);
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", 1, 3);
+const auto b_values = make("batch_size", 1, 3);
 
 /** M0 values to test - Precommit */
-const auto m0_values_precommit_1 = framework::dataset::make("M0", { 4 });
-const auto m0_values_precommit_2 = framework::dataset::make("M0", { 6 });
+const auto m0_values_precommit_1 = make("M0", { 4 });
+const auto m0_values_precommit_2 = make("M0", { 6 });
 
 /** N0 values to test - Precommit */
-const auto n0_values_precommit = framework::dataset::make("N0", { 4 });
+const auto n0_values_precommit = make("N0", { 4 });
 
 /** K0 values to test - Precommit */
-const auto k0_values_precommit = framework::dataset::make("K0", { 16 });
+const auto k0_values_precommit = make("K0", { 16 });
 
 /** V0 values to test - Precommit */
-const auto v0_values_precommit = framework::dataset::make("V0", 1, 3);
+const auto v0_values_precommit = make("V0", 1, 3);
 
 /** H0 values to test - Precommit */
-const auto h0_values_precommit = framework::dataset::make("H0", 1, 3);
+const auto h0_values_precommit = make("H0", 1, 3);
 
 /** M0 values to test - Nightly */
-const auto m0_values_nightly = framework::dataset::make("M0", 2, 7);
+const auto m0_values_nightly = make("M0", 2, 7);
 
 /** N0 values to test - Nightly */
-const auto n0_values_nightly = framework::dataset::make("N0", { 2, 3, 4, 8 });
+const auto n0_values_nightly = make("N0", { 2, 3, 4, 8 });
 
 /** K0 values to test - Nightly */
-const auto k0_values_nightly = framework::dataset::make("K0", { 2, 3, 4, 8, 16 });
+const auto k0_values_nightly = make("K0", { 2, 3, 4, 8, 16 });
 
 /** V0 values to test - Nightly */
-const auto v0_values_nightly = framework::dataset::make("V0", 1, 4);
+const auto v0_values_nightly = make("V0", 1, 4);
 
 /** H0 values to test - Nightly */
-const auto h0_values_nightly = framework::dataset::make("H0", 1, 4);
+const auto h0_values_nightly = make("H0", 1, 4);
 
 /** Interleave values to test with LHS matrix */
-const auto i_values_lhs = framework::dataset::make("interleave_lhs", { true, false });
+const auto i_values_lhs = make("interleave_lhs", { true, false });
 
 /** Interleave values to test with RHS matrix */
-const auto i_values_rhs = framework::dataset::make("interleave_rhs", { true, false });
+const auto i_values_rhs = make("interleave_rhs", { true, false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -146,7 +147,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMLowpMatrixMultiplyReshapedFixture, framew
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                                                                   make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -164,7 +165,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMLowpMatrixMultiplyReshapedFixture, framew
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                                                                   make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -183,7 +184,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMLowpMatrixMultiplyReshaped3DFixture, fr
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                                                                   make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -202,7 +203,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMLowpMatrixMultiplyReshaped3DFixture, fr
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                                                                   make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -221,7 +222,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMLowpMatrixMultiplyReshapedFixture, framew
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED })))
+                                                                   make("DataType", { DataType::QASYMM8_SIGNED })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -239,7 +240,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMLowpMatrixMultiplyReshaped3DFixture, fr
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED })))
+                                                                   make("DataType", { DataType::QASYMM8_SIGNED })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/GEMMLowpMatrixMultiplyReshapedOnlyRHS.cpp
+++ b/tests/validation/CL/GEMMLowpMatrixMultiplyReshapedOnlyRHS.cpp
@@ -43,6 +43,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 
 // Create function for CLGEMMReshapeRHSMatrixKernel
@@ -64,53 +65,53 @@ namespace
 // clang-format off
 
 /** M values to test */
-const auto m_values = framework::dataset::make("M", 37);
+const auto m_values = make("M", 37);
 
 /** M_W values to test */
-const auto m_w_values = framework::dataset::make("M_W", 5);
+const auto m_w_values = make("M_W", 5);
 
 /** M_H values to test */
-const auto m_h_values = framework::dataset::make("M_H", 7);
+const auto m_h_values = make("M_H", 7);
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", 51);
+const auto n_values = make("N", 51);
 
 /** K values to test */
-const auto k_values = framework::dataset::make("K", 23);
+const auto k_values = make("K", 23);
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", 1, 3);
+const auto b_values = make("batch_size", 1, 3);
 
 /** M0 values to test - Precommit */
-const auto m0_values_precommit_1 = framework::dataset::make("M0", {4});
-const auto m0_values_precommit_2 = framework::dataset::make("M0", {6});
+const auto m0_values_precommit_1 = make("M0", {4});
+const auto m0_values_precommit_2 = make("M0", {6});
 
 /** N0 values to test - Precommit */
-const auto n0_values_precommit = framework::dataset::make("N0", { 4 });
+const auto n0_values_precommit = make("N0", { 4 });
 
 /** K0 values to test - Precommit */
-const auto k0_values_precommit = framework::dataset::make("K0", { 16 });
+const auto k0_values_precommit = make("K0", { 16 });
 
 /** H0 values to test - Precommit */
-const auto h0_values_precommit = framework::dataset::make("H0", 1, 3);
+const auto h0_values_precommit = make("H0", 1, 3);
 
 /** M0 values to test - Nightly */
-const auto m0_values_nightly = framework::dataset::make("M0", 2, 8);
+const auto m0_values_nightly = make("M0", 2, 8);
 
 /** N0 values to test - Nightly */
-const auto n0_values_nightly = framework::dataset::make("N0", { 2, 3, 4, 8 });
+const auto n0_values_nightly = make("N0", { 2, 3, 4, 8 });
 
 /** K0 values to test - Nightly */
-const auto k0_values_nightly = framework::dataset::make("K0", { 2, 3, 4, 8, 16 });
+const auto k0_values_nightly = make("K0", { 2, 3, 4, 8, 16 });
 
 /** H0 values to test - Nightly */
-const auto h0_values_nightly = framework::dataset::make("H0", 1, 4);
+const auto h0_values_nightly = make("H0", 1, 4);
 
 /** Interleave values to test with RHS matrix */
-const auto i_values_rhs = framework::dataset::make("interleave_rhs", { true, false });
+const auto i_values_rhs = make("interleave_rhs", { true, false });
 
 /** Transpose values to test with RHS matrix */
-const auto t_values_rhs = framework::dataset::make("transpose_rhs", { true });
+const auto t_values_rhs = make("transpose_rhs", { true });
 
 /** Configuration test */
 void validate_configuration(unsigned int m_value, unsigned int n_value, unsigned int k_value, unsigned int b_value, unsigned int m0_value, unsigned int n0_value, unsigned int k0_value, unsigned int h0_value, bool i_value_rhs)
@@ -166,7 +167,7 @@ TEST_SUITE(GEMMLowpMatrixMultiplyReshapedOnlyRHS)
 DATA_TEST_CASE(Configuration, framework::DatasetMode::ALL, combine(m_values,
                                                                    n_values,
                                                                    k_values,
-                                                                   framework::dataset::make("batch_size", 1),
+                                                                   make("batch_size", 1),
                                                                    m0_values_precommit_1,
                                                                    n0_values_precommit,
                                                                    k0_values_precommit,
@@ -188,7 +189,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall_1, CLGEMMLowpMatrixMultiplyReshapedOnlyRHSFixtur
                                                                    h0_values_precommit,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                    make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -205,7 +206,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall_2, CLGEMMLowpMatrixMultiplyReshapedOnlyRHSFixtur
                                                                    h0_values_precommit,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED })))
+                    make("DataType", { DataType::QASYMM8_SIGNED })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -222,7 +223,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMLowpMatrixMultiplyReshapedOnlyRHSFixture,
                                                                    h0_values_nightly,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                    make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -240,7 +241,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D_1, CLGEMMLowpMatrixMultiplyReshapedOnlyRHS3DFi
                                                                    h0_values_precommit,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                    make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -258,7 +259,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D_2, CLGEMMLowpMatrixMultiplyReshapedOnlyRHS3DFi
                                                                    h0_values_precommit,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED })))
+                    make("DataType", { DataType::QASYMM8_SIGNED })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -276,7 +277,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMLowpMatrixMultiplyReshapedOnlyRHS3DFixt
                                                                    h0_values_nightly,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8 })))
+                    make("DataType", { DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/GEMMLowpMatrixMultiplyReshapedOnlyRhsMMUL.cpp
+++ b/tests/validation/CL/GEMMLowpMatrixMultiplyReshapedOnlyRhsMMUL.cpp
@@ -37,6 +37,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::opencl::kernels;
 
 // Create function for CLGEMMReshapeRHSMatrixKernel
@@ -62,36 +63,36 @@ namespace
 // clang-format off
 
 /** M values to test */
-const auto m_values = framework::dataset::make("M", {16, 49});
+const auto m_values = make("M", {16, 49});
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", {16, 259});
+const auto n_values = make("N", {16, 259});
 
 /** K values to test */
-const auto k_values = framework::dataset::make("K", {192});
+const auto k_values = make("K", {192});
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", {1, 2});
+const auto b_values = make("batch_size", {1, 2});
 
 /** M0 values to test - Precommit */
-const auto m0 = framework::dataset::make("M0", {1, 2, 4});
+const auto m0 = make("M0", {1, 2, 4});
 
 /** N0 values to test - Precommit */
-const auto n0 = framework::dataset::make("N0", { 1, 4, 8});
+const auto n0 = make("N0", { 1, 4, 8});
 
 /** K0 values to test - Precommit */
-const auto k0 = framework::dataset::make("K0", { 4 });
+const auto k0 = make("K0", { 4 });
 
 /** H0 values to test - Precommit */
-const auto h0 = framework::dataset::make("H0", 1);
+const auto h0 = make("H0", 1);
 
 /** Interleave values to test with RHS matrix */
-const auto i_values_rhs = framework::dataset::make("interleave_rhs", { false });
+const auto i_values_rhs = make("interleave_rhs", { false });
 
 /** Transpose values to test with RHS matrix */
-const auto t_values_rhs = framework::dataset::make("transpose_rhs", { true });
+const auto t_values_rhs = make("transpose_rhs", { true });
 
-const auto broadcast_bias = framework::dataset::make("broadcast_bias", {true, false});
+const auto broadcast_bias = make("broadcast_bias", {true, false});
 
 } // namespace
 
@@ -108,7 +109,7 @@ FIXTURE_DATA_TEST_CASE(Signed, CLGEMMLowpMatrixMultiplyReshapedOnlyRHSMMULFixtur
                                                                    h0,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED })))
+                    make("DataType", { DataType::QASYMM8_SIGNED })))
 {
     // Validate output
     if(arm_matrix_multiply_supported(CLKernelLibrary::get().get_device()))
@@ -132,7 +133,7 @@ FIXTURE_DATA_TEST_CASE(Unsigned, CLGEMMLowpMatrixMultiplyReshapedOnlyRHSMMULFixt
                                                                    h0,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                    framework::dataset::make("DataType", { DataType::QASYMM8})))
+                    make("DataType", { DataType::QASYMM8})))
 {
     // Validate output
     if(arm_matrix_multiply_supported(CLKernelLibrary::get().get_device()))
@@ -157,7 +158,7 @@ FIXTURE_DATA_TEST_CASE(OutputStageSigned, CLGEMMLowpMatrixMultiplyReshapedOnlyRH
                                                                    i_values_rhs,
                                                                    t_values_rhs,
                                                                    broadcast_bias,
-                    framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED})))
+                    make("DataType", { DataType::QASYMM8_SIGNED})))
 {
     // Validate output
     if(arm_matrix_multiply_supported(CLKernelLibrary::get().get_device()))
@@ -182,7 +183,7 @@ FIXTURE_DATA_TEST_CASE(OutputStageUnsigned, CLGEMMLowpMatrixMultiplyReshapedOnly
                                                                    i_values_rhs,
                                                                    t_values_rhs,
                                                                    broadcast_bias,
-                    framework::dataset::make("DataType", { DataType::QASYMM8})))
+                    make("DataType", { DataType::QASYMM8})))
 {
     // Validate output
     if(arm_matrix_multiply_supported(CLKernelLibrary::get().get_device()))

--- a/tests/validation/CL/GEMMMatrixMultiplyNative.cpp
+++ b/tests/validation/CL/GEMMMatrixMultiplyNative.cpp
@@ -43,6 +43,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 using namespace arm_compute::opencl::kernels;
 
@@ -65,59 +66,59 @@ RelativeTolerance<float> rel_tolerance_f32(0.001f);
 constexpr float          abs_tolerance_f32(0.0001f);
 
 /** Alpha values to test - Precommit */
-const auto a_values = framework::dataset::make("alpha", {1.0f, -0.75f} );
+const auto a_values = make("alpha", {1.0f, -0.75f} );
 
 /** Beta values to test - Precommit */
-const auto beta_values = framework::dataset::make("beta", {-0.75f, 0.0f} );
+const auto beta_values = make("beta", {-0.75f, 0.0f} );
 
 /** M values to test */
-const auto m_values = framework::dataset::make("M", 37);
+const auto m_values = make("M", 37);
 
 /** M_W values to test */
-const auto m_w_values = framework::dataset::make("M_W", 5);
+const auto m_w_values = make("M_W", 5);
 
 /** M_H values to test */
-const auto m_h_values = framework::dataset::make("M_H", 7);
+const auto m_h_values = make("M_H", 7);
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", 51);
+const auto n_values = make("N", 51);
 
 /** K values to test */
-const auto k_values = framework::dataset::make("K", 23);
+const auto k_values = make("K", 23);
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", 1, 3);
+const auto b_values = make("batch_size", 1, 3);
 
 /** Activation values to test */
-const auto act_values = framework::dataset::make("Activation",
+const auto act_values = make("Activation",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 8.f, 2.f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::ELU),
 });
 
 /** M0 values to test - Precommit */
-const auto m0_values_precommit = framework::dataset::make("M0", { 4, 6 });
+const auto m0_values_precommit = make("M0", { 4, 6 });
 
 /** N0 values to test - Precommit */
-const auto n0_values_precommit = framework::dataset::make("N0", { 4 });
+const auto n0_values_precommit = make("N0", { 4 });
 
 /** K0 values to test - Precommit */
-const auto k0_values_precommit = framework::dataset::make("K0", { 4 });
+const auto k0_values_precommit = make("K0", { 4 });
 
 /** H0 values to test - Precommit */
-const auto h0_values_precommit = framework::dataset::make("H0", 1, 3);
+const auto h0_values_precommit = make("H0", 1, 3);
 
 /** M0 values to test - Nightly */
-const auto m0_values_nightly = framework::dataset::make("M0", 1, 8);
+const auto m0_values_nightly = make("M0", 1, 8);
 
 /** N0 values to test - Nightly */
-const auto n0_values_nightly = framework::dataset::make("N0", { 2, 3, 4, 8 });
+const auto n0_values_nightly = make("N0", { 2, 3, 4, 8 });
 
 /** K0 values to test - Nightly */
-const auto k0_values_nightly = framework::dataset::make("K0", { 2, 3, 4, 8 });
+const auto k0_values_nightly = make("K0", { 2, 3, 4, 8 });
 
 /** Broadcast bias from vector to matrix */
-const auto broadcast_bias_values = framework::dataset::make("broadcast_bias", { false, true } );
+const auto broadcast_bias_values = make("broadcast_bias", { false, true } );
 
 /** Boundary handling cases for testing partial/non-partial (full) block dimensions, resulting from different combinations
  * of M, M0, N and N0 values.
@@ -127,18 +128,18 @@ const auto broadcast_bias_values = framework::dataset::make("broadcast_bias", { 
  * parital blocks in X dimension.
  */
 const auto boundary_handling_cases = combine(// Large k to force potential out-of-bound reads on input0
-                                    framework::dataset::make("K", 315),
+                                    make("K", 315),
                                     // Batch size == 1 to force potential out-of-bound reads on input0
-                                    framework::dataset::make("batch_size", 1),
-                                    framework::dataset::make("M0", 4),
-                                    framework::dataset::make("N0", 4),
-                                    framework::dataset::make("K0", 4),
+                                    make("batch_size", 1),
+                                    make("M0", 4),
+                                    make("N0", 4),
+                                    make("K0", 4),
                                     // Only need to test F32 as F16 shares identical boundary handling logics
-                                    framework::dataset::make("DataType", DataType::F32),
-                                    framework::dataset::make("alpha", -0.75f ),
-                                    framework::dataset::make("beta", -0.35f ),
+                                    make("DataType", DataType::F32),
+                                    make("alpha", -0.75f ),
+                                    make("beta", -0.35f ),
                                     broadcast_bias_values,
-                                    framework::dataset::make("Activation", ActivationLayerInfo()));
+                                    make("Activation", ActivationLayerInfo()));
 
 /** Configuration test */
 void validate_configuration(unsigned int m_value, unsigned int n_value, unsigned int k_value, unsigned int b_value, unsigned int m0_value, unsigned int n0_value, unsigned int k0_value, bool broadcast_bias, DataType data_type, const ActivationLayerInfo &act_info)
@@ -195,7 +196,7 @@ TEST_SUITE(FP32)
 DATA_TEST_CASE(Configuration, framework::DatasetMode::ALL, combine(m_values,
                                                                    n_values,
                                                                    k_values,
-                                                                   framework::dataset::make("batch_size", 1),
+                                                                   make("batch_size", 1),
                                                                    m0_values_precommit,
                                                                    n0_values_precommit,
                                                                    k0_values_precommit,
@@ -207,8 +208,8 @@ m_value, n_value, k_value, b_value, m0_value, n0_value, k0_value, broadcast_bias
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallBoundaryHandlingPartialInXPartialInY, CLGEMMMatrixMultiplyNativeFixture<float>, framework::DatasetMode::ALL,
-                combine(framework::dataset::make("M", 3),
-                        framework::dataset::make("N", 1),
+                combine(make("M", 3),
+                        make("N", 1),
                         boundary_handling_cases))
 {
     // Validate output
@@ -216,8 +217,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBoundaryHandlingPartialInXPartialInY, CLGEMMMatri
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallBoundaryHandlingPartialInXFullInY, CLGEMMMatrixMultiplyNativeFixture<float>, framework::DatasetMode::ALL,
-                combine(framework::dataset::make("M", 64),
-                        framework::dataset::make("N", 51),
+                combine(make("M", 64),
+                        make("N", 51),
                         boundary_handling_cases))
 {
     // Validate output
@@ -225,8 +226,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBoundaryHandlingPartialInXFullInY, CLGEMMMatrixMu
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallBoundaryHandlingFullInXFullInY, CLGEMMMatrixMultiplyNativeFixture<float>, framework::DatasetMode::ALL,
-                combine(framework::dataset::make("M", 64),
-                        framework::dataset::make("N", 32),
+                combine(make("M", 64),
+                        make("N", 32),
                         boundary_handling_cases))
 {
     // Validate output
@@ -234,8 +235,8 @@ FIXTURE_DATA_TEST_CASE(RunSmallBoundaryHandlingFullInXFullInY, CLGEMMMatrixMulti
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallBoundaryHandlingFullInXPartialInY, CLGEMMMatrixMultiplyNativeFixture<float>, framework::DatasetMode::ALL,
-                combine(framework::dataset::make("M", 37),
-                        framework::dataset::make("N", 32),
+                combine(make("M", 37),
+                        make("N", 32),
                         boundary_handling_cases))
 {
     // Validate output
@@ -250,7 +251,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyNativeFixture<float>, frame
                                                                    m0_values_precommit,
                                                                    n0_values_precommit,
                                                                    k0_values_precommit,
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    broadcast_bias_values,
@@ -268,7 +269,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMMatrixMultiplyNativeFixture<float>, frame
                                                                    m0_values_nightly,
                                                                    n0_values_nightly,
                                                                    k0_values_nightly,
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    broadcast_bias_values,
@@ -287,7 +288,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMMatrixMultiplyNative3DFixture<float>, f
                                                                    m0_values_precommit,
                                                                    n0_values_precommit,
                                                                    k0_values_precommit,
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    act_values))
@@ -305,7 +306,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyNative3DFixture<float>, f
                                                                    m0_values_nightly,
                                                                    n0_values_nightly,
                                                                    k0_values_nightly,
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    act_values))

--- a/tests/validation/CL/GEMMMatrixMultiplyReshaped.cpp
+++ b/tests/validation/CL/GEMMMatrixMultiplyReshaped.cpp
@@ -45,6 +45,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 using namespace arm_compute::opencl::kernels;
 
@@ -89,89 +90,89 @@ RelativeTolerance<float> rel_tolerance_f16(0.001f);
 constexpr float          abs_tolerance_f16(0.01f);
 
 /** M values to test */
-const auto m_values = framework::dataset::make("M", 17);
+const auto m_values = make("M", 17);
 
 /** M_W values to test */
-const auto m_w_values = framework::dataset::make("M_W", 5);
+const auto m_w_values = make("M_W", 5);
 
 /** M_H values to test */
-const auto m_h_values = framework::dataset::make("M_H", 7);
+const auto m_h_values = make("M_H", 7);
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", 21);
+const auto n_values = make("N", 21);
 
 /** K values to test */
-const auto k_values = framework::dataset::make("K", 13);
+const auto k_values = make("K", 13);
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", 2, 3);
+const auto b_values = make("batch_size", 2, 3);
 
 /** Activation values to test */
-const auto act_values = framework::dataset::make("Activation",
+const auto act_values = make("Activation",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 8.f, 2.f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::ELU),
 });
 
 /** Alpha values to test - Precommit */
-const auto a_values_precommit = framework::dataset::make("alpha", {-0.75f} );
+const auto a_values_precommit = make("alpha", {-0.75f} );
 
 /** Beta values to test - Precommit */
-const auto beta_values_precommit = framework::dataset::make("beta", {-0.35f} );
+const auto beta_values_precommit = make("beta", {-0.35f} );
 
 /** M0 values to test - Precommit */
-const auto m0_values_precommit = framework::dataset::make("M0", { 4 });
+const auto m0_values_precommit = make("M0", { 4 });
 
 /** N0 values to test - Precommit */
-const auto n0_values_precommit = framework::dataset::make("N0", { 4 });
+const auto n0_values_precommit = make("N0", { 4 });
 
 /** K0 values to test - Precommit */
-const auto k0_values_precommit = framework::dataset::make("K0", { 4 });
+const auto k0_values_precommit = make("K0", { 4 });
 
 /** V0 values to test - Precommit */
-const auto v0_values_precommit = framework::dataset::make("V0", 1, 3);
+const auto v0_values_precommit = make("V0", 1, 3);
 
 /** H0 values to test - Precommit */
-const auto h0_values_precommit = framework::dataset::make("H0", 1, 3);
+const auto h0_values_precommit = make("H0", 1, 3);
 
 /** Alpha values to test - Nightly */
-const auto a_values_nightly = framework::dataset::make("alpha", {1.0f} );
+const auto a_values_nightly = make("alpha", {1.0f} );
 
 /** Beta values to test - Nightly */
-const auto beta_values_nightly = framework::dataset::make("beta", {1.0f} );
+const auto beta_values_nightly = make("beta", {1.0f} );
 
 /** M0 values to test - Nightly */
-const auto m0_values_nightly = framework::dataset::make("M0", { 8 });
+const auto m0_values_nightly = make("M0", { 8 });
 
 /** N0 values to test - Nightly */
-const auto n0_values_nightly = framework::dataset::make("N0", { 8 });
+const auto n0_values_nightly = make("N0", { 8 });
 
 /** K0 values to test - Nightly */
-const auto k0_values_nightly = framework::dataset::make("K0", { 4 });
+const auto k0_values_nightly = make("K0", { 4 });
 
 /** N0 values to test with export to OpenCL image object - Nightly */
-const auto n0_export_to_cl_image_values_nightly = framework::dataset::make("N0", { 4, 8, 16 });
+const auto n0_export_to_cl_image_values_nightly = make("N0", { 4, 8, 16 });
 
 /** K0 values to test with export to OpenCL image object - Nightly */
-const auto k0_export_to_cl_image_values_nightly = framework::dataset::make("K0", { 4, 8, 16 });
+const auto k0_export_to_cl_image_values_nightly = make("K0", { 4, 8, 16 });
 
 /** V0 values to test - Nightly */
-const auto v0_values_nightly = framework::dataset::make("V0", 1, 3);
+const auto v0_values_nightly = make("V0", 1, 3);
 
 /** H0 values to test - Nightly */
-const auto h0_values_nightly = framework::dataset::make("H0", 1, 3);
+const auto h0_values_nightly = make("H0", 1, 3);
 
 /** Interleave values to test with LHS matrix */
-const auto i_values_lhs = framework::dataset::make("interleave_lhs", { true, false });
+const auto i_values_lhs = make("interleave_lhs", { true, false });
 
 /** Interleave values to test with RHS matrix */
-const auto i_values_rhs = framework::dataset::make("interleave_rhs", { true, false });
+const auto i_values_rhs = make("interleave_rhs", { true, false });
 
 /** Broadcast bias from vector to matrix */
-const auto broadcast_bias_values = framework::dataset::make("broadcast_bias", { false, true } );
+const auto broadcast_bias_values = make("broadcast_bias", { false, true } );
 
 /** LHS transposed values */
-const auto lhs_transpose_values = framework::dataset::make("lhs_transpose", { false, true } );
+const auto lhs_transpose_values = make("lhs_transpose", { false, true } );
 
 } // namespace
 
@@ -180,7 +181,7 @@ TEST_SUITE(GEMMMatrixMultiplyReshaped)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input0Info", { TensorInfo(TensorShape(64U, 5U, 2U), 1, DataType::F32),      // OK
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input0Info", { TensorInfo(TensorShape(64U, 5U, 2U), 1, DataType::F32),      // OK
                                                         TensorInfo(TensorShape(64U, 5U, 2U), 1, DataType::F16),      // OK
                                                         TensorInfo(TensorShape(64U, 5U, 2U), 1, DataType::QASYMM8),  // Data type not supported
                                                         TensorInfo(TensorShape(10U, 5U, 2U), 1, DataType::F32),      // Incorrect dimension bias
@@ -190,7 +191,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                         TensorInfo(TensorShape(64U, 5U, 2U), 1, DataType::F16),      // OK, RHS 4,4,2
 
                                                       }),
-               framework::dataset::make("Input1Info",{ TensorInfo(TensorShape(64U, 6U, 2U), 1, DataType::F32),
+               make("Input1Info",{ TensorInfo(TensorShape(64U, 6U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 6U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(64U, 5U, 2U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(64U, 6U, 2U), 1, DataType::F32),
@@ -200,7 +201,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(128U, 3U, 2U), 1, DataType::F16),
 
                       }),
-               framework::dataset::make("Input2Info", { TensorInfo(TensorShape(21U), 1, DataType::F32),
+               make("Input2Info", { TensorInfo(TensorShape(21U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(21U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(21U), 1, DataType::QASYMM8),
                                                         TensorInfo(TensorShape(21U), 1, DataType::F32),
@@ -210,7 +211,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                         TensorInfo(TensorShape(21U,17U,2U), 1, DataType::F16),
 
                                                       }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(21U,17U,2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(21U,17U,2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(21U,17U,2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(21U,17U,2U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(21U,17U,2U), 1, DataType::F32),
@@ -220,7 +221,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(21U,17U,2U), 1, DataType::F16),
 
                            }),
-               framework::dataset::make("LHSMInfo",{
+               make("LHSMInfo",{
                                                           GEMMLHSMatrixInfo(4,4,1,false,true),
                                                           GEMMLHSMatrixInfo(4,4,1,false,true),
                                                           GEMMLHSMatrixInfo(4,4,1,false,true),
@@ -231,7 +232,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                           GEMMLHSMatrixInfo(4,4,1,false,true),
 
                                 }),
-               framework::dataset::make("RHSMInfo",{
+               make("RHSMInfo",{
                                                           GEMMRHSMatrixInfo(4,4,1,true,true,false),
                                                           GEMMRHSMatrixInfo(4,4,1,true,true,false),
                                                           GEMMRHSMatrixInfo(4,4,1,true,true,false),
@@ -245,7 +246,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                            }),
 
 
-               framework::dataset::make("GEMMInfo",{
+               make("GEMMInfo",{
                                                             GEMMKernelInfo( 17 /**<M Number of LHS rows*/,
                                                                             21 /**<N Number of RHS columns*/,
                                                                             13 /**<K Number of LHS columns or RHS rows */, 0 /**< Depth of the output tensor in case is reinterpreted as 3D */,
@@ -325,7 +326,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                                      0  /**< Offset to be added to each element of the matrix A */,
                                                                      0 /**< Offset to be added to each element of the matrix B */),
                                                     }),
-               framework::dataset::make("Expected", { true, true, false, false, false, true, true,true})),
+               make("Expected", { true, true, false, false, false, true, true,true})),
                     input0_info ,input1_info, input2_info, output_info, lhs_info, rhs_info, gemm_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(ClGemmMatrixMultiplyReshapedKernel::validate(&input0_info.clone()->set_is_resizable(true),
@@ -352,8 +353,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedFixture<float>, fra
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    broadcast_bias_values,
@@ -384,8 +385,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMMatrixMultiplyReshapedFixture<float>, fra
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    broadcast_bias_values,
@@ -417,8 +418,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMMatrixMultiplyReshaped3DFixture<float>,
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    lhs_transpose_values,
@@ -449,8 +450,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyReshaped3DFixture<float>,
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    lhs_transpose_values,
@@ -469,28 +470,28 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyReshaped3DFixture<float>,
 }
 
 TEST_SUITE(ExportToCLImage)
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input0Info", { TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input0Info", { TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),  // Incorrect k0
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),  // Incorrect n0
 
                                                       }),
-               framework::dataset::make("Input1Info",{ TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),
+               make("Input1Info",{ TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(512U, 8U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(128U, 32U, 2U), 1, DataType::F32),
 
                       }),
-               framework::dataset::make("Input2Info", { TensorInfo(TensorShape(64U), 1, DataType::F32),
+               make("Input2Info", { TensorInfo(TensorShape(64U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F32),
 
                                                       }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F32),
@@ -498,7 +499,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F32),
 
                            }),
-               framework::dataset::make("LHSMInfo",{
+               make("LHSMInfo",{
                                                           GEMMLHSMatrixInfo(4, 4, 1, false, true),
                                                           GEMMLHSMatrixInfo(4, 8, 1, false, true),
                                                           GEMMLHSMatrixInfo(4, 4, 1, false, true),
@@ -506,14 +507,14 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                           GEMMLHSMatrixInfo(4, 4, 1, false, false),
 
                                 }),
-               framework::dataset::make("RHSMInfo",{
+               make("RHSMInfo",{
                                                           GEMMRHSMatrixInfo(4, 4, 1, true, true, true),
                                                           GEMMRHSMatrixInfo(4, 8, 1, true, true, true),
                                                           GEMMRHSMatrixInfo(8, 4, 1, true, true, true),
                                                           GEMMRHSMatrixInfo(4, 2, 1, true, false, true),
                                                           GEMMRHSMatrixInfo(2, 4, 1, true, false, true),
                            }),
-               framework::dataset::make("GEMMInfo",{GEMMKernelInfo( 64 /**<M Number of LHS rows*/,
+               make("GEMMInfo",{GEMMKernelInfo( 64 /**<M Number of LHS rows*/,
                                                                     64 /**<N Number of RHS columns*/,
                                                                     64 /**<K Number of LHS columns or RHS rows */, 0 /**< Depth of the output tensor in case is reinterpreted as 3D */,
                                                              false /**< reinterpret the input as 3D */,
@@ -585,7 +586,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                              0  /**< Offset to be added to each element of the matrix A */,
                                                              0 /**< Offset to be added to each element of the matrix B */)
                                                     }),
-               framework::dataset::make("Expected", { true,
+               make("Expected", { true,
                                                       true,
                                                       true,
                                                       false,
@@ -613,8 +614,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedFixture<float>, fra
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    broadcast_bias_values,
@@ -646,8 +647,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMMatrixMultiplyReshapedFixture<float>, fra
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    broadcast_bias_values,
@@ -679,8 +680,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMMatrixMultiplyReshaped3DFixture<float>,
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    lhs_transpose_values,
@@ -711,8 +712,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyReshaped3DFixture<float>,
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    lhs_transpose_values,
@@ -747,8 +748,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedFixture<half>, fram
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    broadcast_bias_values,
@@ -779,8 +780,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMMatrixMultiplyReshapedFixture<half>, fram
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    broadcast_bias_values,
@@ -812,8 +813,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMMatrixMultiplyReshaped3DFixture<half>, 
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    lhs_transpose_values,
@@ -844,8 +845,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyReshaped3DFixture<half>, 
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    lhs_transpose_values,
@@ -864,28 +865,28 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyReshaped3DFixture<half>, 
 }
 
 TEST_SUITE(ExportToCLImage)
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input0Info", { TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input0Info", { TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),  // OK or incorrect if cl_khr_image2d_from_buffer not supported
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),  // Incorrect k0
                                                         TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),  // Incorrect n0
 
                                                       }),
-               framework::dataset::make("Input1Info",{ TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),
+               make("Input1Info",{ TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(512U, 8U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(256U, 16U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(128U, 32U, 2U), 1, DataType::F16),
 
                       }),
-               framework::dataset::make("Input2Info", { TensorInfo(TensorShape(64U), 1, DataType::F16),
+               make("Input2Info", { TensorInfo(TensorShape(64U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(64U), 1, DataType::F16),
 
                                                       }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F16),
@@ -893,7 +894,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(64U, 64U, 2U), 1, DataType::F16),
 
                            }),
-               framework::dataset::make("LHSMInfo",{
+               make("LHSMInfo",{
                                                           GEMMLHSMatrixInfo(4, 4, 1, false, true),
                                                           GEMMLHSMatrixInfo(4, 8, 1, false, true),
                                                           GEMMLHSMatrixInfo(4, 4, 1, false, true),
@@ -901,14 +902,14 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                           GEMMLHSMatrixInfo(4, 4, 1, false, false),
 
                                 }),
-               framework::dataset::make("RHSMInfo",{
+               make("RHSMInfo",{
                                                           GEMMRHSMatrixInfo(4, 4, 1, true, true, true),
                                                           GEMMRHSMatrixInfo(4, 8, 1, true, true, true),
                                                           GEMMRHSMatrixInfo(8, 4, 1, true, true, true),
                                                           GEMMRHSMatrixInfo(4, 2, 1, true, false, true),
                                                           GEMMRHSMatrixInfo(2, 4, 1, true, false, true),
                            }),
-               framework::dataset::make("GEMMInfo",{GEMMKernelInfo( 64 /**<M Number of LHS rows*/,
+               make("GEMMInfo",{GEMMKernelInfo( 64 /**<M Number of LHS rows*/,
                                                                     64 /**<N Number of RHS columns*/,
                                                                     64 /**<K Number of LHS columns or RHS rows */, 0 /**< Depth of the output tensor in case is reinterpreted as 3D */,
                                                              false /**< reinterpret the input as 3D */,
@@ -980,7 +981,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                              0  /**< Offset to be added to each element of the matrix A */,
                                                              0 /**< Offset to be added to each element of the matrix B */)
                                                     }),
-               framework::dataset::make("Expected", { true,
+               make("Expected", { true,
                                                       true,
                                                       true,
                                                       false,
@@ -1008,8 +1009,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedFixture<half>, fram
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    broadcast_bias_values,
@@ -1041,8 +1042,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMMatrixMultiplyReshapedFixture<half>, fram
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    broadcast_bias_values,
@@ -1074,8 +1075,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMMatrixMultiplyReshaped3DFixture<half>, 
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    lhs_transpose_values,
@@ -1106,8 +1107,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyReshaped3DFixture<half>, 
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    lhs_transpose_values,
@@ -1142,8 +1143,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedMixedPrecisionFixtu
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    broadcast_bias_values,
@@ -1174,8 +1175,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLGEMMMatrixMultiplyReshapedMixedPrecisionFixtu
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    broadcast_bias_values,
@@ -1207,8 +1208,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall3D, CLGEMMMatrixMultiplyReshaped3DMixedPrecisionF
                                                                    h0_values_precommit,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_precommit,
                                                                    beta_values_precommit,
                                                                    lhs_transpose_values,
@@ -1239,8 +1240,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge3D, CLGEMMMatrixMultiplyReshaped3DMixedPrecisionF
                                                                    h0_values_nightly,
                                                                    i_values_lhs,
                                                                    i_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", false),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", false),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values_nightly,
                                                                    beta_values_nightly,
                                                                    lhs_transpose_values,

--- a/tests/validation/CL/GEMMMatrixMultiplyReshapedOnlyRHS.cpp
+++ b/tests/validation/CL/GEMMMatrixMultiplyReshapedOnlyRHS.cpp
@@ -44,6 +44,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 using namespace arm_compute::opencl::kernels;
 
@@ -72,65 +73,65 @@ RelativeTolerance<float> rel_tolerance_f16(0.001f);
 constexpr float          abs_tolerance_f16(0.01f);
 
 /** Alpha values to test */
-const auto a_values = framework::dataset::make("alpha", {-0.75f} );
+const auto a_values = make("alpha", {-0.75f} );
 
 /** Beta values to test */
-const auto beta_values = framework::dataset::make("beta", {-0.35f} );
+const auto beta_values = make("beta", {-0.35f} );
 
 /** M values to test */
-const auto m_values = framework::dataset::make("M", 37);
+const auto m_values = make("M", 37);
 
 /** M_W values to test */
-const auto m_w_values = framework::dataset::make("M_W", 5);
+const auto m_w_values = make("M_W", 5);
 
 /** M_H values to test */
-const auto m_h_values = framework::dataset::make("M_H", 7);
+const auto m_h_values = make("M_H", 7);
 
 /** N values to test */
-const auto n_values = framework::dataset::make("N", 51);
+const auto n_values = make("N", 51);
 
 /** K values to test */
-const auto k_values = framework::dataset::make("K", 23);
+const auto k_values = make("K", 23);
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", 2);
+const auto b_values = make("batch_size", 2);
 
 /** Activation values to test */
-const auto act_values = framework::dataset::make("Activation",
+const auto act_values = make("Activation",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 10.f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::ELU),
 });
 
 /** M0 values to test - precommit */
-const auto m0_values_precommit = framework::dataset::make("M0", { 4 });
+const auto m0_values_precommit = make("M0", { 4 });
 
 /** N0 values to test - precommit*/
-const auto n0_values_precommit = framework::dataset::make("N0", { 4 });
+const auto n0_values_precommit = make("N0", { 4 });
 
 /** K0 values to test - precommit*/
-const auto k0_values_precommit = framework::dataset::make("K0", { 4 });
+const auto k0_values_precommit = make("K0", { 4 });
 
 /** M0 values to test - nightly */
-const auto m0_values_nightly = framework::dataset::make("M0", { 8 });
+const auto m0_values_nightly = make("M0", { 8 });
 
 /** N0 values to test - nightly */
-const auto n0_values_nightly = framework::dataset::make("N0", { 16 });
+const auto n0_values_nightly = make("N0", { 16 });
 
 /** K0 values to test - nightly */
-const auto k0_values_nightly = framework::dataset::make("K0", { 16 });
+const auto k0_values_nightly = make("K0", { 16 });
 
 /** H0 values to test */
-const auto h0_values = framework::dataset::make("H0", 1, 3);
+const auto h0_values = make("H0", 1, 3);
 
 /** Interleave values to test with RHS matrix */
-const auto i_values_rhs = framework::dataset::make("interleave_rhs", { true, false });
+const auto i_values_rhs = make("interleave_rhs", { true, false });
 
 /** Transpose values to test with RHS matrix */
-const auto t_values_rhs = framework::dataset::make("transpose_rhs", { true, false });
+const auto t_values_rhs = make("transpose_rhs", { true, false });
 
 /** Broadcast bias from vector to matrix */
-const auto broadcast_bias_values = framework::dataset::make("broadcast_bias", { false, true } );
+const auto broadcast_bias_values = make("broadcast_bias", { false, true } );
 
 /** Boundary handling cases for testing partial/non-partial (full) block dimensions, resulting from different combinations
  * of M, M0, N and N0 values.
@@ -140,22 +141,22 @@ const auto broadcast_bias_values = framework::dataset::make("broadcast_bias", { 
  * parital blocks in X dimension.
  */
 const auto boundary_handling_cases = combine(// Large k to force potential out-of-bound reads on input0
-                                    framework::dataset::make("K", 315),
+                                    make("K", 315),
                                     // Batch size == 1 to force potential out-of-bound reads on input0
-                                    framework::dataset::make("batch_size", 1),
-                                    framework::dataset::make("M0", 4),
-                                    framework::dataset::make("N0", 4),
-                                    framework::dataset::make("K0", 4),
-                                    framework::dataset::make("H0", 3),
+                                    make("batch_size", 1),
+                                    make("M0", 4),
+                                    make("N0", 4),
+                                    make("K0", 4),
+                                    make("H0", 3),
                                     i_values_rhs,
                                     t_values_rhs,
-                                    framework::dataset::make("export_to_cl_image_rhs", {true, false}),
+                                    make("export_to_cl_image_rhs", {true, false}),
                                     // Only need to test F32 as F16 shares identical boundary handling logics
-                                    framework::dataset::make("DataType", DataType::F32),
-                                    framework::dataset::make("alpha", -0.75f ),
-                                    framework::dataset::make("beta", -0.35f ),
+                                    make("DataType", DataType::F32),
+                                    make("alpha", -0.75f ),
+                                    make("beta", -0.35f ),
                                     broadcast_bias_values,
-                                    framework::dataset::make("Activation", ActivationLayerInfo()));
+                                    make("Activation", ActivationLayerInfo()));
 
 /** Configuration test */
 bool validate_configuration(unsigned int m_value, unsigned int n_value, unsigned int k_value, unsigned int b_value,
@@ -234,20 +235,20 @@ TEST_SUITE(GEMMMatrixMultiplyReshapedOnlyRHS)
  *     - Incorrect support for creating an OpenCL image object from buffer. N0 is 2 but it can only be 4,8 and 16
  *     - Correct F16 support for creating an OpenCL image object from buffer.
  */
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("batch_size",          { 1, 1, 1, 1, 1, 1, 2, 1, 1, 1 }),
-framework::dataset::make("M0",                  { 4, 9, 4, 4, 4, 4, 4, 4, 4, 4 }),
-framework::dataset::make("N0",                  { 4, 4, 18, 4, 4, 4, 4, 8, 2, 8 }),
-framework::dataset::make("K0",                  { 4, 4, 4, 1, 4, 4, 4, 4, 4, 4 }),
-framework::dataset::make("broadcast_bias",      { false, false, false, false, false, true, true, false, false, false }),
-framework::dataset::make("input_as_3d",         { 0, 0, 0, 0, 1, 0, 1, 0, 0, 0 }),
-framework::dataset::make("depth_output_gemm3d", { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0 }),
-framework::dataset::make("export_to_cl_image",  { false, false, false, false, false, false, false, true, true, true }),
-framework::dataset::make("data_type_input0",    { DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
-framework::dataset::make("data_type_input1",    { DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
-framework::dataset::make("data_type_input2",    { DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
-framework::dataset::make("data_type_output",    { DataType::F16, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
-framework::dataset::make("Beta",                { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f , 1.0f}),
-framework::dataset::make("Expected",            { false, false, false, false, false, false, false, true, false, true })),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("batch_size",          { 1, 1, 1, 1, 1, 1, 2, 1, 1, 1 }),
+make("M0",                  { 4, 9, 4, 4, 4, 4, 4, 4, 4, 4 }),
+make("N0",                  { 4, 4, 18, 4, 4, 4, 4, 8, 2, 8 }),
+make("K0",                  { 4, 4, 4, 1, 4, 4, 4, 4, 4, 4 }),
+make("broadcast_bias",      { false, false, false, false, false, true, true, false, false, false }),
+make("input_as_3d",         { 0, 0, 0, 0, 1, 0, 1, 0, 0, 0 }),
+make("depth_output_gemm3d", { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0 }),
+make("export_to_cl_image",  { false, false, false, false, false, false, false, true, true, true }),
+make("data_type_input0",    { DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
+make("data_type_input1",    { DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
+make("data_type_input2",    { DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
+make("data_type_output",    { DataType::F16, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F32, DataType::F16}),
+make("Beta",                { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f, 0.0f , 1.0f}),
+make("Expected",            { false, false, false, false, false, false, false, true, false, true })),
 b_value, m0_value, n0_value, k0_value, broadcast_bias, input_as_3d, depth_output_gemm3d, export_to_cl_image, dt_input0, dt_intpu1, dt_input2, dt_output, beta, expected)
 {
     bool expected_value = expected;
@@ -266,8 +267,8 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 
 FIXTURE_DATA_TEST_CASE(RunPrecommitBoundaryHandlingPartialInXPartialInY, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<float>, framework::DatasetMode::PRECOMMIT,
-                combine(framework::dataset::make("M", 3),
-                        framework::dataset::make("N", 1),
+                combine(make("M", 3),
+                        make("N", 1),
                         boundary_handling_cases))
 {
     // Validate output
@@ -283,8 +284,8 @@ FIXTURE_DATA_TEST_CASE(RunPrecommitBoundaryHandlingPartialInXPartialInY, CLGEMMM
 }
 
 FIXTURE_DATA_TEST_CASE(RunPrecommitBoundaryHandlingPartialInXFullInY, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<float>, framework::DatasetMode::PRECOMMIT,
-                combine(framework::dataset::make("M", 64),
-                        framework::dataset::make("N", 43),
+                combine(make("M", 64),
+                        make("N", 43),
                         boundary_handling_cases))
 {
     // Validate output
@@ -300,8 +301,8 @@ FIXTURE_DATA_TEST_CASE(RunPrecommitBoundaryHandlingPartialInXFullInY, CLGEMMMatr
 }
 
 FIXTURE_DATA_TEST_CASE(RunPrecommitBoundaryHandlingFullInXFullInY, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<float>, framework::DatasetMode::PRECOMMIT,
-                combine(framework::dataset::make("M", 64),
-                        framework::dataset::make("N", 32),
+                combine(make("M", 64),
+                        make("N", 32),
                         boundary_handling_cases))
 {
     // Validate output
@@ -317,8 +318,8 @@ FIXTURE_DATA_TEST_CASE(RunPrecommitBoundaryHandlingFullInXFullInY, CLGEMMMatrixM
 }
 
 FIXTURE_DATA_TEST_CASE(RunPrecommitBoundaryHandlingFullInXPartialInY, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<float>, framework::DatasetMode::PRECOMMIT,
-                combine(framework::dataset::make("M", 37),
-                        framework::dataset::make("N", 32),
+                combine(make("M", 37),
+                        make("N", 32),
                         boundary_handling_cases))
 {
     // Validate output
@@ -344,8 +345,8 @@ FIXTURE_DATA_TEST_CASE(RunPrecommit, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", {false, true}),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", {false, true}),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    broadcast_bias_values,
@@ -374,8 +375,8 @@ FIXTURE_DATA_TEST_CASE(RunNightly, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<fl
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", {false, true}),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", {false, true}),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    broadcast_bias_values,
@@ -405,9 +406,9 @@ FIXTURE_DATA_TEST_CASE(RunPrecommit3D, CLGEMMMatrixMultiplyReshapedOnlyRHS3DFixt
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", {false, true}),
-                                                                   framework::dataset::make("has_pad_y", {false, true}),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", {false, true}),
+                                                                   make("has_pad_y", {false, true}),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    act_values))
@@ -436,9 +437,9 @@ FIXTURE_DATA_TEST_CASE(RunNightly3D, CLGEMMMatrixMultiplyReshapedOnlyRHS3DFixtur
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", {false, true}),
-                                                                   framework::dataset::make("has_pad_y", {false, true}),
-                                                                   framework::dataset::make("DataType", DataType::F32),
+                                                                   make("export_to_cl_image_rhs", {false, true}),
+                                                                   make("has_pad_y", {false, true}),
+                                                                   make("DataType", DataType::F32),
                                                                    a_values,
                                                                    beta_values,
                                                                    act_values))
@@ -469,8 +470,8 @@ FIXTURE_DATA_TEST_CASE(RunPrecommit, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values,
                                                                    beta_values,
                                                                    broadcast_bias_values,
@@ -499,8 +500,8 @@ FIXTURE_DATA_TEST_CASE(RunNightly, CLGEMMMatrixMultiplyReshapedOnlyRHSFixture<ha
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values,
                                                                    beta_values,
                                                                    broadcast_bias_values,
@@ -530,9 +531,9 @@ FIXTURE_DATA_TEST_CASE(RunPrecommit3D, CLGEMMMatrixMultiplyReshapedOnlyRHS3DFixt
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("has_pad_y", {false, true}),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("has_pad_y", {false, true}),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values,
                                                                    beta_values,
                                                                    act_values))
@@ -561,9 +562,9 @@ FIXTURE_DATA_TEST_CASE(RunNightly3D, CLGEMMMatrixMultiplyReshapedOnlyRHS3DFixtur
                                                                    h0_values,
                                                                    i_values_rhs,
                                                                    t_values_rhs,
-                                                                   framework::dataset::make("export_to_cl_image_rhs", true),
-                                                                   framework::dataset::make("has_pad_y", {false, true}),
-                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                   make("export_to_cl_image_rhs", true),
+                                                                   make("has_pad_y", {false, true}),
+                                                                   make("DataType", DataType::F16),
                                                                    a_values,
                                                                    beta_values,
                                                                    act_values))

--- a/tests/validation/CL/GEMMMatrixMultiplyReshapedOnlyRhsMMUL.cpp
+++ b/tests/validation/CL/GEMMMatrixMultiplyReshapedOnlyRhsMMUL.cpp
@@ -37,6 +37,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::opencl::kernels;
 
 // Create function for ClGemmReshapeRhsMatrixKernel
@@ -59,48 +60,48 @@ RelativeTolerance<half_float::half> rel_tolerance_f16(half_float::half(0.001f));
 constexpr float          abs_tolerance_f16(0.3f);
 
 /** Alpha values to test - Precommit */
-const auto a_values = framework::dataset::make("alpha", {1.0f, 0.75f} );
+const auto a_values = make("alpha", {1.0f, 0.75f} );
 
 /** Beta values to test - Precommit */
-const auto beta_values = framework::dataset::make("beta", {0.0f, -0.75f} );
+const auto beta_values = make("beta", {0.0f, -0.75f} );
 
 /** M values to test */
-const auto m_values = framework::dataset::make("M", {49});
+const auto m_values = make("M", {49});
 
 /** N values to test */
-const auto n_values              = framework::dataset::make("N", {257, 64, 48});
-const auto n_values_fp16         = framework::dataset::make("N", {79, 32, 80});
-const auto n_values_texture_fp16 = framework::dataset::make("N", {128, 96, 48});
+const auto n_values              = make("N", {257, 64, 48});
+const auto n_values_fp16         = make("N", {79, 32, 80});
+const auto n_values_texture_fp16 = make("N", {128, 96, 48});
 
 /** K values to test */
 /** The test case requires this to be multiple of 4*/
-const auto k_values = framework::dataset::make("K", {192});
-const auto k_values_fp16 = framework::dataset::make("K", {64});
+const auto k_values = make("K", {192});
+const auto k_values_fp16 = make("K", {64});
 
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batch_size", {1, 2});
+const auto b_values = make("batch_size", {1, 2});
 
 /** Activation values to test */
-const auto act_values = framework::dataset::make("Activation",
+const auto act_values = make("Activation",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::ELU)
 });
 
 /** M0 values to test - Precommit */
-const auto m0_values_precommit = framework::dataset::make("M0", { 1, 2, 4 });
-const auto m0_values_precommit_fp16 = framework::dataset::make("M0", { 1, 2, 3, 4, 8 });
+const auto m0_values_precommit = make("M0", { 1, 2, 4 });
+const auto m0_values_precommit_fp16 = make("M0", { 1, 2, 3, 4, 8 });
 
 /** N0 values to test - Precommit */
-const auto n0_values_precommit              = framework::dataset::make("N0", { 4, 8 });
-const auto n0_values_precommit_fp16         = framework::dataset::make("N0", { 2, 4, 8, 16 });
-const auto n0_values_precommit_texture_fp16 = framework::dataset::make("N0", { 4, 8 });
+const auto n0_values_precommit              = make("N0", { 4, 8 });
+const auto n0_values_precommit_fp16         = make("N0", { 2, 4, 8, 16 });
+const auto n0_values_precommit_texture_fp16 = make("N0", { 4, 8 });
 
 /** K0 values to test - Precommit */
-const auto k0_values_precommit = framework::dataset::make("K0", { 1 });
+const auto k0_values_precommit = make("K0", { 1 });
 
 /** Broadcast bias from vector to matrix */
-const auto broadcast_bias_values = framework::dataset::make("broadcast_bias", { false, true } );
+const auto broadcast_bias_values = make("broadcast_bias", { false, true } );
 
 } // namespace
 
@@ -116,8 +117,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<
                         m0_values_precommit,
                         n0_values_precommit,
                         k0_values_precommit,
-                        framework::dataset::make("ExportToCLImage", false),
-                        framework::dataset::make("DataType", DataType::F32),
+                        make("ExportToCLImage", false),
+                        make("DataType", DataType::F32),
                         a_values,
                         beta_values,
                         broadcast_bias_values,
@@ -146,8 +147,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<
                         m0_values_precommit_fp16,
                         n0_values_precommit_fp16,
                         k0_values_precommit,
-                        framework::dataset::make("ExportToCLImage", false),
-                        framework::dataset::make("DataType", DataType::F16),
+                        make("ExportToCLImage", false),
+                        make("DataType", DataType::F16),
                         a_values,
                         beta_values,
                         broadcast_bias_values,
@@ -176,8 +177,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<
                         m0_values_precommit,
                         n0_values_precommit,
                         k0_values_precommit,
-                        framework::dataset::make("ExportToCLImage", true),
-                        framework::dataset::make("DataType", DataType::F32),
+                        make("ExportToCLImage", true),
+                        make("DataType", DataType::F32),
                         a_values,
                         beta_values,
                         broadcast_bias_values,
@@ -206,8 +207,8 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLGEMMMatrixMultiplyReshapedOnlyRhsMMULFixture<
                         m0_values_precommit_fp16,
                         n0_values_precommit_texture_fp16,
                         k0_values_precommit,
-                        framework::dataset::make("ExportToCLImage", true),
-                        framework::dataset::make("DataType", DataType::F16),
+                        make("ExportToCLImage", true),
+                        make("DataType", DataType::F16),
                         a_values,
                         beta_values,
                         broadcast_bias_values,

--- a/tests/validation/CL/GEMMReshapeLHSMatrix.cpp
+++ b/tests/validation/CL/GEMMReshapeLHSMatrix.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 using namespace arm_compute::opencl::kernels;
 
@@ -62,28 +63,28 @@ using CLGEMMReshapeLHSMatrix3DFixture = GEMMReshapeLHSMatrixValidationFixture<CL
 namespace
 {
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batchsize", 1, 3);
+const auto b_values = make("batchsize", 1, 3);
 
 /** M0 values to test */
-const auto m0_values_s32 = framework::dataset::make("M0", { 2, 3 });
-const auto m0_values_s16 = framework::dataset::make("M0", { 4 });
-const auto m0_values_s16_nt = framework::dataset::make("M0", { 5 });
-const auto m0_values_s8_nt = framework::dataset::make("M0", { 6,7 });
-const auto m0_values_s8 = framework::dataset::make("M0", { 8 });
+const auto m0_values_s32 = make("M0", { 2, 3 });
+const auto m0_values_s16 = make("M0", { 4 });
+const auto m0_values_s16_nt = make("M0", { 5 });
+const auto m0_values_s8_nt = make("M0", { 6,7 });
+const auto m0_values_s8 = make("M0", { 8 });
 
 /** K0 values to test */
-const auto k0_values_s32 = framework::dataset::make("K0", { 2, 3 });
-const auto k0_values_s16 = framework::dataset::make("K0", { 4, 8 });
-const auto k0_values_s8 = framework::dataset::make("K0", { 16 });
+const auto k0_values_s32 = make("K0", { 2, 3 });
+const auto k0_values_s16 = make("K0", { 4, 8 });
+const auto k0_values_s8 = make("K0", { 16 });
 
 /** V0 values to test */
-const auto v0_values = framework::dataset::make("V0", 1, 4);
+const auto v0_values = make("V0", 1, 4);
 
 /** Interleave values to test */
-const auto i_values = framework::dataset::make("interleave", { true, false });
+const auto i_values = make("interleave", { true, false });
 
 /** Transpose values to test */
-const auto t_values = framework::dataset::make("transpose", { true, false });
+const auto t_values = make("transpose", { true, false });
 
 } // namespace
 
@@ -93,7 +94,7 @@ TEST_SUITE(GEMMReshapeLHSMatrix)
 FIXTURE_DATA_TEST_CASE(S32, CLGEMMReshapeLHSMatrixFixture<int>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape2DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S32),
+                                                                   make("DataType", DataType::S32),
                                                                    m0_values_s32,
                                                                    k0_values_s32,
                                                                    v0_values,
@@ -107,7 +108,7 @@ FIXTURE_DATA_TEST_CASE(S32, CLGEMMReshapeLHSMatrixFixture<int>, framework::Datas
 FIXTURE_DATA_TEST_CASE(S16, CLGEMMReshapeLHSMatrixFixture<short>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape2DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S16),
+                                                                   make("DataType", DataType::S16),
                                                                    m0_values_s16,
                                                                    k0_values_s16,
                                                                    v0_values,
@@ -121,7 +122,7 @@ FIXTURE_DATA_TEST_CASE(S16, CLGEMMReshapeLHSMatrixFixture<short>, framework::Dat
 FIXTURE_DATA_TEST_CASE(S8, CLGEMMReshapeLHSMatrixFixture<char>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape2DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S8),
+                                                                   make("DataType", DataType::S8),
                                                                    m0_values_s8,
                                                                    k0_values_s8,
                                                                    v0_values,
@@ -136,12 +137,12 @@ TEST_SUITE(NotTransposed)
 FIXTURE_DATA_TEST_CASE(S16, CLGEMMReshapeLHSMatrixFixture<short>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape2DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S16),
+                                                                   make("DataType", DataType::S16),
                                                                    m0_values_s16_nt,
                                                                    k0_values_s16,
                                                                    v0_values,
                                                                    i_values,
-                                                                   framework::dataset::make("transpose", { false })))
+                                                                   make("transpose", { false })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -150,12 +151,12 @@ FIXTURE_DATA_TEST_CASE(S16, CLGEMMReshapeLHSMatrixFixture<short>, framework::Dat
 FIXTURE_DATA_TEST_CASE(S8, CLGEMMReshapeLHSMatrixFixture<char>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape2DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S8),
+                                                                   make("DataType", DataType::S8),
                                                                    m0_values_s8_nt,
                                                                    k0_values_s8,
                                                                    v0_values,
                                                                    i_values,
-                                                                   framework::dataset::make("transpose", { false })))
+                                                                   make("transpose", { false })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -167,7 +168,7 @@ TEST_SUITE(ReinterpretInputAs3D)
 FIXTURE_DATA_TEST_CASE(S32, CLGEMMReshapeLHSMatrix3DFixture<int>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape3DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S32),
+                                                                   make("DataType", DataType::S32),
                                                                    m0_values_s32,
                                                                    k0_values_s32,
                                                                    v0_values,
@@ -181,7 +182,7 @@ FIXTURE_DATA_TEST_CASE(S32, CLGEMMReshapeLHSMatrix3DFixture<int>, framework::Dat
 FIXTURE_DATA_TEST_CASE(S16, CLGEMMReshapeLHSMatrix3DFixture<short>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape3DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S16),
+                                                                   make("DataType", DataType::S16),
                                                                    m0_values_s16,
                                                                    k0_values_s16,
                                                                    v0_values,
@@ -195,7 +196,7 @@ FIXTURE_DATA_TEST_CASE(S16, CLGEMMReshapeLHSMatrix3DFixture<short>, framework::D
 FIXTURE_DATA_TEST_CASE(S8, CLGEMMReshapeLHSMatrix3DFixture<char>, framework::DatasetMode::ALL,
                 combine(datasets::SmallGEMMReshape3DShapes(),
                                                                    b_values,
-                                                                   framework::dataset::make("DataType", DataType::S8),
+                                                                   make("DataType", DataType::S8),
                                                                    m0_values_s8,
                                                                    k0_values_s8,
                                                                    v0_values,

--- a/tests/validation/CL/GEMMReshapeRHSMatrix.cpp
+++ b/tests/validation/CL/GEMMReshapeRHSMatrix.cpp
@@ -42,34 +42,35 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 // *INDENT-OFF*
 // clang-format off
 /** Batch size values to test */
-const auto b_values = framework::dataset::make("batchsize", 1, 3);
+const auto b_values = make("batchsize", 1, 3);
 
 /** N0 values to test */
-const auto n0_values_nt_s32 = framework::dataset::make("N0", { 1, 2, 3 });
-const auto n0_values_nt_s16 = framework::dataset::make("N0", { 4, 8 });
-const auto n0_values_nt_s8 = framework::dataset::make("N0", { 16 });
-const auto n0_values_t_s32 = framework::dataset::make("N0", { 4, 8 });
-const auto n0_values_t_s16 = framework::dataset::make("N0", { 16 });
-const auto n0_values_t_s8 = framework::dataset::make("N0", { 2, 3 });
+const auto n0_values_nt_s32 = make("N0", { 1, 2, 3 });
+const auto n0_values_nt_s16 = make("N0", { 4, 8 });
+const auto n0_values_nt_s8 = make("N0", { 16 });
+const auto n0_values_t_s32 = make("N0", { 4, 8 });
+const auto n0_values_t_s16 = make("N0", { 16 });
+const auto n0_values_t_s8 = make("N0", { 2, 3 });
 
 /** K0 values to test */
-const auto k0_values_nt_s32 = framework::dataset::make("K0", { 1, 2 });
-const auto k0_values_nt_s16 = framework::dataset::make("K0", { 16 });
-const auto k0_values_nt_s8 = framework::dataset::make("K0", { 3,4 });
-const auto k0_values_t_s32 = framework::dataset::make("K0", { 2, 3 });
-const auto k0_values_t_s16 = framework::dataset::make("K0", { 4, 8 });
-const auto k0_values_t_s8 = framework::dataset::make("K0", { 16 });
+const auto k0_values_nt_s32 = make("K0", { 1, 2 });
+const auto k0_values_nt_s16 = make("K0", { 16 });
+const auto k0_values_nt_s8 = make("K0", { 3,4 });
+const auto k0_values_t_s32 = make("K0", { 2, 3 });
+const auto k0_values_t_s16 = make("K0", { 4, 8 });
+const auto k0_values_t_s8 = make("K0", { 16 });
 
 /** H0 values to test */
-const auto h0_values = framework::dataset::make("H0", 1, 4);
+const auto h0_values = make("H0", 1, 4);
 
 /** Interleave values to test */
-const auto i_values = framework::dataset::make("interleave", { true, false });
+const auto i_values = make("interleave", { true, false });
 } // namespace
 
 using namespace arm_compute::misc::shape_calculator;
@@ -86,7 +87,7 @@ TEST_SUITE(GEMMReshapeRHSMatrix)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),    // Wrong n0 value
                                                        TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),    // Wrong k0 value
@@ -95,7 +96,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),    // k0 > 16
                                                        TensorInfo(TensorShape(32U, 16U, 2U), 1, DataType::F32),    // k0 == 1 && transpose
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(64U, 2U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(64U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 2U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 2U, 2U), 1, DataType::F32),
@@ -104,10 +105,10 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 2U, 2U), 1, DataType::F32),
                                                      }),
-                framework::dataset::make("N0",{ 4, 0, 4, 4, 4, 17, 4, 4 }),
-                framework::dataset::make("K0",{ 4, 4, 0, 4, 4, 4, 17, 1 }),
-                framework::dataset::make("H0",{ 4, 4, 4, 0, 4, 4, 4, 4 }),
-               framework::dataset::make("Expected", { false, false, false, false, false, false, false})),
+                make("N0",{ 4, 0, 4, 4, 4, 17, 4, 4 }),
+                make("K0",{ 4, 4, 0, 4, 4, 4, 17, 1 }),
+                make("H0",{ 4, 4, 4, 0, 4, 4, 4, 4 }),
+               make("Expected", { false, false, false, false, false, false, false})),
                input_info, output_info, n0, k0, h0, expected)
 {
     GEMMRHSMatrixInfo rhs_info;
@@ -121,13 +122,13 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
     ARM_COMPUTE_EXPECT(has_error == expected, framework::LogLevel::ERRORS);
 }
 
-DATA_TEST_CASE(ValidatePadding, framework::DatasetMode::ALL, combine(framework::dataset::make("InputShape", { TensorShape(32U, 16U, 1U),
+DATA_TEST_CASE(ValidatePadding, framework::DatasetMode::ALL, combine(make("InputShape", { TensorShape(32U, 16U, 1U),
                                                         TensorShape(32U, 16U, 2U)
                                                      }),
-                framework::dataset::make("N0",{ 4 }),
-                framework::dataset::make("K0",{ 4, 8, 16 }),
-                framework::dataset::make("H0",{ 1, 2, 4 }),
-                framework::dataset::make("DataType",{ DataType::F32, DataType::F16 })),
+                make("N0",{ 4 }),
+                make("K0",{ 4, 8, 16 }),
+                make("H0",{ 1, 2, 4 }),
+                make("DataType",{ DataType::F32, DataType::F16 })),
                input_shape, n0, k0, h0, data_type)
 {
     CLTensor input;
@@ -170,12 +171,12 @@ DATA_TEST_CASE(ValidatePadding, framework::DatasetMode::ALL, combine(framework::
 FIXTURE_DATA_TEST_CASE(S32_NT, CLGEMMReshapeRHSMatrixFixture<int>, framework::DatasetMode::ALL,
                        combine(datasets::SmallGEMMReshape2DShapes(),
                                                                                b_values,
-                                                                       framework::dataset::make("DataType", DataType::S32),
+                                                                       make("DataType", DataType::S32),
                                                                n0_values_nt_s32,
                                                        k0_values_nt_s32,
                                                h0_values,
                                        i_values,
-                               framework::dataset::make("transpose", false)))
+                               make("transpose", false)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -185,12 +186,12 @@ FIXTURE_DATA_TEST_CASE(S32_NT, CLGEMMReshapeRHSMatrixFixture<int>, framework::Da
 FIXTURE_DATA_TEST_CASE(S32_T, CLGEMMReshapeRHSMatrixFixture<int>, framework::DatasetMode::ALL,
                        combine(datasets::SmallGEMMReshape2DShapes(),
                                                                                b_values,
-                                                                       framework::dataset::make("DataType", DataType::S32),
+                                                                       make("DataType", DataType::S32),
                                                                n0_values_t_s32,
                                                        k0_values_t_s32,
                                                h0_values,
                                        i_values,
-                               framework::dataset::make("transpose", true)))
+                               make("transpose", true)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -200,12 +201,12 @@ FIXTURE_DATA_TEST_CASE(S32_T, CLGEMMReshapeRHSMatrixFixture<int>, framework::Dat
 FIXTURE_DATA_TEST_CASE(S16_NT, CLGEMMReshapeRHSMatrixFixture<short>, framework::DatasetMode::ALL,
                        combine(datasets::SmallGEMMReshape2DShapes(),
                                                                                b_values,
-                                                                       framework::dataset::make("DataType", DataType::S16),
+                                                                       make("DataType", DataType::S16),
                                                                n0_values_nt_s16,
                                                        k0_values_nt_s16,
                                                h0_values,
                                        i_values,
-                               framework::dataset::make("transpose", false)))
+                               make("transpose", false)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -215,12 +216,12 @@ FIXTURE_DATA_TEST_CASE(S16_NT, CLGEMMReshapeRHSMatrixFixture<short>, framework::
 FIXTURE_DATA_TEST_CASE(S16_T, CLGEMMReshapeRHSMatrixFixture<short>, framework::DatasetMode::ALL,
                        combine(datasets::SmallGEMMReshape2DShapes(),
                                                                                b_values,
-                                                                       framework::dataset::make("DataType", DataType::S16),
+                                                                       make("DataType", DataType::S16),
                                                                n0_values_t_s16,
                                                        k0_values_t_s16,
                                                h0_values,
                                        i_values,
-                               framework::dataset::make("transpose", true)))
+                               make("transpose", true)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -230,12 +231,12 @@ FIXTURE_DATA_TEST_CASE(S16_T, CLGEMMReshapeRHSMatrixFixture<short>, framework::D
 FIXTURE_DATA_TEST_CASE(S8_NT, CLGEMMReshapeRHSMatrixFixture<char>, framework::DatasetMode::ALL,
                        combine(datasets::SmallGEMMReshape2DShapes(),
                                                                                b_values,
-                                                                       framework::dataset::make("DataType", DataType::S8),
+                                                                       make("DataType", DataType::S8),
                                                                n0_values_nt_s8,
                                                        k0_values_nt_s8,
                                                h0_values,
                                        i_values,
-                               framework::dataset::make("transpose", false)))
+                               make("transpose", false)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -245,12 +246,12 @@ FIXTURE_DATA_TEST_CASE(S8_NT, CLGEMMReshapeRHSMatrixFixture<char>, framework::Da
 FIXTURE_DATA_TEST_CASE(S8_T, CLGEMMReshapeRHSMatrixFixture<char>, framework::DatasetMode::ALL,
                        combine(datasets::SmallGEMMReshape2DShapes(),
                                                                                b_values,
-                                                                       framework::dataset::make("DataType", DataType::S8),
+                                                                       make("DataType", DataType::S8),
                                                                n0_values_t_s8,
                                                        k0_values_t_s8,
                                                h0_values,
                                        i_values,
-                               framework::dataset::make("transpose", true)))
+                               make("transpose", true)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/Gather.cpp
+++ b/tests/validation/CL/Gather.cpp
@@ -39,12 +39,13 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Gather)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 27U), 1, DataType::F16),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 27U), 1, DataType::F16),
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),                // Invalid Output shape
@@ -55,7 +56,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),                // Invalid positive axis value
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F16),                // Invalid negative axis value
         }),
-        framework::dataset::make("IndicesInfo", {
+        make("IndicesInfo", {
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
@@ -67,7 +68,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10U), 1, DataType::U32),
         }),
-        framework::dataset::make("OutputInfo", {
+        make("OutputInfo", {
                                                 TensorInfo(TensorShape(10U, 27U), 1, DataType::F16),
                                                 TensorInfo(TensorShape(27U, 10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10U, 27U), 1, DataType::F32),
@@ -79,7 +80,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 27U), 1, DataType::F16),
         }),
-        framework::dataset::make("Axis", {
+        make("Axis", {
                                             0,
                                             1,
                                             -2,
@@ -91,7 +92,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                             2,
                                             -3,
         }),
-        framework::dataset::make("Expected", { true, true, true, false, false, false, false, false, false, false })),
+        make("Expected", { true, true, true, false, false, false, false, false, false, false })),
         input_info, indices_info, output_info, axis, expected)
 {
     const Status status = CLGather::validate(&input_info.clone()->set_is_resizable(true), &indices_info.clone()->set_is_resizable(true), &output_info.clone()->set_is_resizable(true), axis);
@@ -108,7 +109,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLGatherFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallGatherDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallGatherDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -117,7 +118,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
                        CLGatherFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -126,7 +127,7 @@ FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLGatherFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -137,7 +138,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLGatherFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallGatherDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallGatherDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -146,7 +147,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
                        CLGatherFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -155,7 +156,7 @@ FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLGatherFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -167,7 +168,7 @@ TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLGatherFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallGatherDataset(), framework::dataset::make("DataType", DataType::U8)))
+                       combine(datasets::SmallGatherDataset(), make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -176,7 +177,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
                        CLGatherFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), framework::dataset::make("DataType", DataType::U8)))
+                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -185,7 +186,7 @@ FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLGatherFixture<uint8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::U8)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -196,7 +197,7 @@ TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLGatherFixture<uint16_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallGatherDataset(), framework::dataset::make("DataType", DataType::U16)))
+                       combine(datasets::SmallGatherDataset(), make("DataType", DataType::U16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -205,7 +206,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
                        CLGatherFixture<uint16_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), framework::dataset::make("DataType", DataType::U16)))
+                       combine(datasets::CLSmallGatherMultiDimIndicesDataset(), make("DataType", DataType::U16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -215,7 +216,7 @@ FIXTURE_DATA_TEST_CASE(RunSmallMultiDimIndices,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLGatherFixture<uint16_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeGatherDataset(), framework::dataset::make("DataType", DataType::U16)))
+                       combine(datasets::LargeGatherDataset(), make("DataType", DataType::U16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/GenerateProposalsLayer.cpp
+++ b/tests/validation/CL/GenerateProposalsLayer.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 using CLComputeAllAnchors = CLSynthetizeFunction<CLComputeAllAnchorsKernel>;
@@ -77,7 +78,7 @@ inline void fill_tensor(CLAccessor &&tensor, const std::vector<T> &v)
     }
 }
 
-const auto ComputeAllInfoDataset = framework::dataset::make("ComputeAllInfo",
+const auto ComputeAllInfoDataset = make("ComputeAllInfo",
 {
     ComputeAnchorsInfo(10U, 10U, 1. / 16.f),
     ComputeAnchorsInfo(100U, 1U, 1. / 2.f),
@@ -94,49 +95,49 @@ TEST_SUITE(GenerateProposals)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("scores", { TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("scores", { TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F32),
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Mismatching types
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Wrong deltas (number of transformation non multiple of 4)
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Wrong anchors (number of values per roi != 5)
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16), // Output tensor num_valid_proposals not scalar
                                                     TensorInfo(TensorShape(100U, 100U, 9U), 1, DataType::F16)}), // num_valid_proposals not U32
-               framework::dataset::make("deltas",{ TensorInfo(TensorShape(100U, 100U, 36U), 1, DataType::F32),
+               make("deltas",{ TensorInfo(TensorShape(100U, 100U, 36U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 36U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32),
                                                    TensorInfo(TensorShape(100U, 100U, 38U), 1, DataType::F32)}),
-               framework::dataset::make("anchors", { TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
+               make("anchors", { TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(5U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(4U, 9U), 1, DataType::F32)}),
-               framework::dataset::make("proposals", { TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
+               make("proposals", { TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 100U*100U*9U), 1, DataType::F32)}),
-               framework::dataset::make("scores_out", { TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
+               make("scores_out", { TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(100U*100U*9U), 1, DataType::F32)}),
-               framework::dataset::make("num_valid_proposals", { TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
+               make("num_valid_proposals", { TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 10U), 1, DataType::U32),
                                                                  TensorInfo(TensorShape(1U, 1U), 1, DataType::F16)}),
-               framework::dataset::make("generate_proposals_info", { GenerateProposalsInfo(10.f, 10.f, 1.f),
+               make("generate_proposals_info", { GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f),
                                                                      GenerateProposalsInfo(10.f, 10.f, 1.f)}),
-               framework::dataset::make("Expected", { true, false, false, false, false, false })),
+               make("Expected", { true, false, false, false, false, false })),
         scores, deltas, anchors, proposals, scores_out, num_valid_proposals, generate_proposals_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLGenerateProposalsLayer::validate(&scores.clone()->set_is_resizable(true),
@@ -155,7 +156,7 @@ using CLComputeAllAnchorsFixture = ComputeAllAnchorsFixture<CLTensor, CLAccessor
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-DATA_TEST_CASE(IntegrationTestCaseAllAnchors, framework::DatasetMode::ALL, framework::dataset::make("DataType", { DataType::F32 }),
+DATA_TEST_CASE(IntegrationTestCaseAllAnchors, framework::DatasetMode::ALL, make("DataType", { DataType::F32 }),
                data_type)
 {
     const int values_per_roi = 4;
@@ -220,8 +221,8 @@ DATA_TEST_CASE(IntegrationTestCaseAllAnchors, framework::DatasetMode::ALL, frame
     validate(CLAccessor(all_anchors), anchors_expected);
 }
 
-DATA_TEST_CASE(IntegrationTestCaseGenerateProposals, framework::DatasetMode::ALL, combine(framework::dataset::make("DataType", { DataType::F32 }),
-                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })),
+DATA_TEST_CASE(IntegrationTestCaseGenerateProposals, framework::DatasetMode::ALL, combine(make("DataType", { DataType::F32 }),
+                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })),
                data_type, data_layout)
 {
     const int values_per_roi = 4;
@@ -380,7 +381,7 @@ DATA_TEST_CASE(IntegrationTestCaseGenerateProposals, framework::DatasetMode::ALL
 }
 
 FIXTURE_DATA_TEST_CASE(ComputeAllAnchors, CLComputeAllAnchorsFixture<float>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, framework::dataset::make("DataType", { DataType::F32 })))
+                       combine(make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, make("DataType", { DataType::F32 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -389,7 +390,7 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(ComputeAllAnchors, CLComputeAllAnchorsFixture<half>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, framework::dataset::make("DataType", { DataType::F16 })))
+                       combine(make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset, make("DataType", { DataType::F16 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -403,9 +404,9 @@ using CLComputeAllAnchorsQuantizedFixture = ComputeAllAnchorsQuantizedFixture<CL
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(ComputeAllAnchors, CLComputeAllAnchorsQuantizedFixture<int16_t>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset,
-                                       framework::dataset::make("DataType", { DataType::QSYMM16 }),
-                               framework::dataset::make("QuantInfo", { QuantizationInfo(0.125f, 0) })))
+                       combine(make("NumAnchors", { 2, 4, 8 }), ComputeAllInfoDataset,
+                                       make("DataType", { DataType::QSYMM16 }),
+                               make("QuantInfo", { QuantizationInfo(0.125f, 0) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qsymm16);

--- a/tests/validation/CL/GlobalPoolingLayer.cpp
+++ b/tests/validation/CL/GlobalPoolingLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Input data set for float data types */
@@ -59,9 +60,9 @@ using CLGlobalPoolingLayerFixture = GlobalPoolingLayerValidationFixture<CLTensor
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunGlobalPooling, CLGlobalPoolingLayerFixture<float>, framework::DatasetMode::ALL, combine(GlobalPoolingLayerDataset, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunGlobalPooling, CLGlobalPoolingLayerFixture<float>, framework::DatasetMode::ALL, combine(GlobalPoolingLayerDataset, make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                                                                                                                  make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -69,9 +70,9 @@ FIXTURE_DATA_TEST_CASE(RunGlobalPooling, CLGlobalPoolingLayerFixture<float>, fra
 TEST_SUITE_END()
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunGlobalPooling, CLGlobalPoolingLayerFixture<half>, framework::DatasetMode::ALL, combine(GlobalPoolingLayerDataset, framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunGlobalPooling, CLGlobalPoolingLayerFixture<half>, framework::DatasetMode::ALL, combine(GlobalPoolingLayerDataset, make("DataType",
                                                                                                                  DataType::F16),
-                                                                                                                 framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                                                                                                                 make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);

--- a/tests/validation/CL/HeightConcatenateLayer.cpp
+++ b/tests/validation/CL/HeightConcatenateLayer.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(HeightConcatenateLayer)
 
@@ -49,18 +50,18 @@ using CLHeightConcatenateLayerFixture = ConcatenateLayerValidationFixture<CLTens
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLHeightConcatenateLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                   framework::dataset::make("DataType",
+                                                                                                                   make("DataType",
                                                                                                                            DataType::F16),
-                                                                                                                   framework::dataset::make("Axis", 1)))
+                                                                                                                   make("Axis", 1)))
 
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLHeightConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large2DShapes(), datasets::Small4DShapes()),
-                                                                                                                 framework::dataset::make("DataType",
+                                                                                                                 make("DataType",
                                                                                                                          DataType::F16),
-                                                                                                                 framework::dataset::make("Axis", 1)))
+                                                                                                                 make("Axis", 1)))
 
 {
     // Validate output
@@ -70,17 +71,17 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLHeightConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                    framework::dataset::make("DataType",
+                                                                                                                    make("DataType",
                                                                                                                             DataType::F32),
-                                                                                                                    framework::dataset::make("Axis", 1)))
+                                                                                                                    make("Axis", 1)))
 
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLHeightConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLHeightConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                   DataType::F32),
-                                                                                                                  framework::dataset::make("Axis", 1)))
+                                                                                                                  make("Axis", 1)))
 
 {
     // Validate output
@@ -92,17 +93,17 @@ TEST_SUITE_END()
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLHeightConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                      framework::dataset::make("DataType",
+                                                                                                                      make("DataType",
                                                                                                                               DataType::QASYMM8),
-                                                                                                                      framework::dataset::make("Axis", 1)))
+                                                                                                                      make("Axis", 1)))
 
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLHeightConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLHeightConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                     DataType::QASYMM8),
-                                                                                                                    framework::dataset::make("Axis", 1)))
+                                                                                                                    make("Axis", 1)))
 
 {
     // Validate output

--- a/tests/validation/CL/Im2Col.cpp
+++ b/tests/validation/CL/Im2Col.cpp
@@ -37,6 +37,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Im2Col)
 
@@ -152,16 +153,16 @@ TEST_SUITE(NHWC)
 FIXTURE_DATA_TEST_CASE(W3x3,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape",
+                       combine(make("InputShape",
 {
     TensorShape(5U, 7U, 2U, 2U), TensorShape(4U, 6U, 3U, 2U), TensorShape(5U, 3U, 1U, 2U),
 }),
-framework::dataset::make("DataType", DataType::F32),
-framework::dataset::make("Kernel", Size2D(3, 3)),
-framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 2), PadStrideInfo(1, 1, 0, 0) }),
-framework::dataset::make("QInfo", QuantizationInfo()),
-framework::dataset::make("DataLayout", DataLayout::NHWC),
-framework::dataset::make("Groups", 1)))
+make("DataType", DataType::F32),
+make("Kernel", Size2D(3, 3)),
+make("PadStride", { PadStrideInfo(1, 2, 1, 2), PadStrideInfo(1, 1, 0, 0) }),
+make("QInfo", QuantizationInfo()),
+make("DataLayout", DataLayout::NHWC),
+make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -181,16 +182,16 @@ framework::dataset::make("Groups", 1)))
 FIXTURE_DATA_TEST_CASE(W9x9,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape",
+                       combine(make("InputShape",
 {
     TensorShape(13U, 15U, 2U, 2U), TensorShape(15U, 12U, 3U, 2U), TensorShape(13U, 22U, 1U, 2U),
 }),
-framework::dataset::make("DataType", DataType::F32),
-framework::dataset::make("Kernel", Size2D(9, 9)),
-framework::dataset::make("PadStride", { PadStrideInfo(2, 2, 1, 2), PadStrideInfo(1, 1, 0, 0) }),
-framework::dataset::make("QInfo", QuantizationInfo()),
-framework::dataset::make("DataLayout", DataLayout::NHWC),
-framework::dataset::make("Groups", 1)))
+make("DataType", DataType::F32),
+make("Kernel", Size2D(9, 9)),
+make("PadStride", { PadStrideInfo(2, 2, 1, 2), PadStrideInfo(1, 1, 0, 0) }),
+make("QInfo", QuantizationInfo()),
+make("DataLayout", DataLayout::NHWC),
+make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -210,16 +211,16 @@ framework::dataset::make("Groups", 1)))
 FIXTURE_DATA_TEST_CASE(Generic,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape",
+                       combine(make("InputShape",
 {
     TensorShape(13U, 15U, 4U, 2U), TensorShape(15U, 12U, 7U, 1U), TensorShape(5U, 3U, 1U, 1U),
 }),
-framework::dataset::make("DataType", DataType::F32),
-framework::dataset::make("Kernel", Size2D(5, 3)),
-framework::dataset::make("PadStride", { PadStrideInfo(2, 2, 1, 2), PadStrideInfo(1, 1, 0, 0) }),
-framework::dataset::make("QInfo", QuantizationInfo()),
-framework::dataset::make("DataLayout", DataLayout::NHWC),
-framework::dataset::make("Groups", 1)))
+make("DataType", DataType::F32),
+make("Kernel", Size2D(5, 3)),
+make("PadStride", { PadStrideInfo(2, 2, 1, 2), PadStrideInfo(1, 1, 0, 0) }),
+make("QInfo", QuantizationInfo()),
+make("DataLayout", DataLayout::NHWC),
+make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -242,13 +243,13 @@ TEST_SUITE(NCHW)
 FIXTURE_DATA_TEST_CASE(W1x1_Stride1_NoPad,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(4U, 4U, 3U, 2U), TensorShape(5U, 4U, 3U, 2U), TensorShape(3U, 4U, 3U, 2U) }),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                               framework::dataset::make("Kernel", Size2D(1, 1)),
-                                                       framework::dataset::make("PadStride", PadStrideInfo(1, 1, 0, 0)),
-                                               framework::dataset::make("QInfo", QuantizationInfo()),
-                                       framework::dataset::make("DataLayout", DataLayout::NCHW),
-                               framework::dataset::make("Groups", 1)))
+                       combine(make("InputShape", { TensorShape(4U, 4U, 3U, 2U), TensorShape(5U, 4U, 3U, 2U), TensorShape(3U, 4U, 3U, 2U) }),
+                                                                   make("DataType", DataType::F32),
+                                                               make("Kernel", Size2D(1, 1)),
+                                                       make("PadStride", PadStrideInfo(1, 1, 0, 0)),
+                                               make("QInfo", QuantizationInfo()),
+                                       make("DataLayout", DataLayout::NCHW),
+                               make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -265,13 +266,13 @@ FIXTURE_DATA_TEST_CASE(W1x1_Stride1_NoPad,
 FIXTURE_DATA_TEST_CASE(W3x3,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(4U, 4U, 3U, 2U)),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                               framework::dataset::make("Kernel", Size2D(3, 3)),
-                                                       framework::dataset::make("PadStride", PadStrideInfo(1, 2, 1, 2)),
-                                               framework::dataset::make("QInfo", QuantizationInfo()),
-                                       framework::dataset::make("DataLayout", DataLayout::NCHW),
-                               framework::dataset::make("Groups", { 1, 3 })))
+                       combine(make("InputShape", TensorShape(4U, 4U, 3U, 2U)),
+                                                                   make("DataType", DataType::F32),
+                                                               make("Kernel", Size2D(3, 3)),
+                                                       make("PadStride", PadStrideInfo(1, 2, 1, 2)),
+                                               make("QInfo", QuantizationInfo()),
+                                       make("DataLayout", DataLayout::NCHW),
+                               make("Groups", { 1, 3 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -288,13 +289,13 @@ FIXTURE_DATA_TEST_CASE(W3x3,
 FIXTURE_DATA_TEST_CASE(W5x5,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(7U, 4U, 3U, 2U)),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                               framework::dataset::make("Kernel", Size2D(5, 5)),
-                                                       framework::dataset::make("PadStride", PadStrideInfo(2, 1, 2, 1)),
-                                               framework::dataset::make("QInfo", QuantizationInfo()),
-                                       framework::dataset::make("DataLayout", DataLayout::NCHW),
-                               framework::dataset::make("Groups", { 1, 3 })))
+                       combine(make("InputShape", TensorShape(7U, 4U, 3U, 2U)),
+                                                                   make("DataType", DataType::F32),
+                                                               make("Kernel", Size2D(5, 5)),
+                                                       make("PadStride", PadStrideInfo(2, 1, 2, 1)),
+                                               make("QInfo", QuantizationInfo()),
+                                       make("DataLayout", DataLayout::NCHW),
+                               make("Groups", { 1, 3 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -313,13 +314,13 @@ FIXTURE_DATA_TEST_CASE(W5x5,
 FIXTURE_DATA_TEST_CASE(W11x11_NoPad,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(11U, 11U, 2U, 2U), TensorShape(14U, 13U, 1U, 2U) }),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                               framework::dataset::make("Kernel", Size2D(11, 11)),
-                                                       framework::dataset::make("PadStride", PadStrideInfo(1, 1, 0, 0)),
-                                               framework::dataset::make("QInfo", QuantizationInfo()),
-                                       framework::dataset::make("DataLayout", DataLayout::NCHW),
-                               framework::dataset::make("Groups", 1)))
+                       combine(make("InputShape", { TensorShape(11U, 11U, 2U, 2U), TensorShape(14U, 13U, 1U, 2U) }),
+                                                                   make("DataType", DataType::F32),
+                                                               make("Kernel", Size2D(11, 11)),
+                                                       make("PadStride", PadStrideInfo(1, 1, 0, 0)),
+                                               make("QInfo", QuantizationInfo()),
+                                       make("DataLayout", DataLayout::NCHW),
+                               make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -336,13 +337,13 @@ FIXTURE_DATA_TEST_CASE(W11x11_NoPad,
 FIXTURE_DATA_TEST_CASE(GenericZeroPad,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(13U, 11U, 2U, 2U)),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                               framework::dataset::make("Kernel", Size2D(3, 2)),
-                                                       framework::dataset::make("PadStride", PadStrideInfo(2, 1, 0, 0)),
-                                               framework::dataset::make("QInfo", QuantizationInfo()),
-                                       framework::dataset::make("DataLayout", DataLayout::NCHW),
-                               framework::dataset::make("Groups", { 1, 2 })))
+                       combine(make("InputShape", TensorShape(13U, 11U, 2U, 2U)),
+                                                                   make("DataType", DataType::F32),
+                                                               make("Kernel", Size2D(3, 2)),
+                                                       make("PadStride", PadStrideInfo(2, 1, 0, 0)),
+                                               make("QInfo", QuantizationInfo()),
+                                       make("DataLayout", DataLayout::NCHW),
+                               make("Groups", { 1, 2 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -361,13 +362,13 @@ TEST_SUITE_END() // NCHW
 FIXTURE_DATA_TEST_CASE(Generic,
                        ClIm2ColFixture<float>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(13U, 11U, 5U, 2U)),
-                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                               framework::dataset::make("Kernel", { Size2D(3, 2), Size2D(3, 5) }),
-                                                       framework::dataset::make("PadStride", PadStrideInfo(2, 1, 2, 1)),
-                                               framework::dataset::make("QInfo", QuantizationInfo()),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                               framework::dataset::make("Groups", 1)))
+                       combine(make("InputShape", TensorShape(13U, 11U, 5U, 2U)),
+                                                                   make("DataType", DataType::F32),
+                                                               make("Kernel", { Size2D(3, 2), Size2D(3, 5) }),
+                                                       make("PadStride", PadStrideInfo(2, 1, 2, 1)),
+                                               make("QInfo", QuantizationInfo()),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                               make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -386,13 +387,13 @@ FIXTURE_DATA_TEST_CASE(Generic,
 FIXTURE_DATA_TEST_CASE(Quantized,
                        ClIm2ColFixture<uint8_t>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(13U, 11U, 11U, 2U)),
-                                                                   framework::dataset::make("DataType", DataType::QASYMM8),
-                                                               framework::dataset::make("Kernel", { Size2D(1, 1), Size2D(3, 3), Size2D(5, 5), Size2D(3, 5), Size2D(9, 9) }),
-                                                       framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
-                                               framework::dataset::make("QInfo", QuantizationInfo(0.5f, 10)),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                               framework::dataset::make("Groups", 1)))
+                       combine(make("InputShape", TensorShape(13U, 11U, 11U, 2U)),
+                                                                   make("DataType", DataType::QASYMM8),
+                                                               make("Kernel", { Size2D(1, 1), Size2D(3, 3), Size2D(5, 5), Size2D(3, 5), Size2D(9, 9) }),
+                                                       make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
+                                               make("QInfo", QuantizationInfo(0.5f, 10)),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                               make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -411,13 +412,13 @@ FIXTURE_DATA_TEST_CASE(Quantized,
 FIXTURE_DATA_TEST_CASE(FP16,
                        ClIm2ColFixture<half>,
                        framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", TensorShape(13U, 11U, 11U, 2U)),
-                                                                   framework::dataset::make("DataType", DataType::F16),
-                                                               framework::dataset::make("Kernel", { Size2D(1, 1), Size2D(3, 3), Size2D(5, 5), Size2D(3, 5), Size2D(9, 9) }),
-                                                       framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
-                                               framework::dataset::make("QInfo", QuantizationInfo()),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                               framework::dataset::make("Groups", 1)))
+                       combine(make("InputShape", TensorShape(13U, 11U, 11U, 2U)),
+                                                                   make("DataType", DataType::F16),
+                                                               make("Kernel", { Size2D(1, 1), Size2D(3, 3), Size2D(5, 5), Size2D(3, 5), Size2D(9, 9) }),
+                                                       make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
+                                               make("QInfo", QuantizationInfo()),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                               make("Groups", 1)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/IndirectConv2dAddressPrecalculation.cpp
+++ b/tests/validation/CL/IndirectConv2dAddressPrecalculation.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 using namespace arm_compute::misc::shape_calculator;
 using namespace arm_compute::opencl::kernels;
 
@@ -55,14 +56,14 @@ using CLIndirectConv2dAddressPrecalculationFixture = IndirectConv2dAddressPrecal
 
 namespace
 {
-const auto src_w_values  = framework::dataset::make("src_w", {91});
-const auto src_h_values  = framework::dataset::make("src_h", {103});
-const auto src_b_values  = framework::dataset::make("src_b", {1, 2});
-const auto wei_w_values  = framework::dataset::make("wei_w", {3, 5});
-const auto wei_h_values  = framework::dataset::make("wei_h", {1, 6});
-const auto pad_values    = framework::dataset::make("pad", {1, 2, 3});
-const auto stride_values = framework::dataset::make("stride", {1, 2});
-const auto m0_values     = framework::dataset::make("M0", { 1, 2, 4, 5, 7 });
+const auto src_w_values  = make("src_w", {91});
+const auto src_h_values  = make("src_h", {103});
+const auto src_b_values  = make("src_b", {1, 2});
+const auto wei_w_values  = make("wei_w", {3, 5});
+const auto wei_h_values  = make("wei_h", {1, 6});
+const auto pad_values    = make("pad", {1, 2, 3});
+const auto stride_values = make("stride", {1, 2});
+const auto m0_values     = make("M0", { 1, 2, 4, 5, 7 });
 } // namespace
 
 TEST_SUITE(CL)

--- a/tests/validation/CL/IndirectConvolutionLayer.cpp
+++ b/tests/validation/CL/IndirectConvolutionLayer.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<half>  tolerance_fp16(half(0.2));  /**< Tolerance for floating point tests */
@@ -48,7 +49,7 @@ constexpr float          abs_tolerance_f32(0.0001f); /**< Absolute tolerance for
 constexpr float          tolerance_num = 0.07f;      /**< Tolerance number */
 
 /** Activation function Dataset*/
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 0.5f) });
 } // namespace
 
@@ -170,34 +171,34 @@ using CLIndirectConvolutionLayerMixedDataLayoutFixture = DirectConvolutionValida
 TEST_SUITE(NHWC)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLIndirectConvolutionLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1, 3, 1, 1 }),
-               framework::dataset::make("StrideY", { 1, 3, 2, 1 }),
-               framework::dataset::make("PadX", { 1, 3, 0, 4 }),
-               framework::dataset::make("PadY", { 1, 3, 0, 4 }),
-               framework::dataset::make("KernelSize", { 3, 8, 1, 9 }),
-               framework::dataset::make("NumKernels", { 17, 3, 1, 19 })),
-               framework::dataset::make("DataType",  DataType::F16),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1, 3, 1, 1 }),
+               make("StrideY", { 1, 3, 2, 1 }),
+               make("PadX", { 1, 3, 0, 4 }),
+               make("PadY", { 1, 3, 0, 4 }),
+               make("KernelSize", { 3, 8, 1, 9 }),
+               make("NumKernels", { 17, 3, 1, 19 })),
+               make("DataType",  DataType::F16),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp16, tolerance_num);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLIndirectConvolutionLayerFixture<half>, framework::DatasetMode::NIGHTLY,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(800U, 800U, 3U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 1 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 9 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::F16),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               combine(zip(make("InputShape", { TensorShape(800U, 800U, 3U) } ),
+               make("StrideX", { 1 }),
+               make("StrideY", { 1 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 9 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::F16),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp16, tolerance_num);
 }
@@ -206,50 +207,50 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLIndirectConvolutionLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1, 3, 1, 1 }),
-               framework::dataset::make("StrideY", { 1, 3, 2, 1 }),
-               framework::dataset::make("PadX", { 1, 3, 0, 4 }),
-               framework::dataset::make("PadY", { 1, 3, 0, 4 }),
-               framework::dataset::make("KernelSize", { 3, 8, 1, 9 }),
-               framework::dataset::make("NumKernels", { 17, 3, 1, 19 })),
-               framework::dataset::make("DataType",  DataType::F32),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1, 3, 1, 1 }),
+               make("StrideY", { 1, 3, 2, 1 }),
+               make("PadX", { 1, 3, 0, 4 }),
+               make("PadY", { 1, 3, 0, 4 }),
+               make("KernelSize", { 3, 8, 1, 9 }),
+               make("NumKernels", { 17, 3, 1, 19 })),
+               make("DataType",  DataType::F32),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLIndirectConvolutionLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 23U),
+               combine(zip(make("InputShape", { TensorShape(27U, 13U, 23U),
                                                         TensorShape(19U, 5U, 16U, 4U),
                                                         TensorShape(13U, 5U, 17U, 2U),
                                                         TensorShape(32U, 37U, 13U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 2 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 3 }),
-               framework::dataset::make("KernelSize", { 3 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::F32),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               make("StrideX", { 1 }),
+               make("StrideY", { 2 }),
+               make("PadX", { 1 }),
+               make("PadY", { 3 }),
+               make("KernelSize", { 3 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::F32),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLIndirectConvolutionLayerFixture<float>, framework::DatasetMode::NIGHTLY,
-               combine(zip(framework::dataset::make("InputShape", { TensorShape(800U, 800U, 3U) } ),
-               framework::dataset::make("StrideX", { 1 }),
-               framework::dataset::make("StrideY", { 1 }),
-               framework::dataset::make("PadX", { 1 }),
-               framework::dataset::make("PadY", { 1 }),
-               framework::dataset::make("KernelSize", { 9 }),
-               framework::dataset::make("NumKernels", { 3 })),
-               framework::dataset::make("DataType",  DataType::F32),
-               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
-               framework::dataset::make("DataLayout", DataLayout::NHWC)))
+               combine(zip(make("InputShape", { TensorShape(800U, 800U, 3U) } ),
+               make("StrideX", { 1 }),
+               make("StrideY", { 1 }),
+               make("PadX", { 1 }),
+               make("PadY", { 1 }),
+               make("KernelSize", { 9 }),
+               make("NumKernels", { 3 })),
+               make("DataType",  DataType::F32),
+               make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::IDENTITY) ),
+               make("DataLayout", DataLayout::NHWC)))
 {
     validate(CLAccessor(_target), _reference, tolerance_fp32, 0.0, abs_tolerance_f32);
 }

--- a/tests/validation/CL/InstanceNormalizationLayer.cpp
+++ b/tests/validation/CL/InstanceNormalizationLayer.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Tolerance for float operations */
@@ -52,7 +53,7 @@ TEST_SUITE(InstanceNormalizationLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",  { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",  { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32), // Mismatching data type input/output
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32), // Mismatching shape input/output
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 2, DataType::F32), // Number of Input channels != 1
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::S16), // DataType != F32
@@ -63,7 +64,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F16),
+    make("OutputInfo", { TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F16),
                                              TensorInfo(TensorShape(256U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::S16),
@@ -74,7 +75,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U, 32U, 4U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("Expected",   { false, false, false, false, true, true, true, true, true, true })),
+    make("Expected",   { false, false, false, false, true, true, true, true, true, true })),
     input_info, output_info, expected)
 {
     bool is_valid = bool(CLInstanceNormalizationLayer::validate(&input_info.clone()->set_is_resizable(false),
@@ -91,9 +92,9 @@ using CLInstanceNormalizationLayerFixture = InstanceNormalizationLayerValidation
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLInstanceNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::Small4DShapes(),
-                                               framework::dataset::make("DataType", DataType::F32),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                               framework::dataset::make("InPlace", { false, true })))
+                                               make("DataType", DataType::F32),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                               make("InPlace", { false, true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -103,9 +104,9 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLInstanceNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapes(),
-                                               framework::dataset::make("DataType", DataType::F16),
-                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                               framework::dataset::make("InPlace", { false, true })))
+                                               make("DataType", DataType::F16),
+                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                               make("InPlace", { false, true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);

--- a/tests/validation/CL/L2NormalizeLayer.cpp
+++ b/tests/validation/CL/L2NormalizeLayer.cpp
@@ -40,14 +40,15 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Tolerance for float operations */
 constexpr AbsoluteTolerance<float> tolerance_f32(0.00001f);
 constexpr AbsoluteTolerance<float> tolerance_f16(0.2f);
 
-auto data = concat(combine(framework::dataset::make("DataLayout", { DataLayout::NCHW }), framework::dataset::make("Axis", { -1, 0, 2 })), combine(framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                   framework::dataset::make("Axis", { -2, 2 })));
+auto data = concat(combine(make("DataLayout", { DataLayout::NCHW }), make("Axis", { -1, 0, 2 })), combine(make("DataLayout", { DataLayout::NHWC }),
+                   make("Axis", { -2, 2 })));
 
 } // namespace
 
@@ -56,7 +57,7 @@ TEST_SUITE(L2NormalizeLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",  { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",  { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching shape input/output
                                              TensorInfo(TensorShape(128U, 64U), 2, DataType::F32), // Number of Input channels != 1
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::S16), // DataType != F32
@@ -65,7 +66,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(128U, 64U), 1, DataType::F16),
+    make("OutputInfo", { TensorInfo(TensorShape(128U, 64U), 1, DataType::F16),
                                              TensorInfo(TensorShape(256U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::S16),
@@ -74,7 +75,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32),
                                              TensorInfo(TensorShape(128U, 64U), 1, DataType::F32)
                                            }),
-    framework::dataset::make("Axis",       {
+    make("Axis",       {
                                             0,
                                             0,
                                             0,
@@ -83,7 +84,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                             3,
                                             -2,
                                             0 }),
-    framework::dataset::make("Expected",   { false, false, false, false, true, true, true, true })),
+    make("Expected",   { false, false, false, false, true, true, true, true })),
     input_info, output_info, axis, expected)
 {
     bool is_valid = bool(CLL2NormalizeLayer::validate(&input_info.clone()->set_is_resizable(false),
@@ -100,13 +101,13 @@ using CLL2NormalizeLayerFixture = L2NormalizeLayerValidationFixture<CLTensor, CL
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLL2NormalizeLayerFixture<float>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32), data, framework::dataset::make("Epsilon", { 1e-12 })))
+                       combine(datasets::SmallShapes(), make("DataType", DataType::F32), data, make("Epsilon", { 1e-12 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLL2NormalizeLayerFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F32), data, framework::dataset::make("Epsilon", { 1e-12 })))
+                       combine(datasets::LargeShapes(), make("DataType", DataType::F32), data, make("Epsilon", { 1e-12 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -114,13 +115,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLL2NormalizeLayerFixture<float>, framework::Da
 TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLL2NormalizeLayerFixture<half>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16), data, framework::dataset::make("Epsilon", { 1e-6 })))
+                       combine(datasets::SmallShapes(), make("DataType", DataType::F16), data, make("Epsilon", { 1e-6 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLL2NormalizeLayerFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F16), data, framework::dataset::make("Epsilon", { 1e-6 })))
+                       combine(datasets::LargeShapes(), make("DataType", DataType::F16), data, make("Epsilon", { 1e-6 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);

--- a/tests/validation/CL/LSTMLayer.cpp
+++ b/tests/validation/CL/LSTMLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, 2024 Arm Limited.
+ * Copyright (c) 2018-2020, 2024-2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -37,13 +37,13 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_f32(0.001f);
 RelativeTolerance<half>  tolerance_f16(half(0.1));
 } // namespace
 
-using framework::dataset::make;
 
 TEST_SUITE(CL)
 TEST_SUITE(LSTMLayer)

--- a/tests/validation/CL/LogLayer.cpp
+++ b/tests/validation/CL/LogLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Arm Limited.
+ * Copyright (c) 2019, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -52,13 +53,13 @@ using CLLogLayerFixture = LogValidationFixture<CLTensor, CLAccessor, CLLogLayer,
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLLogLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLLogLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp16);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLLogLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLLogLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     // Validate output
@@ -67,13 +68,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLLogLayerFixture<half>, framework::DatasetMode
 
 TEST_SUITE_END() // FP16
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLLogLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLLogLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLLogLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLLogLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output

--- a/tests/validation/CL/LogSoftmaxLayer.cpp
+++ b/tests/validation/CL/LogSoftmaxLayer.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Tolerance for float operations */
@@ -52,7 +53,6 @@ constexpr AbsoluteTolerance<int8_t> tolerance_qasymm8_signed(1);
 
 } // namespace
 
-using framework::dataset::make;
 
 TEST_SUITE(CL)
 TEST_SUITE(LogSoftmaxLayer)
@@ -66,25 +66,25 @@ using CLLogSoftmaxLayerQuantizedFixture = SoftmaxValidationQuantizedFixture<CLTe
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLLogSoftmaxLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                      framework::dataset::make("DataType", DataType::F16),
-                                                                                                              framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                      framework::dataset::make("Axis", { 0, -1 })))
+                                                                                                                      make("DataType", DataType::F16),
+                                                                                                              make("Beta", { 1.0f, 2.0f }),
+                                                                                                      make("Axis", { 0, -1 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLLogSoftmaxLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                  framework::dataset::make("DataType", DataType::F16),
-                                                                                                                  framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                          framework::dataset::make("Axis", { 0 })))
+                                                                                                                  make("DataType", DataType::F16),
+                                                                                                                  make("Beta", { 1.0f, 2.0f }),
+                                                                                                          make("Axis", { 0 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(Run4D, CLLogSoftmaxLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayer4DShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::F16),
-                                                                                                               framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                       framework::dataset::make("Axis", { 0, -3, 2 })))
+                                                                                                                       make("DataType", DataType::F16),
+                                                                                                               make("Beta", { 1.0f, 2.0f }),
+                                                                                                       make("Axis", { 0, -3, 2 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -93,25 +93,25 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLLogSoftmaxLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::F32),
-                                                                                                               framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                       framework::dataset::make("Axis", { 0, 1 })))
+                                                                                                                       make("DataType", DataType::F32),
+                                                                                                               make("Beta", { 1.0f, 2.0f }),
+                                                                                                       make("Axis", { 0, 1 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLLogSoftmaxLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                           framework::dataset::make("Axis", { 0 })))
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                                   make("Beta", { 1.0f, 2.0f }),
+                                                                                                           make("Axis", { 0 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(Run4D, CLLogSoftmaxLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayer4DShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::F32),
-                                                                                                            framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                    framework::dataset::make("Axis", { 0, -4, 3 })))
+                                                                                                                    make("DataType", DataType::F32),
+                                                                                                            make("Beta", { 1.0f, 2.0f }),
+                                                                                                    make("Axis", { 0, -4, 3 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);

--- a/tests/validation/CL/Logical.cpp
+++ b/tests/validation/CL/Logical.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Arm Limited.
+ * Copyright (c) 2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -52,6 +52,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(LogicalOr)
 TEST_SUITE(Validate)
@@ -163,7 +164,7 @@ TEST_SUITE_END() // Validate
 template <typename T>
 using CLLogicalNotFixture = LogicalNotValidationFixture<CLTensor, CLAccessor, CLLogicalNot, T>;
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLLogicalNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLLogicalNotFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::U8)))
 {
     // Validate output

--- a/tests/validation/CL/MatMul.cpp
+++ b/tests/validation/CL/MatMul.cpp
@@ -43,6 +43,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for fp32 data type */
@@ -70,7 +71,7 @@ template <typename T>
 using CLQuantizedMatMulActivationFixture = QuantizedMatMulValidationWithActivationFixture<CLTensor, CLAccessor, CLMatMul, GpuMatMulSettings, T>;
 
 /* The main act functions matmul (float) is expected to support */
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -79,17 +80,17 @@ const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo
 });
 
 /* (Float datatype only) Larger activation functions dataset, used during some nightly tests. */
-const auto AllActivationsDataset = combine(datasets::ActivationFunctions(), framework::dataset::make("AlphaBeta", { 0.5f, 1.f }));
+const auto AllActivationsDataset = combine(datasets::ActivationFunctions(), make("AlphaBeta", { 0.5f, 1.f }));
 
 // Alpha beta values should be integer values
 // This is for testing purposes with quantized datatypes and is not a limitation of the kernel.
 // To properly remove this restriction, dst_qinfo should be auto-initialised with consideration for alpha beta values
 // The main act functions quantized matmul kernels are expected to support
-const auto ActivationFunctionsQuantizedDataset = concat(concat(concat(
-                                                                   framework::dataset::make("ActivationInfo", ActivationLayerInfo()),
-                                                                   framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU))),
-                                                               framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 1.f))),
-                                                        framework::dataset::make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 2.f, 1.f)));
+const auto ActivationFunctionsQuantizedDataset = concat(
+                                                        make("ActivationInfo", ActivationLayerInfo()),
+                                                        make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU)),
+                                                        make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 1.f)),
+                                                        make("ActivationInfo", ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, 2.f, 1.f)));
 
 TEST_SUITE(CL)
 TEST_SUITE(MatMul)
@@ -98,9 +99,9 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulActivationFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                        framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                        framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                framework::dataset::make("DataType", DataType::F32),
+                                                                                                                        make("TransposeA", { false, true }),
+                                                                                                                        make("TransposeB", { false, true }),
+                                                                                                                make("DataType", DataType::F32),
                                                                                                         ActivationFunctionsDataset))
 {
     // Validate output
@@ -108,9 +109,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulActivationFixture<float>, framework::Da
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLMatMulActivationFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                    framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                    framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                    framework::dataset::make("DataType", DataType::F32),
+                                                                                                                    make("TransposeA", { false, true }),
+                                                                                                                    make("TransposeB", { false, true }),
+                                                                                                                    make("DataType", DataType::F32),
                                                                                                             ActivationFunctionsDataset))
 {
     // Validate output
@@ -118,9 +119,9 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLMatMulActivationFixture<float>, framework::Da
 }
 
 FIXTURE_DATA_TEST_CASE(RunAllActivations, CLMatMulActivationAlphaBetaFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::SmallerMatMulDataset(),
-                       framework::dataset::make("TransposeA", { false }),
-                       framework::dataset::make("TransposeB", { true }),
-                       framework::dataset::make("DataType", DataType::F32),
+                       make("TransposeA", { false }),
+                       make("TransposeB", { true }),
+                       make("DataType", DataType::F32),
                        AllActivationsDataset))
 {
     // Validate output
@@ -132,9 +133,9 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulActivationFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                       framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                       framework::dataset::make("TransposeB", { false, true }),
-                                                                                                               framework::dataset::make("DataType", DataType::F16),
+                                                                                                                       make("TransposeA", { false, true }),
+                                                                                                                       make("TransposeB", { false, true }),
+                                                                                                               make("DataType", DataType::F16),
                                                                                                        ActivationFunctionsDataset))
 {
     // Validate output
@@ -142,9 +143,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulActivationFixture<half>, framework::Dat
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLMatMulActivationFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                   framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                   framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                   framework::dataset::make("DataType", DataType::F16),
+                                                                                                                   make("TransposeA", { false, true }),
+                                                                                                                   make("TransposeB", { false, true }),
+                                                                                                                   make("DataType", DataType::F16),
                                                                                                            ActivationFunctionsDataset))
 {
     // Validate output
@@ -158,28 +159,28 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLQuantizedMatMulFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                     framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                 framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                 framework::dataset::make("DataType", DataType::QASYMM8),
+                                                                                                                     make("TransposeA", { false, true }),
+                                                                                                                 make("TransposeB", { false, true }),
+                                                                                                                 make("DataType", DataType::QASYMM8),
                                                                                                                  ActivationFunctionsQuantizedDataset,
-                                                                                                                 framework::dataset::make("NumberOfExtraRuns", { 0, 1 }),
-                                                                                                                 framework::dataset::make("LhsQInfo", { QuantizationInfo(1.f / 50, 1) }),
-                                                                                                                 framework::dataset::make("RhsQInfo", { QuantizationInfo(1.f / 30, -1) }),
-                                                                                                         framework::dataset::make("DstQInfo", { QuantizationInfo(1.f, 2) })))
+                                                                                                                 make("NumberOfExtraRuns", { 0, 1 }),
+                                                                                                                 make("LhsQInfo", { QuantizationInfo(1.f / 50, 1) }),
+                                                                                                                 make("RhsQInfo", { QuantizationInfo(1.f / 30, -1) }),
+                                                                                                         make("DstQInfo", { QuantizationInfo(1.f, 2) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLQuantizedMatMulFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-        framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                     framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                     framework::dataset::make("DataType", DataType::QASYMM8),
+        make("TransposeA", { false, true }),
+                                                                                                                     make("TransposeB", { false, true }),
+                                                                                                                     make("DataType", DataType::QASYMM8),
                                                                                                                      ActivationFunctionsQuantizedDataset,
-                                                                                                                     framework::dataset::make("NumberOfExtraRuns", { 0, 1 }),
-                                                                                                                     framework::dataset::make("LhsQInfo", { QuantizationInfo(1.f / 100, 1) }),
-                                                                                                                     framework::dataset::make("RhsQInfo", { QuantizationInfo(1.f / 200, -1) }),
-                                                                                                             framework::dataset::make("DstQInfo", { QuantizationInfo(1.f, 2) })))
+                                                                                                                     make("NumberOfExtraRuns", { 0, 1 }),
+                                                                                                                     make("LhsQInfo", { QuantizationInfo(1.f / 100, 1) }),
+                                                                                                                     make("RhsQInfo", { QuantizationInfo(1.f / 200, -1) }),
+                                                                                                             make("DstQInfo", { QuantizationInfo(1.f, 2) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
@@ -190,28 +191,28 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLQuantizedMatMulFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-        framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                        framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                        framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+        make("TransposeA", { false, true }),
+                                                                                                                        make("TransposeB", { false, true }),
+                                                                                                                        make("DataType", DataType::QASYMM8_SIGNED),
                                                                                                                         ActivationFunctionsQuantizedDataset,
-                                                                                                                        framework::dataset::make("NumberOfExtraRuns", { 0, 1 }),
-                                                                                                                        framework::dataset::make("LhsQInfo", { QuantizationInfo(1.f / 50, 1) }),
-                                                                                                                framework::dataset::make("RhsQInfo", { QuantizationInfo(1.f / 30, -1) }),
-                                                                                                        framework::dataset::make("DstQInfo", { QuantizationInfo(1.f, 2) })))
+                                                                                                                        make("NumberOfExtraRuns", { 0, 1 }),
+                                                                                                                        make("LhsQInfo", { QuantizationInfo(1.f / 50, 1) }),
+                                                                                                                make("RhsQInfo", { QuantizationInfo(1.f / 30, -1) }),
+                                                                                                        make("DstQInfo", { QuantizationInfo(1.f, 2) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLQuantizedMatMulFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                        framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                    framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                    framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                        make("TransposeA", { false, true }),
+                                                                                                                    make("TransposeB", { false, true }),
+                                                                                                                    make("DataType", DataType::QASYMM8_SIGNED),
                                                                                                                     ActivationFunctionsQuantizedDataset,
-                                                                                                                    framework::dataset::make("NumberOfExtraRuns", { 0, 1 }),
-                                                                                                                    framework::dataset::make("LhsQInfo", { QuantizationInfo(1.f / 100, 1) }),
-                                                                                                                    framework::dataset::make("RhsQInfo", { QuantizationInfo(1.f / 200, -1) }),
-                                                                                                            framework::dataset::make("DstQInfo", { QuantizationInfo(1.f, 50) })))
+                                                                                                                    make("NumberOfExtraRuns", { 0, 1 }),
+                                                                                                                    make("LhsQInfo", { QuantizationInfo(1.f / 100, 1) }),
+                                                                                                                    make("RhsQInfo", { QuantizationInfo(1.f / 200, -1) }),
+                                                                                                            make("DstQInfo", { QuantizationInfo(1.f, 50) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);

--- a/tests/validation/CL/MatMulKernel.cpp
+++ b/tests/validation/CL/MatMulKernel.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for floating point data types */
@@ -51,26 +52,26 @@ RelativeTolerance<half_float::half> tolerance_f16(half(0.01)); /**< Tolerance va
 } // namespace
 
 /** M0 values to test --precommit*/
-const auto m0_values_precommit = framework::dataset::make("M0", { 1, 3 });
+const auto m0_values_precommit = make("M0", { 1, 3 });
 
 /** N0 values to test --precommit*/
-const auto n0_values_precommit = framework::dataset::make("N0", { 2, 4 });
+const auto n0_values_precommit = make("N0", { 2, 4 });
 
 /** K0 values to test --precommit*/
-const auto k0_values_precommit = framework::dataset::make("K0", { 2, 3 });
+const auto k0_values_precommit = make("K0", { 2, 3 });
 
 /** M0 values to test --nightly*/
-const auto m0_values_nightly_lhs_nt = framework::dataset::make("M0", { 1, 2, 3, 4, 5, 6, 7, 8 });
-const auto m0_values_nightly_lhs_t  = framework::dataset::make("M0", { 1, 2, 3, 4, 8 });
+const auto m0_values_nightly_lhs_nt = make("M0", { 1, 2, 3, 4, 5, 6, 7, 8 });
+const auto m0_values_nightly_lhs_t  = make("M0", { 1, 2, 3, 4, 8 });
 
 /** N0 values to test --nightly*/
-const auto n0_values_nightly_rhs_nt = framework::dataset::make("N0", { 1, 2, 3, 4, 8, 16 });
-const auto n0_values_nightly_rhs_t  = framework::dataset::make("N0", { 1, 2, 3, 4, 8 });
+const auto n0_values_nightly_rhs_nt = make("N0", { 1, 2, 3, 4, 8, 16 });
+const auto n0_values_nightly_rhs_t  = make("N0", { 1, 2, 3, 4, 8 });
 
 /** K0 values to test --nightly*/
-const auto k0_values_nightly_lhs_nt_rhs_nt = framework::dataset::make("K0", { 1, 2, 3, 4, 8, 16 });
-const auto k0_values_nightly_rhs_t         = framework::dataset::make("K0", { 1, 2, 3, 4, 8 });
-const auto k0_values_nightly_lhs_t_rhs_nt  = framework::dataset::make("K0", { 1, 2, 3, 4, 5, 6, 7, 8 });
+const auto k0_values_nightly_lhs_nt_rhs_nt = make("K0", { 1, 2, 3, 4, 8, 16 });
+const auto k0_values_nightly_rhs_t         = make("K0", { 1, 2, 3, 4, 8 });
+const auto k0_values_nightly_lhs_t_rhs_nt  = make("K0", { 1, 2, 3, 4, 5, 6, 7, 8 });
 
 template <typename T>
 using CLMatMulKernelFixture = MatMulKernelValidationFixture<T, ClMatMulNativeKernel>;
@@ -341,87 +342,87 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 TEST_SUITE(Buffer)
 FIXTURE_DATA_TEST_CASE(RunTiny, CLMatMulKernelFixture<float>, framework::DatasetMode::ALL, combine(datasets::TinyMatMulDataset(),
-                                                                                                                   framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                   framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                   make("TransposeA", { false, true }),
+                                                                                                                   make("TransposeB", { false, true }),
                                                                                                                    m0_values_precommit,
                                                                                                                    n0_values_precommit,
                                                                                                                    k0_values_precommit,
-                                                                                                           framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                   framework::dataset::make("DataType", DataType::F32)))
+                                                                                                           make("ExportRhsToCLImage", { false }),
+                                                                                                   make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulKernelFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                    framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                    framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                    make("TransposeA", { false, true }),
+                                                                                                                    make("TransposeB", { false, true }),
                                                                                                                     m0_values_precommit,
                                                                                                                     n0_values_precommit,
                                                                                                                     k0_values_precommit,
-                                                                                                            framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                    framework::dataset::make("DataType", DataType::F32)))
+                                                                                                            make("ExportRhsToCLImage", { false }),
+                                                                                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunWithBias, CLMatMulKernelBiasFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                   framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                   framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                   make("TransposeA", { false, true }),
+                                                                                                                   make("TransposeB", { false, true }),
                                                                                                                    m0_values_precommit,
                                                                                                                    n0_values_precommit,
                                                                                                                    k0_values_precommit,
-                                                                                                                   framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                           framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                   make("ExportRhsToCLImage", { false }),
+                                                                                                           make("DataType", DataType::F32)))
 
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulKernelFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                   framework::dataset::make("TransposeA", { false }),
-                                                                                                                   framework::dataset::make("TransposeB", { false }),
+                                                                                                                   make("TransposeA", { false }),
+                                                                                                                   make("TransposeB", { false }),
                                                                                                                    m0_values_nightly_lhs_nt,
                                                                                                                    n0_values_nightly_rhs_nt,
                                                                                                                    k0_values_nightly_lhs_nt_rhs_nt,
-                                                                                                                   framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                   framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                   make("ExportRhsToCLImage", { false }),
+                                                                                                                   make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTransposed, CLMatMulKernelFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                     framework::dataset::make("TransposeA", { false }),
-                                                                                                                     framework::dataset::make("TransposeB", { true }),
+                                                                                                                     make("TransposeA", { false }),
+                                                                                                                     make("TransposeB", { true }),
                                                                                                                      m0_values_nightly_lhs_nt,
                                                                                                                      n0_values_nightly_rhs_t,
                                                                                                                      k0_values_nightly_rhs_t,
-                                                                                                                     framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                     framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                     make("ExportRhsToCLImage", { false }),
+                                                                                                                     make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulKernelFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                     framework::dataset::make("TransposeA", { true }),
-                                                                                                                     framework::dataset::make("TransposeB", { false }),
+                                                                                                                     make("TransposeA", { true }),
+                                                                                                                     make("TransposeB", { false }),
                                                                                                                      m0_values_nightly_lhs_t,
                                                                                                                      n0_values_nightly_rhs_nt,
                                                                                                                      k0_values_nightly_lhs_t_rhs_nt,
-                                                                                                                     framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                     framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                     make("ExportRhsToCLImage", { false }),
+                                                                                                                     make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulKernelFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_t,
                                                k0_values_nightly_rhs_t,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
@@ -429,13 +430,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulKernelFixture
 // Running High Dimensional test is enough for FP32, because we're stressing the number of dimensions, not data type or M0/N0/K0
 // It's a good idea to test for each Lhs/Rhs T/NT combinations because they're different CL kernels
 FIXTURE_DATA_TEST_CASE(RunHighDimensional, CLMatMulKernelFixture<float>, framework::DatasetMode::ALL, combine(datasets::HighDimensionalMatMulDataset(),
-                                                                                                                      framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                      framework::dataset::make("TransposeB", { false, true }),
-                                                                                                                      framework::dataset::make("M0", { 2 }),
-                                                                                                                      framework::dataset::make("N0", { 2 }),
-                                                                                                                      framework::dataset::make("K0", { 2 }),
-                                                                                                                      framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                              framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                      make("TransposeA", { false, true }),
+                                                                                                                      make("TransposeB", { false, true }),
+                                                                                                                      make("M0", { 2 }),
+                                                                                                                      make("N0", { 2 }),
+                                                                                                                      make("K0", { 2 }),
+                                                                                                                      make("ExportRhsToCLImage", { false }),
+                                                                                                              make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0.f, abs_tolerance_f32);
@@ -445,13 +446,13 @@ TEST_SUITE_END() // Buffer
 TEST_SUITE(ExportRhsToCLImage)
 FIXTURE_DATA_TEST_CASE(RunSmallRhsNotTransposed, CLMatMulKernelFixture<float>, framework::DatasetMode::ALL,
                        combine(datasets::SmallMatMulDatasetRhsExportToCLImageRhsNT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
-                                                               framework::dataset::make("M0", { 2 }),
-                                                       framework::dataset::make("N0", { 4, 8, 16 }),
-                                               framework::dataset::make("K0", { 2, 4 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { false }),
+                                                               make("M0", { 2 }),
+                                                       make("N0", { 4, 8, 16 }),
+                                               make("K0", { 2, 4 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)
@@ -461,13 +462,13 @@ FIXTURE_DATA_TEST_CASE(RunSmallRhsNotTransposed, CLMatMulKernelFixture<float>, f
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsNotTransposed, CLMatMulKernelFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDatasetRhsExportToCLImageRhsNT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
-                                                               framework::dataset::make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
-                                                       framework::dataset::make("N0", { 4, 8, 16 }),
-                                               framework::dataset::make("K0", { 1, 2, 3, 4 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { false }),
+                                                               make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
+                                                       make("N0", { 4, 8, 16 }),
+                                               make("K0", { 1, 2, 3, 4 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)
@@ -477,13 +478,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeRhsNotTransposed, CLMatMulKernelFixture<float>, f
 }
 FIXTURE_DATA_TEST_CASE(RunSmallRhsTransposed, CLMatMulKernelFixture<float>, framework::DatasetMode::ALL,
                        combine(datasets::SmallMatMulDatasetRhsExportToCLImageRhsT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
-                                                               framework::dataset::make("M0", { 2 }),
-                                                       framework::dataset::make("N0", { 2, 4 }),
-                                               framework::dataset::make("K0", { 4, 8, 16 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { true }),
+                                                               make("M0", { 2 }),
+                                                       make("N0", { 2, 4 }),
+                                               make("K0", { 4, 8, 16 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)
@@ -493,13 +494,13 @@ FIXTURE_DATA_TEST_CASE(RunSmallRhsTransposed, CLMatMulKernelFixture<float>, fram
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTransposed, CLMatMulKernelFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDatasetRhsExportToCLImageRhsT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
-                                                               framework::dataset::make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
-                                                       framework::dataset::make("N0", { 1, 2, 3, 4 }),
-                                               framework::dataset::make("K0", { 4, 8, 16 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { true }),
+                                                               make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
+                                                       make("N0", { 1, 2, 3, 4 }),
+                                               make("K0", { 4, 8, 16 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)
@@ -513,62 +514,62 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 TEST_SUITE(Buffer)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulKernelFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                   framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                   framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                   make("TransposeA", { false, true }),
+                                                                                                                   make("TransposeB", { false, true }),
                                                                                                                    m0_values_precommit,
                                                                                                                    n0_values_precommit,
                                                                                                                    k0_values_precommit,
-                                                                                                           framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                   framework::dataset::make("DataType", DataType::F16)))
+                                                                                                           make("ExportRhsToCLImage", { false }),
+                                                                                                   make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, 0.f, abs_tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulKernelFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                  framework::dataset::make("TransposeA", { false }),
-                                                                                                                  framework::dataset::make("TransposeB", { false }),
+                                                                                                                  make("TransposeA", { false }),
+                                                                                                                  make("TransposeB", { false }),
                                                                                                                   m0_values_nightly_lhs_nt,
                                                                                                                   n0_values_nightly_rhs_nt,
                                                                                                                   k0_values_nightly_lhs_nt_rhs_nt,
-                                                                                                                  framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                  framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                  make("ExportRhsToCLImage", { false }),
+                                                                                                                  make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, 0.f, abs_tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTransposed, CLMatMulKernelFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                    framework::dataset::make("TransposeA", { false }),
-                                                                                                                    framework::dataset::make("TransposeB", { true }),
+                                                                                                                    make("TransposeA", { false }),
+                                                                                                                    make("TransposeB", { true }),
                                                                                                                     m0_values_nightly_lhs_nt,
                                                                                                                     n0_values_nightly_rhs_t,
                                                                                                                     k0_values_nightly_rhs_t,
-                                                                                                                    framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                    framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                    make("ExportRhsToCLImage", { false }),
+                                                                                                                    make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, 0.f, abs_tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulKernelFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeMatMulDataset(),
-                                                                                                                    framework::dataset::make("TransposeA", { true }),
-                                                                                                                    framework::dataset::make("TransposeB", { false }),
+                                                                                                                    make("TransposeA", { true }),
+                                                                                                                    make("TransposeB", { false }),
                                                                                                                     m0_values_nightly_lhs_t,
                                                                                                                     n0_values_nightly_rhs_nt,
                                                                                                                     k0_values_nightly_lhs_t_rhs_nt,
-                                                                                                                    framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                    framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                    make("ExportRhsToCLImage", { false }),
+                                                                                                                    make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, 0.f, abs_tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulKernelFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_t,
                                                k0_values_nightly_rhs_t,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, 0.f, abs_tolerance_f16);
@@ -578,13 +579,13 @@ TEST_SUITE_END() // Buffer
 TEST_SUITE(ExportRhsToCLImage)
 FIXTURE_DATA_TEST_CASE(RunSmallRhsNotTransposed, CLMatMulKernelFixture<half>, framework::DatasetMode::ALL,
                        combine(datasets::SmallMatMulDatasetRhsExportToCLImageRhsNT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
-                                                               framework::dataset::make("M0", { 2 }),
-                                                       framework::dataset::make("N0", { 4, 8, 16 }),
-                                               framework::dataset::make("K0", { 2, 4 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { false }),
+                                                               make("M0", { 2 }),
+                                                       make("N0", { 4, 8, 16 }),
+                                               make("K0", { 2, 4 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)
@@ -594,13 +595,13 @@ FIXTURE_DATA_TEST_CASE(RunSmallRhsNotTransposed, CLMatMulKernelFixture<half>, fr
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsNotTransposed, CLMatMulKernelFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDatasetRhsExportToCLImageRhsNT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
-                                                               framework::dataset::make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
-                                                       framework::dataset::make("N0", { 4, 8, 16 }),
-                                               framework::dataset::make("K0", { 1, 2, 3, 4 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { false }),
+                                                               make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
+                                                       make("N0", { 4, 8, 16 }),
+                                               make("K0", { 1, 2, 3, 4 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)
@@ -610,13 +611,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeRhsNotTransposed, CLMatMulKernelFixture<half>, fr
 }
 FIXTURE_DATA_TEST_CASE(RunSmallRhsTransposed, CLMatMulKernelFixture<half>, framework::DatasetMode::ALL,
                        combine(datasets::SmallMatMulDatasetRhsExportToCLImageRhsT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
-                                                               framework::dataset::make("M0", { 2 }),
-                                                       framework::dataset::make("N0", { 2, 4 }),
-                                               framework::dataset::make("K0", { 4, 8, 16 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { true }),
+                                                               make("M0", { 2 }),
+                                                       make("N0", { 2, 4 }),
+                                               make("K0", { 4, 8, 16 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)
@@ -626,13 +627,13 @@ FIXTURE_DATA_TEST_CASE(RunSmallRhsTransposed, CLMatMulKernelFixture<half>, frame
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTransposed, CLMatMulKernelFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDatasetRhsExportToCLImageRhsT(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
-                                                               framework::dataset::make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
-                                                       framework::dataset::make("N0", { 1, 2, 3, 4 }),
-                                               framework::dataset::make("K0", { 4, 8, 16 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { true }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { true }),
+                                                               make("M0", { 2 }), // Choices of M0 does not matter much because it's related to Lhs tensor
+                                                       make("N0", { 1, 2, 3, 4 }),
+                                               make("K0", { 4, 8, 16 }),
+                                       make("ExportRhsToCLImage", { true }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     if(_device_supports_export_to_cl_image)

--- a/tests/validation/CL/MatMulLowpNativeKernel.cpp
+++ b/tests/validation/CL/MatMulLowpNativeKernel.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_quant(1); /**< Tolerance value for comparing reference's output against implementation's output for quantized data types */
@@ -53,26 +54,26 @@ template <typename T>
 using CLMatMulLowpKernelWithBiasFixture = MatMulKernelWithBiasValidation<T, ClMatMulLowpNativeKernel>;
 
 /** M0 values to test --precommit*/
-const auto m0_values_precommit = framework::dataset::make("M0", { 1, 3 });
+const auto m0_values_precommit = make("M0", { 1, 3 });
 
 /** N0 values to test --precommit*/
-const auto n0_values_precommit = framework::dataset::make("N0", { 2, 4 });
+const auto n0_values_precommit = make("N0", { 2, 4 });
 
 /** K0 values to test --precommit*/
-const auto k0_values_precommit = framework::dataset::make("K0", { 2, 3 });
+const auto k0_values_precommit = make("K0", { 2, 3 });
 
 /** M0 values to test --nightly*/
-const auto m0_values_nightly_lhs_nt = framework::dataset::make("M0", { 1, 2, 3, 4, 5, 6, 7, 8 });
-const auto m0_values_nightly_lhs_t  = framework::dataset::make("M0", { 1, 2, 3, 4, 8 });
+const auto m0_values_nightly_lhs_nt = make("M0", { 1, 2, 3, 4, 5, 6, 7, 8 });
+const auto m0_values_nightly_lhs_t  = make("M0", { 1, 2, 3, 4, 8 });
 
 /** N0 values to test --nightly*/
-const auto n0_values_nightly_rhs_nt = framework::dataset::make("N0", { 1, 2, 3, 4, 8, 16 });
-const auto n0_values_nightly_rhs_t  = framework::dataset::make("N0", { 1, 2, 3, 4, 8 });
+const auto n0_values_nightly_rhs_nt = make("N0", { 1, 2, 3, 4, 8, 16 });
+const auto n0_values_nightly_rhs_t  = make("N0", { 1, 2, 3, 4, 8 });
 
 /** K0 values to test --nightly*/
-const auto k0_values_nightly_lhs_nt_rhs_nt = framework::dataset::make("K0", { 1, 2, 3, 4, 8, 16 });
-const auto k0_values_nightly_rhs_t         = framework::dataset::make("K0", { 1, 2, 3, 4, 8 });
-const auto k0_values_nightly_lhs_t_rhs_nt  = framework::dataset::make("K0", { 1, 2, 3, 4, 5, 6, 7, 8 });
+const auto k0_values_nightly_lhs_nt_rhs_nt = make("K0", { 1, 2, 3, 4, 8, 16 });
+const auto k0_values_nightly_rhs_t         = make("K0", { 1, 2, 3, 4, 8 });
+const auto k0_values_nightly_lhs_t_rhs_nt  = make("K0", { 1, 2, 3, 4, 5, 6, 7, 8 });
 
 TEST_SUITE(CL)
 TEST_SUITE(MatMulLowpNativeKernel)
@@ -221,89 +222,89 @@ TEST_SUITE_END() // Validate
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunTiny, CLMatMulLowpNativeKernelFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::TinyMatMulDataset(),
-                                                                                                                      framework::dataset::make("TransposeA", { true, false }),
-                                                                                                                      framework::dataset::make("TransposeB", { true, false }),
+                                                                                                                      make("TransposeA", { true, false }),
+                                                                                                                      make("TransposeB", { true, false }),
                                                                                                                       m0_values_precommit,
                                                                                                                       n0_values_precommit,
                                                                                                                       k0_values_precommit,
-                                                                                                                      framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                              framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                                                                                                      make("ExportRhsToCLImage", { false }),
+                                                                                                              make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulLowpNativeKernelFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                       framework::dataset::make("TransposeA", { true, false }),
-                                                                                                                       framework::dataset::make("TransposeB", { true, false }),
+                                                                                                                       make("TransposeA", { true, false }),
+                                                                                                                       make("TransposeB", { true, false }),
                                                                                                                        m0_values_precommit,
                                                                                                                        n0_values_precommit,
                                                                                                                        k0_values_precommit,
-                                                                                                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                                                                                                       make("ExportRhsToCLImage", { false }),
+                                                                                                               make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunWithBias, CLMatMulLowpKernelWithBiasFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                    framework::dataset::make("TransposeA", { true, false }),
-                                                                                                                    framework::dataset::make("TransposeB", { true, false }),
+                                                                                                                    make("TransposeA", { true, false }),
+                                                                                                                    make("TransposeB", { true, false }),
                                                                                                                     m0_values_precommit,
                                                                                                                     n0_values_precommit,
                                                                                                                     k0_values_precommit,
-                                                                                                                    framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                    framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                                                                                                    make("ExportRhsToCLImage", { false }),
+                                                                                                                    make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulLowpNativeKernelFixture<int8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_nt,
                                                k0_values_nightly_lhs_nt_rhs_nt,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTransposed, CLMatMulLowpNativeKernelFixture<int8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_t,
                                                k0_values_nightly_rhs_t,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulLowpNativeKernelFixture<int8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_nt,
                                                k0_values_nightly_lhs_t_rhs_nt,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulLowpNativeKernelFixture<int8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_t,
                                                k0_values_nightly_rhs_t,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
@@ -312,13 +313,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulLowpNativeKer
 // It's a good idea to test for each Lhs/Rhs T/NT combinations because they're different CL kernels
 FIXTURE_DATA_TEST_CASE(RunHighDimensional, CLMatMulLowpNativeKernelFixture<int8_t>, framework::DatasetMode::ALL,
                        combine(datasets::HighDimensionalMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { true, false }),
-                                                                       framework::dataset::make("TransposeB", { true, false }),
-                                                               framework::dataset::make("M0", { 2 }),
-                                                       framework::dataset::make("N0", { 2 }),
-                                               framework::dataset::make("K0", { 2 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)))
+                                                                               make("TransposeA", { true, false }),
+                                                                       make("TransposeB", { true, false }),
+                                                               make("M0", { 2 }),
+                                                       make("N0", { 2 }),
+                                               make("K0", { 2 }),
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8_SIGNED)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
@@ -327,77 +328,77 @@ TEST_SUITE_END() // QASYMM8_SIGNED
 
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunTiny, CLMatMulLowpNativeKernelFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::TinyMatMulDataset(),
-                                                                                                                       framework::dataset::make("TransposeA", { true, false }),
-                                                                                                                       framework::dataset::make("TransposeB", { true, false }),
+                                                                                                                       make("TransposeA", { true, false }),
+                                                                                                                       make("TransposeB", { true, false }),
                                                                                                                        m0_values_precommit,
                                                                                                                        n0_values_precommit,
                                                                                                                        k0_values_precommit,
-                                                                                                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                               framework::dataset::make("DataType", DataType::QASYMM8)))
+                                                                                                                       make("ExportRhsToCLImage", { false }),
+                                                                                                               make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulLowpNativeKernelFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulDataset(),
-                                                                                                                        framework::dataset::make("TransposeA", { true, false }),
-                                                                                                                        framework::dataset::make("TransposeB", { true, false }),
+                                                                                                                        make("TransposeA", { true, false }),
+                                                                                                                        make("TransposeB", { true, false }),
                                                                                                                         m0_values_precommit,
                                                                                                                         n0_values_precommit,
                                                                                                                         k0_values_precommit,
-                                                                                                                        framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                                framework::dataset::make("DataType", DataType::QASYMM8)))
+                                                                                                                        make("ExportRhsToCLImage", { false }),
+                                                                                                                make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulLowpNativeKernelFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_nt,
                                                k0_values_nightly_lhs_nt_rhs_nt,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTransposed, CLMatMulLowpNativeKernelFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_t,
                                                k0_values_nightly_rhs_t,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulLowpNativeKernelFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_nt,
                                                k0_values_nightly_lhs_t_rhs_nt,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulLowpNativeKernelFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_t,
                                                k0_values_nightly_rhs_t,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::QASYMM8)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_quant);

--- a/tests/validation/CL/MatMulLowpNativeMMULKernel.cpp
+++ b/tests/validation/CL/MatMulLowpNativeMMULKernel.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Arm Limited.
+ * Copyright (c) 2023, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -41,11 +41,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_quant(1); /**< Tolerance value for comparing reference's output against implementation's output for quantized data types */
 }
-using framework::dataset::make;
 
 template <typename T>
 using CLMatMulLowpNativeMMULKernelFixture = MatMulKernelValidationFixture<T, ClMatMulLowpNativeMMULKernel, true /* use_mmul */>;
@@ -54,17 +54,17 @@ template <typename T>
 using CLMatMulLowpNativeMMULKernelWithBiasFixture = MatMulKernelWithBiasValidation<T, ClMatMulLowpNativeMMULKernel, true /* use_mmul */>;
 
 /** M0 values to test --precommit*/
-const auto m0_values_precommit = framework::dataset::make("M0", { 1, 3 });
+const auto m0_values_precommit = make("M0", { 1, 3 });
 
 /** N0 values to test --precommit*/
-const auto n0_values_precommit = framework::dataset::make("N0", { 2, 4 });
+const auto n0_values_precommit = make("N0", { 2, 4 });
 
 /** M0 values to test --nightly*/
-const auto m0_values_nightly_lhs_nt = framework::dataset::make("M0", { 2, 4, 5, 8 });
-const auto m0_values_nightly_lhs_t  = framework::dataset::make("M0", { 2, 4, 8 });
+const auto m0_values_nightly_lhs_nt = make("M0", { 2, 4, 5, 8 });
+const auto m0_values_nightly_lhs_t  = make("M0", { 2, 4, 8 });
 
 /** N0 values to test --nightly*/
-const auto n0_values_nightly = framework::dataset::make("N0", { 1, 3, 8, 16 });
+const auto n0_values_nightly = make("N0", { 1, 3, 8, 16 });
 
 TEST_SUITE(CL)
 TEST_SUITE(MatMulLowpNativeMMULKernel)

--- a/tests/validation/CL/MatMulNativeMMULKernel.cpp
+++ b/tests/validation/CL/MatMulNativeMMULKernel.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for floating point data types */
@@ -51,21 +52,21 @@ RelativeTolerance<half_float::half> tolerance_f16(half(0.02)); /**< Tolerance va
 } // namespace
 
 /** M0 values to test --precommit*/
-const auto m0_values_precommit = framework::dataset::make("M0", { 1, 3 });
+const auto m0_values_precommit = make("M0", { 1, 3 });
 
 /** N0 values to test --precommit*/
-const auto n0_values_precommit = framework::dataset::make("N0", { 2, 4 });
+const auto n0_values_precommit = make("N0", { 2, 4 });
 
 /** M0 values to test --nightly*/
-const auto m0_values_nightly_lhs_nt = framework::dataset::make("M0", { 1, 2, 3, 4, 5, 6, 7, 8 });
-const auto m0_values_nightly_lhs_t  = framework::dataset::make("M0", { 1, 2, 3, 4, 8 });
+const auto m0_values_nightly_lhs_nt = make("M0", { 1, 2, 3, 4, 5, 6, 7, 8 });
+const auto m0_values_nightly_lhs_t  = make("M0", { 1, 2, 3, 4, 8 });
 
 /** N0 values to test --nightly*/
-const auto n0_values_nightly_rhs_nt = framework::dataset::make("N0", { 1, 2, 3, 4, 8, 16 });
-const auto n0_values_nightly_rhs_t  = framework::dataset::make("N0", { 1, 2, 3, 4, 8 });
+const auto n0_values_nightly_rhs_nt = make("N0", { 1, 2, 3, 4, 8, 16 });
+const auto n0_values_nightly_rhs_t  = make("N0", { 1, 2, 3, 4, 8 });
 
 /** K0 value -- Fixed to 1 */
-const auto k0_value = framework::dataset::make("K0", { 1 });
+const auto k0_value = make("K0", { 1 });
 
 template <typename T>
 using CLMatMulNativeMMULKernelFixture = MatMulKernelValidationFixture<T, ClMatMulNativeMMULKernel, true /*use_mmul*/>;
@@ -274,13 +275,13 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 TEST_SUITE(Buffer)
 FIXTURE_DATA_TEST_CASE(RunTiny, CLMatMulNativeMMULKernelFixture<float>, framework::DatasetMode::ALL, combine(datasets::TinyMatMulMMULDataset(),
-                                                                                                                     framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                     framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                     make("TransposeA", { false, true }),
+                                                                                                                     make("TransposeB", { false, true }),
                                                                                                                      m0_values_precommit,
                                                                                                                      n0_values_precommit,
                                                                                                                      k0_value,
-                                                                                                                     framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                             framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                     make("ExportRhsToCLImage", { false }),
+                                                                                                             make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -289,13 +290,13 @@ FIXTURE_DATA_TEST_CASE(RunTiny, CLMatMulNativeMMULKernelFixture<float>, framewor
     }
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulNativeMMULKernelFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulMMULDataset(),
-                                                                                                                      framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                      framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                      make("TransposeA", { false, true }),
+                                                                                                                      make("TransposeB", { false, true }),
                                                                                                                       m0_values_precommit,
                                                                                                                       n0_values_precommit,
                                                                                                                       k0_value,
-                                                                                                                      framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                              framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                      make("ExportRhsToCLImage", { false }),
+                                                                                                              make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -304,13 +305,13 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulNativeMMULKernelFixture<float>, framewo
     }
 }
 FIXTURE_DATA_TEST_CASE(RunWithBias, CLMatMulKernelBiasFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulMMULDataset(),
-                                                                                                                   framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                   framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                   make("TransposeA", { false, true }),
+                                                                                                                   make("TransposeB", { false, true }),
                                                                                                                    m0_values_precommit,
                                                                                                                    n0_values_precommit,
                                                                                                                    k0_value,
-                                                                                                                   framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                           framework::dataset::make("DataType", DataType::F32)))
+                                                                                                                   make("ExportRhsToCLImage", { false }),
+                                                                                                           make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -320,13 +321,13 @@ FIXTURE_DATA_TEST_CASE(RunWithBias, CLMatMulKernelBiasFixture<float>, framework:
 }
 FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulNativeMMULKernelFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_nt,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -337,13 +338,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulNativeMMULKernelFixture<floa
 
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTranspose, CLMatMulNativeMMULKernelFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_t,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -353,13 +354,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeRhsTranspose, CLMatMulNativeMMULKernelFixture<flo
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulNativeMMULKernelFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_nt,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     // Validate output
@@ -370,13 +371,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulNativeMMULKernelFixture<fl
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulNativeMMULKernelFixture<float>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_t,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     // Validate output
@@ -389,13 +390,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulNativeMMULKer
 // It's a good idea to test for each Lhs/Rhs T/NT combinations because they're different CL kernels
 FIXTURE_DATA_TEST_CASE(RunHighDimensional, CLMatMulNativeMMULKernelFixture<float>, framework::DatasetMode::ALL,
                        combine(datasets::HighDimensionalMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { false, true }),
-                                                                       framework::dataset::make("TransposeB", { false, true }),
-                                                               framework::dataset::make("M0", { 2 }),
-                                                       framework::dataset::make("N0", { 2 }),
-                                               framework::dataset::make("K0", { 1 }),
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                                                                               make("TransposeA", { false, true }),
+                                                                       make("TransposeB", { false, true }),
+                                                               make("M0", { 2 }),
+                                                       make("N0", { 2 }),
+                                               make("K0", { 1 }),
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -410,13 +411,13 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 TEST_SUITE(Buffer)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulNativeMMULKernelFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallMatMulMMULDataset(),
-                                                                                                                     framework::dataset::make("TransposeA", { false, true }),
-                                                                                                                     framework::dataset::make("TransposeB", { false, true }),
+                                                                                                                     make("TransposeA", { false, true }),
+                                                                                                                     make("TransposeB", { false, true }),
                                                                                                                      m0_values_precommit,
                                                                                                                      n0_values_precommit,
                                                                                                                      k0_value,
-                                                                                                                     framework::dataset::make("ExportRhsToCLImage", { false }),
-                                                                                                             framework::dataset::make("DataType", DataType::F16)))
+                                                                                                                     make("ExportRhsToCLImage", { false }),
+                                                                                                             make("DataType", DataType::F16)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -426,13 +427,13 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLMatMulNativeMMULKernelFixture<half>, framewor
 }
 FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulNativeMMULKernelFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_nt,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -442,13 +443,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeNoTranspose, CLMatMulNativeMMULKernelFixture<half
 }
 FIXTURE_DATA_TEST_CASE(RunLargeRhsTranspose, CLMatMulNativeMMULKernelFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { false }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { false }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_nt,
                                                        n0_values_nightly_rhs_t,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     if(_device_supports_mmul)
@@ -458,13 +459,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeRhsTranspose, CLMatMulNativeMMULKernelFixture<hal
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulNativeMMULKernelFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { false }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { false }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_nt,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     // Validate output
@@ -475,13 +476,13 @@ FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposed, CLMatMulNativeMMULKernelFixture<ha
 }
 FIXTURE_DATA_TEST_CASE(RunLargeLhsTransposedRhsTransposed, CLMatMulNativeMMULKernelFixture<half>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeMatMulMMULDataset(),
-                                                                               framework::dataset::make("TransposeA", { true }),
-                                                                       framework::dataset::make("TransposeB", { true }),
+                                                                               make("TransposeA", { true }),
+                                                                       make("TransposeB", { true }),
                                                                m0_values_nightly_lhs_t,
                                                        n0_values_nightly_rhs_t,
                                                k0_value,
-                                       framework::dataset::make("ExportRhsToCLImage", { false }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                                       make("ExportRhsToCLImage", { false }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     // Validate output

--- a/tests/validation/CL/MaxUnpoolingLayer.cpp
+++ b/tests/validation/CL/MaxUnpoolingLayer.cpp
@@ -40,20 +40,21 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(MaxUnpoolingLayer)
 
 template <typename T>
 using CLMaxUnpoolingLayerFixture = MaxUnpoolingLayerValidationFixture<CLTensor, CLAccessor, CLPoolingLayer, CLMaxUnpoolingLayer, T>;
 
-const auto PoolingLayerIndicesDatasetFPSmall = combine(framework::dataset::make("PoolType", { PoolingType::MAX }), framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                                       framework::dataset::make("PadStride", { PadStrideInfo(2, 2, 0, 0), PadStrideInfo(2, 1, 0, 0) }));
+const auto PoolingLayerIndicesDatasetFPSmall = combine(make("PoolType", { PoolingType::MAX }), make("PoolingSize", { Size2D(2, 2) }),
+                                                       make("PadStride", { PadStrideInfo(2, 2, 0, 0), PadStrideInfo(2, 1, 0, 0) }));
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(MaxUnpooling, CLMaxUnpoolingLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(), PoolingLayerIndicesDatasetFPSmall,
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
 
                                                                                                                   ))
 {
@@ -64,8 +65,8 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(MaxUnpooling, CLMaxUnpoolingLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(), PoolingLayerIndicesDatasetFPSmall,
-                                                                                                                  framework::dataset::make("DataType", DataType::F16),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
+                                                                                                                  make("DataType", DataType::F16),
+                                                                                                                  make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })
 
                                                                                                                  ))
 {

--- a/tests/validation/CL/MeanStdDevNormalizationLayer.cpp
+++ b/tests/validation/CL/MeanStdDevNormalizationLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Tolerance for float operations */
@@ -53,15 +54,15 @@ TEST_SUITE(MeanStdDevNormalizationLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::F32), // Mismatching data type input/output
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32), // Mismatching shapes
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { false, false, true })),
+               make("Expected", { false, false, true })),
                input_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLMeanStdDevNormalizationLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -75,17 +76,17 @@ using CLMeanStdDevNormalizationLayerFixture = MeanStdDevNormalizationLayerValida
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMeanStdDevNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small2DShapes(),
-                       framework::dataset::make("DataType", DataType::F16),
-                       framework::dataset::make("InPlace", { false, true }),
-                       framework::dataset::make("Epsilon", { 1e-3 })))
+                       make("DataType", DataType::F16),
+                       make("InPlace", { false, true }),
+                       make("Epsilon", { 1e-3 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLMeanStdDevNormalizationLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large2DMeanStdDevNormalizationShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::F16),
-                                                                                                                       framework::dataset::make("InPlace", { false, true }),
-                                                                                                                       framework::dataset::make("Epsilon", { 1e-8 })))
+                                                                                                                       make("DataType", DataType::F16),
+                                                                                                                       make("InPlace", { false, true }),
+                                                                                                                       make("Epsilon", { 1e-8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -94,17 +95,17 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMeanStdDevNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small2DShapes(),
-                       framework::dataset::make("DataType", DataType::F32),
-                       framework::dataset::make("InPlace", { false, true }),
-                       framework::dataset::make("Epsilon", { 1e-8 })))
+                       make("DataType", DataType::F32),
+                       make("InPlace", { false, true }),
+                       make("Epsilon", { 1e-8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLMeanStdDevNormalizationLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::Large2DMeanStdDevNormalizationShapes(),
-                                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                                        framework::dataset::make("InPlace", { false, true }),
-                                                                                                                        framework::dataset::make("Epsilon", { 1e-8 })))
+                                                                                                                        make("DataType", DataType::F32),
+                                                                                                                        make("InPlace", { false, true }),
+                                                                                                                        make("Epsilon", { 1e-8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);

--- a/tests/validation/CL/NegLayer.cpp
+++ b/tests/validation/CL/NegLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Arm Limited.
+ * Copyright (c) 2019-2021, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -51,7 +52,7 @@ template <typename T>
 using CLNegLayerFixture = NegValidationFixture<CLTensor, CLAccessor, CLNegLayer, T>;
 
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLNegLayerFixture<int>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLNegLayerFixture<int>, framework::DatasetMode::ALL, combine(datasets::SmallShapes(), make("DataType",
                                                                                                     DataType::S32)))
 {
     // Validate output
@@ -61,13 +62,13 @@ TEST_SUITE_END()
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLNegLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLNegLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp16);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLNegLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLNegLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     // Validate output
@@ -76,13 +77,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLNegLayerFixture<half>, framework::DatasetMode
 
 TEST_SUITE_END() // FP16
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLNegLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLNegLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLNegLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLNegLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output

--- a/tests/validation/CL/NormalizationLayer.cpp
+++ b/tests/validation/CL/NormalizationLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Tolerance for float operations */
@@ -48,15 +49,15 @@ RelativeTolerance<half>  tolerance_f16(half(0.2));
 RelativeTolerance<float> tolerance_f32(0.05f);
 
 /** Input data set. */
-const auto NormalizationDatasetFP16 = combine(framework::dataset::make("NormType", { NormType::IN_MAP_1D, NormType::IN_MAP_2D, NormType::CROSS_MAP }),
-                                                              framework::dataset::make("NormalizationSize", 3, 9, 2),
-                                                      framework::dataset::make("Beta", { 0.5f, 1.f, 2.f }),
-                                              framework::dataset::make("IsScaled", { true }));
+const auto NormalizationDatasetFP16 = combine(make("NormType", { NormType::IN_MAP_1D, NormType::IN_MAP_2D, NormType::CROSS_MAP }),
+                                                              make("NormalizationSize", 3, 9, 2),
+                                                      make("Beta", { 0.5f, 1.f, 2.f }),
+                                              make("IsScaled", { true }));
 
-const auto NormalizationDatasetFP32 = combine(framework::dataset::make("NormType", { NormType::IN_MAP_1D, NormType::IN_MAP_2D, NormType::CROSS_MAP }),
-                                                              framework::dataset::make("NormalizationSize", 3, 9, 2),
-                                                      framework::dataset::make("Beta", { 0.5f, 1.f, 2.f }),
-                                              framework::dataset::make("IsScaled", { true, false }));
+const auto NormalizationDatasetFP32 = combine(make("NormType", { NormType::IN_MAP_1D, NormType::IN_MAP_2D, NormType::CROSS_MAP }),
+                                                              make("NormalizationSize", 3, 9, 2),
+                                                      make("Beta", { 0.5f, 1.f, 2.f }),
+                                              make("IsScaled", { true, false }));
 } // namespace
 
 TEST_SUITE(CL)
@@ -64,25 +65,25 @@ TEST_SUITE(NormalizationLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Mismatching data type input/output
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Mismatching shapes
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Even normalization
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Windows shrinking for NCHW
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(27U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("NormInfo",  { NormalizationLayerInfo(NormType::IN_MAP_1D, 5),
+               make("NormInfo",  { NormalizationLayerInfo(NormType::IN_MAP_1D, 5),
                                                        NormalizationLayerInfo(NormType::IN_MAP_1D, 5),
                                                        NormalizationLayerInfo(NormType::IN_MAP_1D, 4),
                                                        NormalizationLayerInfo(NormType::IN_MAP_2D, 5),
                                                        NormalizationLayerInfo(NormType::CROSS_MAP, 5),
                                                       }),
-               framework::dataset::make("Expected", { false, false, false, false, true })),
+               make("Expected", { false, false, false, false, true })),
                input_info, output_info, norm_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLNormalizationLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), norm_info)) == expected, framework::LogLevel::ERRORS);
@@ -96,15 +97,15 @@ using CLNormalizationLayerFixture = NormalizationValidationFixture<CLTensor, CLA
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLNormalizationLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), NormalizationDatasetFP16,
-                                                                                                                       framework::dataset::make("DataType", DataType::F16),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                       make("DataType", DataType::F16),
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLNormalizationLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), NormalizationDatasetFP16,
-                                                                                                                     framework::dataset::make("DataType", DataType::F16),
-                                                                                                             framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                     make("DataType", DataType::F16),
+                                                                                                             make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -113,15 +114,15 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLNormalizationLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), NormalizationDatasetFP32,
-                                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                                framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                        make("DataType", DataType::F32),
+                                                                                                                make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLNormalizationLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), NormalizationDatasetFP32,
-                                                                                                                      framework::dataset::make("DataType", DataType::F32),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                      make("DataType", DataType::F32),
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);

--- a/tests/validation/CL/NormalizePlanarYUVLayer.cpp
+++ b/tests/validation/CL/NormalizePlanarYUVLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr RelativeTolerance<float> tolerance_f16(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for DataType::F16 */
@@ -56,28 +57,28 @@ using CLNormalizePlanarYUVLayerFixture = NormalizePlanarYUVLayerValidationFixtur
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),     // Window shrink
                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Unsupported data type
                         TensorInfo(TensorShape(32U, 16U, 8U), 1, DataType::F16),
                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),     // Mismatching mean and sd shapes
                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                         }),
-                    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+                    make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                         TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                         TensorInfo(TensorShape(32U, 16U, 8U), 1, DataType::F16),
                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F16),
                         TensorInfo(TensorShape(30U, 11U, 2U), 1, DataType::F32),
                         }),
-                framework::dataset::make("MSTDInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F16),
+                make("MSTDInfo",{ TensorInfo(TensorShape(2U), 1, DataType::F16),
                     TensorInfo(TensorShape(2U), 1, DataType::F16),
                     TensorInfo(TensorShape(2U), 1, DataType::U8),
                     TensorInfo(TensorShape(8U), 1, DataType::F16),
                     TensorInfo(TensorShape(6U), 1, DataType::F16),
                     TensorInfo(TensorShape(2U), 1, DataType::F32),
                     }),
-                    framework::dataset::make("Expected", { false, false, false, true, false, false })),
+                    make("Expected", { false, false, false, true, false, false })),
                     input_info, output_info, msd_info, expected)
 {
     const auto &mean_info = msd_info;
@@ -91,8 +92,8 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(Random, CLNormalizePlanarYUVLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::RandomNormalizePlanarYUVLayerDataset(),
-                                                                                                                  framework::dataset::make("DataType", DataType::F16),
-                                                                                                                  framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                  make("DataType", DataType::F16),
+                                                                                                                  make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16, 0);
@@ -101,8 +102,8 @@ TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(Random, CLNormalizePlanarYUVLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::RandomNormalizePlanarYUVLayerDataset(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                                   framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                                   make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -116,9 +117,9 @@ using CLNormalizePlanarYUVLayerQuantizedFixture = NormalizePlanarYUVLayerValidat
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(Random, CLNormalizePlanarYUVLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::RandomNormalizePlanarYUVLayerDataset(),
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("DataLayout", { DataLayout::NHWC }),
+                       make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, 0);
@@ -126,9 +127,9 @@ FIXTURE_DATA_TEST_CASE(Random, CLNormalizePlanarYUVLayerQuantizedFixture<uint8_t
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(Random, CLNormalizePlanarYUVLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::RandomNormalizePlanarYUVLayerDataset(),
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataLayout", { DataLayout::NCHW }),
+                       make("QuantizationInfo", { QuantizationInfo(0.1f, 128.0f) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8, 0);

--- a/tests/validation/CL/PReluLayer.cpp
+++ b/tests/validation/CL/PReluLayer.cpp
@@ -41,27 +41,28 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
 RelativeTolerance<float> tolerance_fp16(0.001f);
 
 /** Input data sets **/
-const auto PReluLayerU8Dataset = combine(framework::dataset::make("DataType", DataType::U8), framework::dataset::make("DataType", DataType::U8),
-                                         framework::dataset::make("DataType",
+const auto PReluLayerU8Dataset = combine(make("DataType", DataType::U8), make("DataType", DataType::U8),
+                                         make("DataType",
                                                                   DataType::U8));
-const auto PReluLayerQASYMM8Dataset = combine(framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("DataType", DataType::QASYMM8),
-                                              framework::dataset::make("DataType",
+const auto PReluLayerQASYMM8Dataset = combine(make("DataType", DataType::QASYMM8), make("DataType", DataType::QASYMM8),
+                                              make("DataType",
                                                                        DataType::QASYMM8));
-const auto PReluLayerQASYMM8SIGNEDDataset = combine(framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                    framework::dataset::make("DataType",
+const auto PReluLayerQASYMM8SIGNEDDataset = combine(make("DataType", DataType::QASYMM8_SIGNED), make("DataType", DataType::QASYMM8_SIGNED),
+                                                    make("DataType",
                                                                              DataType::QASYMM8_SIGNED));
-const auto PReluLayerS16Dataset = combine(framework::dataset::make("DataType", { DataType::S16 }), framework::dataset::make("DataType", DataType::S16),
-                                          framework::dataset::make("DataType", DataType::S16));
-const auto PReluLayerFP16Dataset = combine(framework::dataset::make("DataType", DataType::F16), framework::dataset::make("DataType", DataType::F16),
-                                           framework::dataset::make("DataType", DataType::F16));
-const auto PReluLayerFP32Dataset = combine(framework::dataset::make("DataType", DataType::F32), framework::dataset::make("DataType", DataType::F32),
-                                           framework::dataset::make("DataType", DataType::F32));
+const auto PReluLayerS16Dataset = combine(make("DataType", { DataType::S16 }), make("DataType", DataType::S16),
+                                          make("DataType", DataType::S16));
+const auto PReluLayerFP16Dataset = combine(make("DataType", DataType::F16), make("DataType", DataType::F16),
+                                           make("DataType", DataType::F16));
+const auto PReluLayerFP32Dataset = combine(make("DataType", DataType::F32), make("DataType", DataType::F32),
+                                           make("DataType", DataType::F32));
 } // namespace
 
 TEST_SUITE(CL)
@@ -69,19 +70,19 @@ TEST_SUITE(PReluLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false})),
+               make("Expected", { true, false, false})),
                input1_info, input2_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLPReluLayer::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -164,9 +165,9 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPReluLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                    PReluLayerQASYMM8Dataset,
-                                                                                                                   framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                                                                                                   framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                                                                                                   framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
+                                                                                                                   make("QuantizationInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                                                                                                   make("QuantizationInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                                                                                                   make("QuantizationInfo", { QuantizationInfo(1.f / 255.f, 5) }))
 
                       )
 {
@@ -178,9 +179,9 @@ TEST_SUITE_END()
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPReluLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(),
                                                                                                                   PReluLayerQASYMM8SIGNEDDataset,
-                                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo(5.f / 127.f, 20) }),
-                                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.f / 127.f, 10) }),
-                                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.f / 127.f, 5) }))
+                                                                                                                  make("QuantizationInfo", { QuantizationInfo(5.f / 127.f, 20) }),
+                                                                                                                  make("QuantizationInfo", { QuantizationInfo(2.f / 127.f, 10) }),
+                                                                                                                  make("QuantizationInfo", { QuantizationInfo(1.f / 127.f, 5) }))
 
                       )
 {
@@ -196,7 +197,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLPReluLayerFixture<int16_t>, framework::Datase
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunOneDimensional, CLPReluLayerFixture<int16_t>, framework::DatasetMode::ALL, combine(framework::dataset::make("Shape", TensorShape(1U, 16U)), PReluLayerS16Dataset))
+FIXTURE_DATA_TEST_CASE(RunOneDimensional, CLPReluLayerFixture<int16_t>, framework::DatasetMode::ALL, combine(make("Shape", TensorShape(1U, 16U)), PReluLayerS16Dataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/PadLayer.cpp
+++ b/tests/validation/CL/PadLayer.cpp
@@ -40,9 +40,10 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-const auto PaddingSizesDataset3D = framework::dataset::make("PaddingSize",
+const auto PaddingSizesDataset3D = make("PaddingSize",
 {
     PaddingList{ { 0, 0 } },
     PaddingList{ { 1, 1 } },
@@ -52,7 +53,7 @@ const auto PaddingSizesDataset3D = framework::dataset::make("PaddingSize",
     PaddingList{ { 0, 0 }, { 1, 0 }, { 0, 1 } },
     PaddingList{ { 0, 0 }, { 0, 0 }, { 0, 0 } }
 });
-const auto PaddingSizesDataset4D = framework::dataset::make("PaddingSize",
+const auto PaddingSizesDataset4D = make("PaddingSize",
 {
     PaddingList{ { 1, 1 }, { 1, 0 }, { 1, 1 }, { 0, 0 } },
     PaddingList{ { 0, 0 }, { 0, 0 }, { 0, 0 }, { 1, 1 } },
@@ -67,7 +68,7 @@ TEST_SUITE(PadLayer)
 // *INDENT-OFF*
 // clang-format off
 
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),    // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),    // Mismatching data type input/output
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),    // Mismatching shapes with padding
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),    // Invalid number of pad dimensions
@@ -75,7 +76,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::F32)     // Invalid padding list
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(28U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(29U, 17U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(29U, 15U, 4U, 3U), 1, DataType::F32),
@@ -83,7 +84,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(29U, 17U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::F32)
                                                      }),
-               framework::dataset::make("PaddingSize", { PaddingList{{0, 0}},
+               make("PaddingSize", { PaddingList{{0, 0}},
                                                          PaddingList{{1, 1}},
                                                          PaddingList{{1, 1}, {2, 2}},
                                                          PaddingList{{1,1}, {1,1}, {1,1}, {1,1}},
@@ -91,7 +92,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                          PaddingList{{1, 1}, {2, 2}},
                                                          PaddingList{{0,0}, {0,0}, {1,1}}
                                                          }),
-               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT,
+               make("PaddingMode", { PaddingMode::CONSTANT,
                                                          PaddingMode::CONSTANT,
                                                          PaddingMode::CONSTANT,
                                                          PaddingMode::CONSTANT,
@@ -99,7 +100,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                          PaddingMode::REFLECT,
                                                          PaddingMode::REFLECT
                                                        }),
-               framework::dataset::make("Expected", { false,
+               make("Expected", { false,
                                                       false,
                                                       true,
                                                       false,
@@ -111,7 +112,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
     ARM_COMPUTE_EXPECT(bool(CLPadLayer::validate(&input_info.clone()->set_is_resizable(true), &output_info.clone()->set_is_resizable(true), padding, PixelValue(), mode)) == expected, framework::LogLevel::ERRORS);
 }
 
-DATA_TEST_CASE(CheckFusingWithConvolution, framework::DatasetMode::ALL, zip(framework::dataset::make("DataLayout",  { DataLayout::NCHW,
+DATA_TEST_CASE(CheckFusingWithConvolution, framework::DatasetMode::ALL, zip(make("DataLayout",  { DataLayout::NCHW,
                                                           DataLayout::NCHW,
                                                           DataLayout::NCHW,
                                                           DataLayout::NCHW,
@@ -128,7 +129,7 @@ DATA_TEST_CASE(CheckFusingWithConvolution, framework::DatasetMode::ALL, zip(fram
                                                           DataLayout::NHWC,
                                                           DataLayout::UNKNOWN
                                                         }),
-                framework::dataset::make("PaddingList", { PaddingList({{0, 0}, {1, 1}, {1, 1}}),          // nchw
+                make("PaddingList", { PaddingList({{0, 0}, {1, 1}, {1, 1}}),          // nchw
                                                           PaddingList({{1, 1}, {1, 1}, {0, 0}, {0, 0}}),
                                                           PaddingList({{1, 1}, {1, 1}}),
                                                           PaddingList({}),
@@ -145,7 +146,7 @@ DATA_TEST_CASE(CheckFusingWithConvolution, framework::DatasetMode::ALL, zip(fram
                                                           PaddingList({{0, 0}, {1, 1}}),
                                                           PaddingList({{0, 0}})
                                                         }),                           // unknown
-                framework::dataset::make("Expected",    { false,    // nchw
+                make("Expected",    { false,    // nchw
                                                           true,
                                                           true,
                                                           true,
@@ -177,22 +178,22 @@ TEST_SUITE(Float)
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPaddingFixture<float>, framework::DatasetMode::ALL,
-                       combine(datasets::Small3DShapes(), framework::dataset::make("DataType", { DataType::F32 }), PaddingSizesDataset3D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
+                       combine(datasets::Small3DShapes(), make("DataType", { DataType::F32 }), PaddingSizesDataset3D,
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall4D, CLPaddingFixture<float>, framework::DatasetMode::ALL,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", { DataType::F32 }), PaddingSizesDataset4D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT })))
+                       combine(datasets::Small4DShapes(), make("DataType", { DataType::F32 }), PaddingSizesDataset4D,
+                               make("PaddingMode", { PaddingMode::CONSTANT })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPaddingFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large3DShapes(), framework::dataset::make("DataType", { DataType::F32 }), PaddingSizesDataset3D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
+                       combine(datasets::Large3DShapes(), make("DataType", { DataType::F32 }), PaddingSizesDataset3D,
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT, PaddingMode::SYMMETRIC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -201,8 +202,8 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPaddingFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large3DShapes(), framework::dataset::make("DataType", { DataType::F16 }), PaddingSizesDataset3D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
+                       combine(datasets::Large3DShapes(), make("DataType", { DataType::F16 }), PaddingSizesDataset3D,
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -213,22 +214,22 @@ TEST_SUITE_END() // Float
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPaddingFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small3DShapes(), framework::dataset::make("DataType", { DataType::QASYMM8 }), PaddingSizesDataset3D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
+                       combine(datasets::Small3DShapes(), make("DataType", { DataType::QASYMM8 }), PaddingSizesDataset3D,
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall4D, CLPaddingFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", { DataType::QASYMM8 }), PaddingSizesDataset4D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT })))
+                       combine(datasets::Small4DShapes(), make("DataType", { DataType::QASYMM8 }), PaddingSizesDataset4D,
+                               make("PaddingMode", { PaddingMode::CONSTANT })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPaddingFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large3DShapes(), framework::dataset::make("DataType", { DataType::QASYMM8 }), PaddingSizesDataset3D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
+                       combine(datasets::Large3DShapes(), make("DataType", { DataType::QASYMM8 }), PaddingSizesDataset3D,
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -237,8 +238,8 @@ TEST_SUITE_END() // QASYMM8
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPaddingFixture<int8_t>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small3DShapes(), framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED }), PaddingSizesDataset3D,
-                               framework::dataset::make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
+                       combine(datasets::Small3DShapes(), make("DataType", { DataType::QASYMM8_SIGNED }), PaddingSizesDataset3D,
+                               make("PaddingMode", { PaddingMode::CONSTANT, PaddingMode::REFLECT })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/Permute.cpp
+++ b/tests/validation/CL/Permute.cpp
@@ -40,9 +40,10 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-const auto PermuteVectors3 = framework::dataset::make("PermutationVector",
+const auto PermuteVectors3 = make("PermutationVector",
 {
     PermutationVector(2U, 0U, 1U),
     PermutationVector(1U, 2U, 0U),
@@ -51,7 +52,7 @@ const auto PermuteVectors3 = framework::dataset::make("PermutationVector",
     PermutationVector(1U, 0U, 2U),
     PermutationVector(2U, 1U, 0U),
 });
-const auto PermuteVectors4 = framework::dataset::make("PermutationVector",
+const auto PermuteVectors4 = make("PermutationVector",
 {
     PermutationVector(3U, 2U, 0U, 1U),
     PermutationVector(3U, 2U, 1U, 0U),
@@ -62,7 +63,7 @@ const auto PermuteVectors4 = framework::dataset::make("PermutationVector",
     PermutationVector(0U, 3U, 2U, 1U)
 });
 const auto PermuteVectors         = concat(PermuteVectors3, PermuteVectors4);
-const auto PermuteParametersSmall = concat(concat(datasets::Small2DShapes(), datasets::Small3DShapes()), datasets::Small4DShapes()) * PermuteVectors;
+const auto PermuteParametersSmall = concat(datasets::Small2DShapes(), datasets::Small3DShapes(), datasets::Small4DShapes()) * PermuteVectors;
 const auto PermuteParametersLarge = datasets::Large4DShapes() * PermuteVectors;
 } // namespace
 TEST_SUITE(CL)
@@ -70,7 +71,7 @@ TEST_SUITE(Permute)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",{
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",{
                 TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),     // valid
                 TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),     // permutation not supported
                 TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),     // permutation not supported
@@ -84,7 +85,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                 TensorInfo(TensorShape(27U, 13U, 37U, 2U), 1, DataType::F32)   // permutation not supported
 
         }),
-        framework::dataset::make("OutputInfo", {
+        make("OutputInfo", {
                 TensorInfo(TensorShape(5U, 7U, 7U, 3U), 1, DataType::U16),
                 TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),
                 TensorInfo(TensorShape(7U, 7U, 5U, 3U), 1, DataType::U16),
@@ -98,7 +99,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                 TensorInfo(TensorShape(37U, 2U, 13U, 27U), 1, DataType::F32)
 
         }),
-        framework::dataset::make("PermutationVector", {
+        make("PermutationVector", {
                 PermutationVector(2U, 1U, 0U),
                 PermutationVector(2U, 2U, 1U),
                 PermutationVector(1U, 1U, 1U),
@@ -111,7 +112,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                 PermutationVector(2U, 3U, 1U, 0U),
                 PermutationVector(0U, 0U, 0U, 1000U)
         }),
-        framework::dataset::make("Expected", { true, false, false, false, true, true, false, true, false, true, false })),
+        make("Expected", { true, false, false, false, true, true, false, true, false, true, false })),
         input_info, output_info, perm_vect, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLPermute::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), perm_vect)) == expected, framework::LogLevel::ERRORS);
@@ -126,14 +127,14 @@ using CLPermuteFixture = PermuteValidationFixture<CLTensor, CLAccessor, CLPermut
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPermuteFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U8))
+                       PermuteParametersSmall * make("DataType", DataType::U8))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPermuteFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U8))
+                       PermuteParametersLarge * make("DataType", DataType::U8))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -142,13 +143,13 @@ TEST_SUITE_END() // U8
 
 TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPermuteFixture<uint16_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U16))
+                       PermuteParametersSmall * make("DataType", DataType::U16))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPermuteFixture<uint16_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U16))
+                       PermuteParametersLarge * make("DataType", DataType::U16))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -157,13 +158,13 @@ TEST_SUITE_END() // U16
 
 TEST_SUITE(U32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPermuteFixture<uint32_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U32))
+                       PermuteParametersSmall * make("DataType", DataType::U32))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPermuteFixture<uint32_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U32))
+                       PermuteParametersLarge * make("DataType", DataType::U32))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/PixelWiseMultiplication.cpp
+++ b/tests/validation/CL/PixelWiseMultiplication.cpp
@@ -36,6 +36,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 namespace
@@ -43,14 +44,14 @@ namespace
 const float                        scale_255 = 1.f / 255.f;
 constexpr AbsoluteTolerance<float> tolerance_qasymm8(1); /**< Tolerance value for comparing reference's output against implementation's output for 8-bit quantized asymmetric data types */
 constexpr AbsoluteTolerance<float> tolerance_qsymm16(1); /**< Tolerance value for comparing reference's output against implementation's output for 16-bit quantized symmetric data types */
-const auto                         EmptyActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto                         EmptyActivationFunctionsDataset = make("ActivationInfo",
 { ActivationLayerInfo() });
-const auto ActivationFunctionsDataset = framework::dataset::make("ActivationInfo",
+const auto ActivationFunctionsDataset = make("ActivationInfo",
 {
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::BOUNDED_RELU, 0.75f, 0.25f),
     ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::LOGISTIC, 0.75f, 0.25f)
 });
-const auto InPlaceDataSet = framework::dataset::make("InPlace", { false });
+const auto InPlaceDataSet = make("InPlace", { false });
 } //namespace
 // *INDENT-OFF*
 // clang-format off
@@ -60,11 +61,11 @@ const auto InPlaceDataSet = framework::dataset::make("InPlace", { false });
     FIXTURE_DATA_TEST_CASE(TEST_NAME, CLPixelWiseMultiplication##FIXTURE, framework::DatasetMode::MODE,                   \
                            combine(\
                            datasets::SHAPES,                                                                              \
-                           framework::dataset::make("DataType1", DataType::DT1),                                         \
-                           framework::dataset::make("DataType2", DataType::DT2),                                         \
-                           framework::dataset::make("Scale", std::move(SCALE)),                                          \
+                           make("DataType1", DataType::DT1),                                         \
+                           make("DataType2", DataType::DT2),                                         \
+                           make("Scale", std::move(SCALE)),                                          \
                            datasets::ConvertPolicies(),                                                                  \
-                           framework::dataset::make("RoundingPolicy", RoundingPolicy::RP), ACT, \
+                           make("RoundingPolicy", RoundingPolicy::RP), ACT, \
                            InPlaceDataSet))  \
     {                                                                                                                     \
         VALIDATE                                                                                                          \
@@ -87,26 +88,26 @@ TEST_SUITE(PixelWiseMultiplication)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid scale
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),      // Invalid data type combination
                                                         TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                       }),
-               framework::dataset::make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+               make("Input2Info",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                        TensorInfo(TensorShape(48U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Scale",{  2.f, 2.f, -1.f, 1.f, 1.f}),
-               framework::dataset::make("Expected", { true, true, false, false, false})),
+               make("Scale",{  2.f, 2.f, -1.f, 1.f, 1.f}),
+               make("Expected", { true, true, false, false, false})),
                input1_info, input2_info, output_info, scale, expected)
 {
     bool has_error = bool(CLPixelWiseMultiplication::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), scale, ConvertPolicy::WRAP, RoundingPolicy::TO_ZERO));
@@ -117,11 +118,11 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 TEST_SUITE(INT32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationIntegerFixture<int>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapes(),
-                                                                           framework::dataset::make("DataType1", DataType::S32),
-                                                                       framework::dataset::make("DataType2", DataType::S32),
-                                                               framework::dataset::make("Scale", { 1.f }),
+                                                                           make("DataType1", DataType::S32),
+                                                                       make("DataType2", DataType::S32),
+                                                               make("Scale", { 1.f }),
                                                        datasets::ConvertPolicies(),
-                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
+                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
                                        EmptyActivationFunctionsDataset,
                                InPlaceDataSet))
 {
@@ -129,13 +130,13 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationIntegerFixture<int>, f
 }
 FIXTURE_DATA_TEST_CASE(RunInplace, CLPixelWiseMultiplicationIntegerFixture<int>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::TinyShapes(),
-                                                                               framework::dataset::make("DataType1", DataType::S32),
-                                                                       framework::dataset::make("DataType2", DataType::S32),
-                                                               framework::dataset::make("Scale", { 1.f }),
+                                                                               make("DataType1", DataType::S32),
+                                                                       make("DataType2", DataType::S32),
+                                                               make("Scale", { 1.f }),
                                                        datasets::ConvertPolicies(),
-                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
+                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
                                        EmptyActivationFunctionsDataset,
-                               framework::dataset::make("InPlace", { true })))
+                               make("InPlace", { true })))
 {
     validate(CLAccessor(_target), _reference);
 }
@@ -156,13 +157,13 @@ PIXEL_WISE_MULTIPLICATION_FIXTURE_DATA_TEST_CASE(RunSmall, ToF32Fixture<float>, 
 PIXEL_WISE_MULTIPLICATION_FIXTURE_DATA_TEST_CASE(RunWithActivation, ToF32Fixture<float>, ALL, TinyShapes(), F32, F32, scale_255, TO_NEAREST_UP, ActivationFunctionsDataset, VALIDATE(float, 1.f))
 FIXTURE_DATA_TEST_CASE(RunInplace, CLPixelWiseMultiplicationToF32Fixture<float>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::TinyShapes(),
-                                                                               framework::dataset::make("DataTypeIn1", DataType::F32),
-                                                                       framework::dataset::make("DataTypeIn2", DataType::F32),
-                                                               framework::dataset::make("Scale", { scale_255 }),
+                                                                               make("DataTypeIn1", DataType::F32),
+                                                                       make("DataTypeIn2", DataType::F32),
+                                                               make("Scale", { scale_255 }),
                                                        datasets::ConvertPolicies(),
-                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
+                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_UP),
                                        EmptyActivationFunctionsDataset,
-                               framework::dataset::make("InPlace", { true })))
+                               make("InPlace", { true })))
 {
     // Validate output
     VALIDATE(float, 1.f)
@@ -188,15 +189,15 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapes(),
-                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                                               framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                                                       framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                                               framework::dataset::make("Scale", { 1.f, 2.f }),
-                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("OUtQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                       make("DataTypeIn1", DataType::QASYMM8),
+                                                                                               make("DataTypeIn2", DataType::QASYMM8),
+                                                                                       make("DataTypeOut", DataType::QASYMM8),
+                                                                               make("Scale", { 1.f, 2.f }),
+                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
+                                                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("OUtQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -205,15 +206,15 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationQuantizedFixture<uint8
 
 FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLPixelWiseMultiplicationQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapesBroadcast(),
-                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                                               framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                                                       framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                                               framework::dataset::make("Scale", { 1.f, 2.f }),
-                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("OUtQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                       make("DataTypeIn1", DataType::QASYMM8),
+                                                                                               make("DataTypeIn2", DataType::QASYMM8),
+                                                                                       make("DataTypeOut", DataType::QASYMM8),
+                                                                               make("Scale", { 1.f, 2.f }),
+                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
+                                                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("OUtQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -222,16 +223,16 @@ FIXTURE_DATA_TEST_CASE(RunSmallBroadcast, CLPixelWiseMultiplicationQuantizedBroa
 
 FIXTURE_DATA_TEST_CASE(RunInplace, CLPixelWiseMultiplicationQuantizedBroadcastFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::TinyShapesBroadcastInplace(),
-                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8),
-                                                                                               framework::dataset::make("DataTypeIn2", DataType::QASYMM8),
-                                                                                       framework::dataset::make("DataTypeOut", DataType::QASYMM8),
-                                                                               framework::dataset::make("Scale", { 1.f, 2.f }),
-                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("OUtQInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                               framework::dataset::make("InPlace", { true })))
+                                                                                                       make("DataTypeIn1", DataType::QASYMM8),
+                                                                                               make("DataTypeIn2", DataType::QASYMM8),
+                                                                                       make("DataTypeOut", DataType::QASYMM8),
+                                                                               make("Scale", { 1.f, 2.f }),
+                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
+                                                       make("Src0QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("OUtQInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                               make("InPlace", { true })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -242,15 +243,15 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapes(),
-                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QASYMM8_SIGNED),
-                                                                                               framework::dataset::make("DataTypeIn2", DataType::QASYMM8_SIGNED),
-                                                                                       framework::dataset::make("DataTypeOut", DataType::QASYMM8_SIGNED),
-                                                                               framework::dataset::make("Scale", { 1.f, 2.f }),
-                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
-                                       framework::dataset::make("OUtQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
+                                                                                                       make("DataTypeIn1", DataType::QASYMM8_SIGNED),
+                                                                                               make("DataTypeIn2", DataType::QASYMM8_SIGNED),
+                                                                                       make("DataTypeOut", DataType::QASYMM8_SIGNED),
+                                                                               make("Scale", { 1.f, 2.f }),
+                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
+                                                       make("Src0QInfo", { QuantizationInfo(5.f / 255.f, 20) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 255.f, 10) }),
+                                       make("OUtQInfo", { QuantizationInfo(1.f / 255.f, 5) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -261,15 +262,15 @@ TEST_SUITE_END() // QASYMM8_SIGNED
 TEST_SUITE(QSYMM16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationQuantizedFixture<int16_t>, framework::DatasetMode::PRECOMMIT,
                        combine(datasets::SmallShapes(),
-                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QSYMM16),
-                                                                                               framework::dataset::make("DataTypeIn2", DataType::QSYMM16),
-                                                                                       framework::dataset::make("DataTypeOut", DataType::QSYMM16),
-                                                                               framework::dataset::make("Scale", { 1.f, 2.f }),
-                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
-                                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                       make("DataTypeIn1", DataType::QSYMM16),
+                                                                                               make("DataTypeIn2", DataType::QSYMM16),
+                                                                                       make("DataTypeOut", DataType::QSYMM16),
+                                                                               make("Scale", { 1.f, 2.f }),
+                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
+                                                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
+                                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -277,15 +278,15 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationQuantizedFixture<int16
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPixelWiseMultiplicationQuantizedFixture<int16_t>, framework::DatasetMode::NIGHTLY,
                        combine(datasets::LargeShapes(),
-                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QSYMM16),
-                                                                                               framework::dataset::make("DataTypeIn2", DataType::QSYMM16),
-                                                                                       framework::dataset::make("DataTypeOut", DataType::QSYMM16),
-                                                                               framework::dataset::make("Scale", { 1.f, 2.f }),
-                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
-                                       framework::dataset::make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
+                                                                                                       make("DataTypeIn1", DataType::QSYMM16),
+                                                                                               make("DataTypeIn2", DataType::QSYMM16),
+                                                                                       make("DataTypeOut", DataType::QSYMM16),
+                                                                               make("Scale", { 1.f, 2.f }),
+                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
+                                                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
+                                       make("OutQInfo", { QuantizationInfo(5.f / 32768.f, 0) }),
                                InPlaceDataSet))
 {
     // Validate output
@@ -295,15 +296,15 @@ TEST_SUITE_END() // QSYMM16
 TEST_SUITE(QSYMM16ToS32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPixelWiseMultiplicationQSYMM16ToS32Fxture, framework::DatasetMode::ALL,
                        combine(datasets::SmallShapes(),
-                                                                                                       framework::dataset::make("DataTypeIn1", DataType::QSYMM16),
-                                                                                               framework::dataset::make("DataTypeIn2", DataType::QSYMM16),
-                                                                                       framework::dataset::make("DataTypeOut", DataType::S32),
-                                                                               framework::dataset::make("Scale", { 1.f }),
-                                                                       framework::dataset::make("ConvertPolicy", { ConvertPolicy::SATURATE }),
-                                                               framework::dataset::make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
-                                                       framework::dataset::make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
-                                               framework::dataset::make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
-                                       framework::dataset::make("OutQInfo", { QuantizationInfo(1.f, 0) }),
+                                                                                                       make("DataTypeIn1", DataType::QSYMM16),
+                                                                                               make("DataTypeIn2", DataType::QSYMM16),
+                                                                                       make("DataTypeOut", DataType::S32),
+                                                                               make("Scale", { 1.f }),
+                                                                       make("ConvertPolicy", { ConvertPolicy::SATURATE }),
+                                                               make("RoundingPolicy", RoundingPolicy::TO_NEAREST_EVEN),
+                                                       make("Src0QInfo", { QuantizationInfo(1.f / 32768.f, 0) }),
+                                               make("Src1QInfo", { QuantizationInfo(2.f / 32768.f, 0) }),
+                                       make("OutQInfo", { QuantizationInfo(1.f, 0) }),
                                InPlaceDataSet))
 {
     // Validate output

--- a/tests/validation/CL/Pooling3dLayer.cpp
+++ b/tests/validation/CL/Pooling3dLayer.cpp
@@ -46,26 +46,28 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::ContainerDataset;
+using framework::dataset::make;
 namespace
 {
 /** Input data sets for floating-point data types */
-const auto Pooling3dLayerDatasetFP = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size3D(2, 3, 2) }),
-                                                             framework::dataset::make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(2, 2, 1) }),
-                                                     framework::dataset::make("Padding", { Padding3D(0, 1, 0), Padding3D(1, 1, 1) }),
-                                             framework::dataset::make("ExcludePadding", { true, false }));
+const auto Pooling3dLayerDatasetFP = combine(datasets::PoolingTypes(), make("PoolingSize", { Size3D(2, 3, 2) }),
+                                                             make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(2, 2, 1) }),
+                                                     make("Padding", { Padding3D(0, 1, 0), Padding3D(1, 1, 1) }),
+                                             make("ExcludePadding", { true, false }));
 
-const auto Pooling3dLayerDatasetFPSmall = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size3D(2, 2, 2), Size3D(3, 3, 3) }),
-                                                                  framework::dataset::make("Stride", { Size3D(2, 2, 2), Size3D(2, 1, 1) }),
-                                                          framework::dataset::make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
-                                                  framework::dataset::make("ExcludePadding", { true, false }));
+const auto Pooling3dLayerDatasetFPSmall = combine(datasets::PoolingTypes(), make("PoolingSize", { Size3D(2, 2, 2), Size3D(3, 3, 3) }),
+                                                                  make("Stride", { Size3D(2, 2, 2), Size3D(2, 1, 1) }),
+                                                          make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
+                                                  make("ExcludePadding", { true, false }));
 
-const auto Pooling3DLayerDatasetQuantized = combine(framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
-                                                                            framework::dataset::make("PoolingSize", { Size3D(2, 3, 2) }),
-                                                                    framework::dataset::make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(1, 1, 2), Size3D(2, 2, 1)}),
-                                                            framework::dataset::make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
-                                                    framework::dataset::make("ExcludePadding", { true }));
+const auto Pooling3DLayerDatasetQuantized = combine(make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
+                                                                            make("PoolingSize", { Size3D(2, 3, 2) }),
+                                                                    make("Stride", { Size3D(1, 1, 1), Size3D(2, 1, 1), Size3D(1, 2, 1), Size3D(1, 1, 2), Size3D(2, 2, 1)}),
+                                                            make("Padding", { Padding3D(0, 0, 0), Padding3D(1, 1, 1), Padding3D(1, 0, 0) }),
+                                                    make("ExcludePadding", { true }));
 
-using ShapeDataset = framework::dataset::ContainerDataset<std::vector<TensorShape>>;
+using ShapeDataset = ContainerDataset<std::vector<TensorShape>>;
 
 constexpr AbsoluteTolerance<float>   tolerance_f32(0.001f);       /**< Tolerance value for comparing reference's output against implementation's output for 32-bit floating-point type */
 constexpr AbsoluteTolerance<float>   tolerance_f16(0.1f);         /**< Tolerance value for comparing reference's output against implementation's output for 16-bit floating-point type */
@@ -121,7 +123,7 @@ TEST_CASE(RoundToNearestInteger, framework::DatasetMode::ALL)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(2U, 27U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC), // Mismatching data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(2U, 27U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC), // Mismatching data type
                                                        TensorInfo(TensorShape(2U, 27U, 13U, 4U, 2U), 1, DataType::F32, DataLayout::NDHWC), // Invalid pad/size combination
                                                        TensorInfo(TensorShape(2U, 27U, 13U, 4U, 2U), 1, DataType::F32, DataLayout::NDHWC), // Invalid pad/size combination
                                                        TensorInfo(TensorShape(2U, 27U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC), // Invalid output shape
@@ -136,7 +138,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(5U, 13U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC),
                                                        TensorInfo(TensorShape(5U, 13U, 13U, 4U, 3U), 1, DataType::F32, DataLayout::NDHWC),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(2U, 25U, 11U, 3U, 3U), 1, DataType::F16, DataLayout::NDHWC),
+               make("OutputInfo",{ TensorInfo(TensorShape(2U, 25U, 11U, 3U, 3U), 1, DataType::F16, DataLayout::NDHWC),
                                                        TensorInfo(TensorShape(2U, 30U, 11U, 3U, 2U), 1, DataType::F32, DataLayout::NDHWC),
                                                        TensorInfo(TensorShape(2U, 25U, 16U, 3U, 2U), 1, DataType::F32, DataLayout::NDHWC),
                                                        TensorInfo(TensorShape(2U, 27U, 13U, 3U, 3U), 1, DataType::F32, DataLayout::NDHWC),
@@ -151,7 +153,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(5U, 6U, 6U, 2U, 3U),  1, DataType::F32, DataLayout::NDHWC),
                                                        TensorInfo(TensorShape(5U, 6U, 6U, 2U, 3U),  1, DataType::F32, DataLayout::NDHWC),
                                                      }),
-               framework::dataset::make("PoolInfo",  { Pooling3dLayerInfo(PoolingType::AVG, 3, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
+               make("PoolInfo",  { Pooling3dLayerInfo(PoolingType::AVG, 3, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
                                                        Pooling3dLayerInfo(PoolingType::AVG, 2, Size3D(1, 1, 1), Padding3D(2, 0, 0)),
                                                        Pooling3dLayerInfo(PoolingType::AVG, 2, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
                                                        Pooling3dLayerInfo(PoolingType::L2,  3, Size3D(1, 1, 1), Padding3D(0, 0, 0)),
@@ -166,7 +168,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        Pooling3dLayerInfo(PoolingType::AVG, 1, Size3D(2U, 2U, 2U), Padding3D(2, 2, 2), false), // Pool size is smaller than the padding size with padding included
                                                        Pooling3dLayerInfo(PoolingType::AVG, 3, Size3D(2U, 2U, 2U), Padding3D(2,1,2,2,1,2), false, false, DimensionRoundingType::CEIL), // CEIL with asymmetric Padding
                                                       }),
-               framework::dataset::make("Expected", { false, false, false, false, true, false, false, false, true , false, true, false, false, false})),
+               make("Expected", { false, false, false, false, true, false, false, false, true , false, true, false, false, false})),
                input_info, output_info, pool_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLPooling3dLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), pool_info)) == expected, framework::LogLevel::ERRORS);
@@ -193,9 +195,9 @@ TEST_SUITE(QASYMM8)
 // Small Dataset Quantized Dataset
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5dShapes(),
                                                                                                                        Pooling3DLayerDatasetQuantized,
-                                                                                                                               framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, 10), QuantizationInfo(1.f / 127.f, 10) }),
-                                                                                                                       framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, 5), QuantizationInfo(1.f / 127.f, 10) })))
+                                                                                                                               make("DataType", DataType::QASYMM8),
+                                                                                                                       make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, 10), QuantizationInfo(1.f / 127.f, 10) }),
+                                                                                                                       make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, 5), QuantizationInfo(1.f / 127.f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -204,9 +206,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerQuantizedFixture<uint8_t>, fram
 // Large Dataset Quantized Dataset
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPooling3dLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::Large5dShapes(),
                                                                                                                        Pooling3DLayerDatasetQuantized,
-                                                                                                                               framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, 10), QuantizationInfo(1.f / 127.f, 10) }),
-                                                                                                                       framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, 5), QuantizationInfo(1.f / 127.f, 10) })))
+                                                                                                                               make("DataType", DataType::QASYMM8),
+                                                                                                                       make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, 10), QuantizationInfo(1.f / 127.f, 10) }),
+                                                                                                                       make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, 5), QuantizationInfo(1.f / 127.f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -218,9 +220,9 @@ TEST_SUITE(QASYMM8_SIGNED)
 // Large Dataset Quantized Dataset Signed
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5dShapes(),
                                                                                                                       Pooling3DLayerDatasetQuantized,
-                                                                                                                              framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                      framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10), QuantizationInfo(1.f / 127.f, -10) }),
-                                                                                                                      framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -5), QuantizationInfo(1.f / 127.f, -10) })))
+                                                                                                                              make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                      make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10), QuantizationInfo(1.f / 127.f, -10) }),
+                                                                                                                      make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -5), QuantizationInfo(1.f / 127.f, -10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8_signed);
@@ -229,9 +231,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerQuantizedFixture<int8_t>, frame
 // Large Dataset Quantized pooling test
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPooling3dLayerQuantizedFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::Large5dShapes(),
                                                                                                                     Pooling3DLayerDatasetQuantized,
-                                                                                                                            framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                    framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10), QuantizationInfo(1.f / 127.f, -10) }),
-                                                                                                                    framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -5), QuantizationInfo(1.f / 127.f, -10) })))
+                                                                                                                            make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                    make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10), QuantizationInfo(1.f / 127.f, -10) }),
+                                                                                                                    make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -5), QuantizationInfo(1.f / 127.f, -10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8_signed);
@@ -243,21 +245,21 @@ TEST_SUITE_END()
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 
-FIXTURE_DATA_TEST_CASE(RunSpecial, CLSpecialPooling3dLayerFixture<float>, framework::DatasetMode::ALL, datasets::Pooling3dLayerDatasetSpecial() * framework::dataset::make("DataType", DataType::F32))
+FIXTURE_DATA_TEST_CASE(RunSpecial, CLSpecialPooling3dLayerFixture<float>, framework::DatasetMode::ALL, datasets::Pooling3dLayerDatasetSpecial() * make("DataType", DataType::F32))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5dShapes(), Pooling3dLayerDatasetFPSmall,
-                                                                                                            framework::dataset::make("DataType", DataType::F32)))
+                                                                                                            make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPooling3dLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::Large5dShapes(), Pooling3dLayerDatasetFP,
-                                                                                                          framework::dataset::make("DataType", DataType::F32)))
+                                                                                                          make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -267,40 +269,40 @@ TEST_SUITE(GlobalPooling)
 // *INDENT-OFF*
 // clang-format off
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerFixture<float>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
+                       combine(make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
                                                                              TensorShape(4U, 27U, 13U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(27, 13, 4) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F32)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(27, 13, 4) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallGlobal, CLPooling3dLayerGlobalFixture<float>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
+                       combine(make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
                                                                              TensorShape(27U, 13U, 4U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("DataType", DataType::F32)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPooling3dLayerFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(framework::dataset::make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
+                       combine(make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
                                                                              TensorShape(4U, 79U, 37U, 11U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(79, 37, 11) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F32)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(79, 37, 11) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -313,14 +315,14 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::Small5x5Shapes(), Pooling3dLayerDatasetFPSmall,
-                                                                                                           framework::dataset::make("DataType", DataType::F16)))
+                                                                                                           make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPooling3dLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::Large5dShapes(), Pooling3dLayerDatasetFP,
-                                                                                                         framework::dataset::make("DataType", DataType::F16)))
+                                                                                                         make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -330,40 +332,40 @@ TEST_SUITE(GlobalPooling)
 // *INDENT-OFF*
 // clang-format off
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPooling3dLayerFixture<half>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
+                       combine(make("InputShape", { TensorShape(3U, 27U, 13U, 4U),
                                                                              TensorShape(4U, 27U, 13U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(27, 13, 4) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F16)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(27, 13, 4) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 
 FIXTURE_DATA_TEST_CASE(RunSmallGlobal, CLPooling3dLayerGlobalFixture<half>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
+                       combine(make("InputShape", { TensorShape(27U, 13U, 4U, 3U),
                                                                              TensorShape(27U, 13U, 4U, 4U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("DataType", DataType::F16)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPooling3dLayerFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(framework::dataset::make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
+                       combine(make("InputShape", { TensorShape(4U, 79U, 37U, 11U),
                                                                              TensorShape(4U, 79U, 37U, 11U, 2U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size3D(79, 37, 11) }),
-                                    framework::dataset::make("Strides",  Size3D(1, 1, 1)),
-                                    framework::dataset::make("Paddings", Padding3D(0, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F16)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size3D(79, 37, 11) }),
+                                    make("Strides",  Size3D(1, 1, 1)),
+                                    make("Paddings", Padding3D(0, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);

--- a/tests/validation/CL/PoolingLayer.cpp
+++ b/tests/validation/CL/PoolingLayer.cpp
@@ -42,48 +42,49 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Input data sets for floating-point data types */
-const auto PoolingLayerDatasetFP = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(5, 7) }),
-                                                   framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0), PadStrideInfo(1, 2, 1, 1), PadStrideInfo(2, 2, 1, 0) }),
-                                           framework::dataset::make("ExcludePadding", { true, false }));
+const auto PoolingLayerDatasetFP = combine(datasets::PoolingTypes(), make("PoolingSize", { Size2D(2, 2), Size2D(3, 3), Size2D(5, 7) }),
+                                                   make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0), PadStrideInfo(1, 2, 1, 1), PadStrideInfo(2, 2, 1, 0) }),
+                                           make("ExcludePadding", { true, false }));
 
-const auto PoolingLayerDatasetFPSmall = combine(datasets::PoolingTypes(), framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(3, 3) }),
-                                                        framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0) }),
-                                                framework::dataset::make("ExcludePadding", { true, false }));
+const auto PoolingLayerDatasetFPSmall = combine(datasets::PoolingTypes(), make("PoolingSize", { Size2D(2, 2), Size2D(3, 3) }),
+                                                        make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 1, 0, 0) }),
+                                                make("ExcludePadding", { true, false }));
 
 /** Input data sets for asymmetric data type */
-const auto PoolingLayerDatasetQASYMM8 = combine(concat(combine(framework::dataset::make("PoolingType",
+const auto PoolingLayerDatasetQASYMM8 = combine(concat(combine(make("PoolingType",
 {
     PoolingType::MAX, PoolingType::AVG,
 }),
-framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(3, 3) }),
-framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(1, 2, 1, 1), PadStrideInfo(2, 2, 1, 0) })),
-combine(framework::dataset::make("PoolingType", { PoolingType::AVG }), framework::dataset::make("PoolingSize", { Size2D(5, 7) }), framework::dataset::make("PadStride", { PadStrideInfo(2, 1, 0, 0) }))),
-framework::dataset::make("ExcludePadding", { true }));
+make("PoolingSize", { Size2D(2, 2), Size2D(3, 3) }),
+make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(1, 2, 1, 1), PadStrideInfo(2, 2, 1, 0) })),
+combine(make("PoolingType", { PoolingType::AVG }), make("PoolingSize", { Size2D(5, 7) }), make("PadStride", { PadStrideInfo(2, 1, 0, 0) }))),
+make("ExcludePadding", { true }));
 
-const auto PoolingLayerDatasetQASYMM8Small = combine(framework::dataset::make("PoolingType",
+const auto PoolingLayerDatasetQASYMM8Small = combine(make("PoolingType",
 {
     PoolingType::MAX, PoolingType::AVG,
 }),
-framework::dataset::make("PoolingSize", { Size2D(2, 2), Size2D(5, 7) }),
-framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
-framework::dataset::make("ExcludePadding", { true }));
+make("PoolingSize", { Size2D(2, 2), Size2D(5, 7) }),
+make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
+make("ExcludePadding", { true }));
 
-const auto PoolingLayerDatasetFPIndicesSmall = combine(framework::dataset::make("PoolingType",
+const auto PoolingLayerDatasetFPIndicesSmall = combine(make("PoolingType",
 { PoolingType::MAX }),
-framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-framework::dataset::make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 2, 0, 0) }),
-framework::dataset::make("ExcludePadding", { true, false }));
+make("PoolingSize", { Size2D(2, 2) }),
+make("PadStride", { PadStrideInfo(1, 1, 0, 0), PadStrideInfo(2, 2, 0, 0) }),
+make("ExcludePadding", { true, false }));
 
 constexpr AbsoluteTolerance<float>   tolerance_f32(0.001f);  /**< Tolerance value for comparing reference's output against implementation's output for 32-bit floating-point type */
 constexpr AbsoluteTolerance<float>   tolerance_f16(0.01f);   /**< Tolerance value for comparing reference's output against implementation's output for 16-bit floating-point type */
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);   /**< Tolerance value for comparing reference's output against implementation's output for 8-bit asymmetric type */
 constexpr AbsoluteTolerance<int8_t>  tolerance_qasymm8_s(1); /**< Tolerance value for comparing reference's output against implementation's output for 8-bit signed asymmetric type */
-const auto                           pool_data_layout_dataset = framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC });
+const auto                           pool_data_layout_dataset = make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC });
 
-const auto pool_fp_mixed_precision_dataset = framework::dataset::make("FpMixedPrecision", { true, false });
+const auto pool_fp_mixed_precision_dataset = make("FpMixedPrecision", { true, false });
 
 void RoundToNearestIntegerPoolTestBody(const DataLayout layout, const TensorShape &shape,
     const TensorShape &output_shape)
@@ -149,7 +150,7 @@ TEST_CASE(RoundToNearestIntegerNCHW, framework::DatasetMode::ALL)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data type
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Invalid pad/size combination
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Invalid pad/size combination
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::QASYMM8), // Invalid parameters
@@ -159,7 +160,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(13U, 13U, 5U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 16U, 1U),  1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(30U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(25U, 16U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::QASYMM8),
@@ -169,7 +170,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(1U, 1U, 5U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 15U, 1U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("PoolInfo",  { PoolingLayerInfo(PoolingType::AVG, 3, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 0)),
+               make("PoolInfo",  { PoolingLayerInfo(PoolingType::AVG, 3, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 0)),
                                                        PoolingLayerInfo(PoolingType::AVG, 2, DataLayout::NCHW, PadStrideInfo(1, 1, 2, 0)),
                                                        PoolingLayerInfo(PoolingType::AVG, 2, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 2)),
                                                        PoolingLayerInfo(PoolingType::L2, 3, DataLayout::NCHW, PadStrideInfo(1, 1, 0, 0)),
@@ -179,7 +180,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        PoolingLayerInfo(PoolingType::AVG, DataLayout::NCHW),
                                                        PoolingLayerInfo(PoolingType::MAX, 2, DataLayout::NHWC, PadStrideInfo(1, 1, 0, 0), false),
                                                       }),
-               framework::dataset::make("Expected", { false, false, false, false, true, false, true, true , false})),
+               make("Expected", { false, false, false, false, true, false, true, true , false})),
                input_info, output_info, pool_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLPoolingLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), pool_info)) == expected, framework::LogLevel::ERRORS);
@@ -204,13 +205,13 @@ using CLPoolingLayerIndicesFixture = PoolingLayerIndicesValidationFixture<CLTens
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSpecial, CLSpecialPoolingLayerFixture<float>, framework::DatasetMode::ALL, datasets::PoolingLayerDatasetSpecial() * framework::dataset::make("DataType", DataType::F32))
+FIXTURE_DATA_TEST_CASE(RunSpecial, CLSpecialPoolingLayerFixture<float>, framework::DatasetMode::ALL, datasets::PoolingLayerDatasetSpecial() * make("DataType", DataType::F32))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPoolingLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(), PoolingLayerDatasetFPSmall,
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::F32),
                                                                                                           pool_data_layout_dataset))
 {
@@ -219,17 +220,17 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLPoolingLayerFixture<float>, framework::Datase
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLPoolingLayerMixedDataLayoutFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
                        datasets::PoolingTypes(),
-                                                       framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                               framework::dataset::make("PadStride", { PadStrideInfo(2, 1, 0, 0) }),
-                                       framework::dataset::make("ExcludePadding", { false }),
-                               framework::dataset::make("DataType", DataType::F32),
+                                                       make("PoolingSize", { Size2D(2, 2) }),
+                                               make("PadStride", { PadStrideInfo(2, 1, 0, 0) }),
+                                       make("ExcludePadding", { false }),
+                               make("DataType", DataType::F32),
                        pool_data_layout_dataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPoolingLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), PoolingLayerDatasetFP,
-                                                                                                                framework::dataset::make("DataType",
+                                                                                                                make("DataType",
                                                                                                                         DataType::F32),
                                                                                                         pool_data_layout_dataset))
 {
@@ -239,9 +240,9 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLPoolingLayerFixture<float>, framework::Datase
 
 FIXTURE_DATA_TEST_CASE(RunSmallIndices, CLPoolingLayerIndicesFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
                                                                                                                         PoolingLayerDatasetFPIndicesSmall,
-                                                                                                                                framework::dataset::make("DataType",
+                                                                                                                                make("DataType",
                                                                                                                                         DataType::F32),
-                                                                                                                        pool_data_layout_dataset,framework::dataset::make("UseKernelIndices", { false })))
+                                                                                                                        pool_data_layout_dataset,make("UseKernelIndices", { false })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -252,30 +253,30 @@ TEST_SUITE(GlobalPooling)
 // *INDENT-OFF*
 // clang-format off
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPoolingLayerFixture<float>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 2U),
+                       combine(make("InputShape", { TensorShape(27U, 13U, 2U),
                                                                              TensorShape(27U, 13U, 2U, 4U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size2D(27, 13) }),
-                                    framework::dataset::make("PadStride", PadStrideInfo(1, 1, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F32),
-                                    framework::dataset::make("DataLayout", DataLayout::NHWC)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size2D(27, 13) }),
+                                    make("PadStride", PadStrideInfo(1, 1, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F32),
+                                    make("DataLayout", DataLayout::NHWC)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPoolingLayerFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(framework::dataset::make("InputShape", { TensorShape(79U, 37U, 11U),
+                       combine(make("InputShape", { TensorShape(79U, 37U, 11U),
                                                                              TensorShape(79U, 37U, 11U, 4U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size2D(79, 37) }),
-                                    framework::dataset::make("PadStride", PadStrideInfo(1, 1, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F32),
-                                    framework::dataset::make("DataLayout", DataLayout::NHWC)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size2D(79, 37) }),
+                                    make("PadStride", PadStrideInfo(1, 1, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F32),
+                                    make("DataLayout", DataLayout::NHWC)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -289,7 +290,7 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLMixedPrecesionPoolingLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
                                                                                                                        PoolingLayerDatasetFPSmall,
-                                                                                                                               framework::dataset::make("DataType", DataType::F16),
+                                                                                                                               make("DataType", DataType::F16),
                                                                                                                        pool_data_layout_dataset,
                                                                                                                        pool_fp_mixed_precision_dataset))
 {
@@ -297,7 +298,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLMixedPrecesionPoolingLayerFixture<half>, fram
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLMixedPrecesionPoolingLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), PoolingLayerDatasetFP,
-                                                                                                                     framework::dataset::make("DataType", DataType::F16),
+                                                                                                                     make("DataType", DataType::F16),
                                                                                                                      pool_data_layout_dataset,
                                                                                                                      pool_fp_mixed_precision_dataset))
 {
@@ -306,9 +307,9 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLMixedPrecesionPoolingLayerFixture<half>, fram
 }
 FIXTURE_DATA_TEST_CASE(RunSmallIndices, CLPoolingLayerIndicesFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
                                                                                                                        PoolingLayerDatasetFPIndicesSmall,
-                                                                                                                               framework::dataset::make("DataType",
+                                                                                                                               make("DataType",
                                                                                                                                        DataType::F16),
-                                                                                                                       pool_data_layout_dataset, framework::dataset::make("UseKernelIndices", { false })))
+                                                                                                                       pool_data_layout_dataset, make("UseKernelIndices", { false })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -319,30 +320,30 @@ TEST_SUITE(GlobalPooling)
 // *INDENT-OFF*
 // clang-format off
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPoolingLayerFixture<half>, framework::DatasetMode::ALL,
-                       combine(framework::dataset::make("InputShape", { TensorShape(27U, 13U, 2U),
+                       combine(make("InputShape", { TensorShape(27U, 13U, 2U),
                                                                              TensorShape(27U, 13U, 2U, 4U)
                                                                             }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size2D(27, 13) }),
-                                    framework::dataset::make("PadStride", PadStrideInfo(1, 1, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F16),
-                                    framework::dataset::make("DataLayout", DataLayout::NHWC)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size2D(27, 13) }),
+                                    make("PadStride", PadStrideInfo(1, 1, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F16),
+                                    make("DataLayout", DataLayout::NHWC)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPoolingLayerFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(framework::dataset::make("InputShape", { TensorShape(79U, 37U, 11U),
+                       combine(make("InputShape", { TensorShape(79U, 37U, 11U),
                                                                              TensorShape(79U, 37U, 11U, 4U)
                                                                            }),
-                                    framework::dataset::make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
-                                    framework::dataset::make("PoolingSize", { Size2D(79, 37) }),
-                                    framework::dataset::make("PadStride", PadStrideInfo(1, 1, 0, 0)),
-                                    framework::dataset::make("ExcludePadding", false),
-                                    framework::dataset::make("DataType", DataType::F16),
-                                    framework::dataset::make("DataLayout", DataLayout::NHWC)))
+                                    make("PoolingType", { PoolingType::AVG, PoolingType::L2, PoolingType::MAX }),
+                                    make("PoolingSize", { Size2D(79, 37) }),
+                                    make("PadStride", PadStrideInfo(1, 1, 0, 0)),
+                                    make("ExcludePadding", false),
+                                    make("DataType", DataType::F16),
+                                    make("DataLayout", DataLayout::NHWC)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -364,23 +365,23 @@ using CLPoolingLayerQuantizedMixedDataLayoutFixture = PoolingLayerValidationQuan
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPoolingLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
                                                                                                                      PoolingLayerDatasetQASYMM8Small,
-                                                                                                                             framework::dataset::make("DataType", DataType::QASYMM8),
+                                                                                                                             make("DataType", DataType::QASYMM8),
                                                                                                                      pool_data_layout_dataset,
-                                                                                                                     framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(1.f / 255.f, 10) }),
-                                                                                                                     framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 255.f, 5), QuantizationInfo(1.f / 255.f, 10) })))
+                                                                                                                     make("InputQuantInfo", { QuantizationInfo(1.f / 255.f, 10), QuantizationInfo(1.f / 255.f, 10) }),
+                                                                                                                     make("OutputQuantInfo", { QuantizationInfo(1.f / 255.f, 5), QuantizationInfo(1.f / 255.f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLPoolingLayerQuantizedMixedDataLayoutFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
-                       framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
-                                                       framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                               framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
-                                       framework::dataset::make("ExcludePadding", { true }),
-                               framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
-                       framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 255.f, 10) }),
-                       framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 255.f, 5) })))
+                       make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
+                                                       make("PoolingSize", { Size2D(2, 2) }),
+                                               make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
+                                       make("ExcludePadding", { true }),
+                               make("DataType", DataType::QASYMM8),
+                       make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
+                       make("InputQuantInfo", { QuantizationInfo(1.f / 255.f, 10) }),
+                       make("OutputQuantInfo", { QuantizationInfo(1.f / 255.f, 5) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -390,23 +391,23 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPoolingLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
                                                                                                                     PoolingLayerDatasetQASYMM8Small,
-                                                                                                                            framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                            make("DataType", DataType::QASYMM8_SIGNED),
                                                                                                                     pool_data_layout_dataset,
-                                                                                                                    framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10), QuantizationInfo(1.f / 127.f, -10) }),
-                                                                                                                    framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -5), QuantizationInfo(1.f / 127.f, -10) })))
+                                                                                                                    make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10), QuantizationInfo(1.f / 127.f, -10) }),
+                                                                                                                    make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -5), QuantizationInfo(1.f / 127.f, -10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8_s);
 }
 FIXTURE_DATA_TEST_CASE(RunMixedDataLayout, CLPoolingLayerQuantizedMixedDataLayoutFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallNoneUnitShapes(),
-                       framework::dataset::make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
-                                                       framework::dataset::make("PoolingSize", { Size2D(2, 2) }),
-                                               framework::dataset::make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
-                                       framework::dataset::make("ExcludePadding", { true }),
-                               framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
-                       framework::dataset::make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) }),
-                       framework::dataset::make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) })))
+                       make("PoolingType", { PoolingType::MAX, PoolingType::AVG }),
+                                                       make("PoolingSize", { Size2D(2, 2) }),
+                                               make("PadStride", { PadStrideInfo(1, 2, 1, 1) }),
+                                       make("ExcludePadding", { true }),
+                               make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataLayout", { DataLayout::NHWC, DataLayout::NCHW }),
+                       make("InputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) }),
+                       make("OutputQuantInfo", { QuantizationInfo(1.f / 127.f, -10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8_s);

--- a/tests/validation/CL/PriorBoxLayer.cpp
+++ b/tests/validation/CL/PriorBoxLayer.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<float> tolerance_f32(0.00001f); /**< Tolerance value for comparing reference's output against implementation's output for DataType::F32 */
@@ -55,19 +56,19 @@ using CLPriorBoxLayerFixture = PriorBoxLayerValidationFixture<CLTensor, CLAccess
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("Input1Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("Input1Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32),    // Window shrink
                                                      }),
-               framework::dataset::make("Input2Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32),
+               make("Input2Info", { TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(10U, 10U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(1200U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(1200U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1000U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("PriorBoxInfo",{ PriorBoxLayerInfo(std::vector<float>(1), std::vector<float>(1), 0, true, true, std::vector<float>(1), std::vector<float>(1), Coordinates2D{8, 8}, std::array<float, 2>()),
+               make("PriorBoxInfo",{ PriorBoxLayerInfo(std::vector<float>(1), std::vector<float>(1), 0, true, true, std::vector<float>(1), std::vector<float>(1), Coordinates2D{8, 8}, std::array<float, 2>()),
                                                          PriorBoxLayerInfo(std::vector<float>(1), std::vector<float>(1), 0, true, true, std::vector<float>(1), std::vector<float>(1), Coordinates2D{8, 8}, std::array<float, 2>()),
                                                      }),
-               framework::dataset::make("Expected", { true, false})),
+               make("Expected", { true, false})),
                input1_info, input2_info, output_info, info, expected)
 {
     bool has_error = bool(CLPriorBoxLayer::validate(&input1_info.clone()->set_is_resizable(false), &input2_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), info));
@@ -79,15 +80,15 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLPriorBoxLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallPriorBoxLayerDataset(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F32),
-                                                                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::F32),
+                                                                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLPriorBoxLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargePriorBoxLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F32),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataType", DataType::F32),
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32, 0);

--- a/tests/validation/CL/QLSTMLayerNormalization.cpp
+++ b/tests/validation/CL/QLSTMLayerNormalization.cpp
@@ -39,6 +39,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<int16_t> tolerance_s16(0); /**< Tolerance value for comparing reference's output against implementation's output for QSYMM16 data types */
@@ -94,7 +95,7 @@ static const uint32_t    tensor_num_channel{ 1 };
 // clang-format off
 
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL,
-    zip(framework::dataset::make("InputInfo", {
+    zip(make("InputInfo", {
             TensorInfo(correct_input_shape, tensor_num_channel, DataType::F16), // input supports only QSYMM16
             TensorInfo(correct_input_shape, tensor_num_channel, correct_input_dt), // weight supports only QSYMM16
             TensorInfo(correct_input_shape, tensor_num_channel, correct_input_dt), // bias supports only S32
@@ -104,7 +105,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL,
             TensorInfo(correct_input_shape, tensor_num_channel, correct_input_dt), // input_shape[0] != weight_shape[0] should fail
             TensorInfo(correct_input_shape, tensor_num_channel, correct_input_dt), // weight_shape[0] != bias_shape[0] should fail
         }),
-        framework::dataset::make("WeightInfo", {
+        make("WeightInfo", {
             TensorInfo(correct_weight_shape, tensor_num_channel, correct_weight_dt),
             TensorInfo(correct_weight_shape, tensor_num_channel, DataType::F16),
             TensorInfo(correct_weight_shape, tensor_num_channel, correct_weight_dt),
@@ -114,7 +115,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL,
             TensorInfo(TensorShape(14U), tensor_num_channel, correct_weight_dt),
             TensorInfo(correct_weight_shape, tensor_num_channel, correct_weight_dt),
         }),
-        framework::dataset::make("BiasInfo", {
+        make("BiasInfo", {
             TensorInfo(correct_bias_shape, tensor_num_channel, correct_bias_dt),
             TensorInfo(correct_bias_shape, tensor_num_channel, correct_bias_dt),
             TensorInfo(correct_bias_shape, tensor_num_channel, DataType::QSYMM16),
@@ -162,14 +163,14 @@ constexpr uint32_t qsymm16_per_vector = vector_size_byte / sizeof(int16_t);
     combine(zip(QLSTMLayerNormShapeDataSet<qsymm16_per_vector, num_input_batch, num_iter>("InputShape"), \
                             QLSTMLayerNormShapeDataSet<qsymm16_per_vector, 1, num_iter>("WeightShape"),             \
                         QLSTMLayerNormShapeDataSet<qsymm16_per_vector, 1, num_iter>("BiasShape")),                   \
-                    framework::dataset::make("DataType", DataType::QSYMM16),                                        \
-            framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1. / 8192), QuantizationInfo(2) }))
+                    make("DataType", DataType::QSYMM16),                                                            \
+            make("InputQuantizationInfo", { QuantizationInfo(1. / 8192), QuantizationInfo(2) }))
 
 #define QSYMM16_DATASET_1D \
-    concat(concat(QSYMM16_DATASET_ITER(1, 0), QSYMM16_DATASET_ITER(1, 1)), QSYMM16_DATASET_ITER(1, 2))
+    concat(QSYMM16_DATASET_ITER(1, 0), QSYMM16_DATASET_ITER(1, 1), QSYMM16_DATASET_ITER(1, 2))
 
 #define QSYMM16_DATASET_2D \
-    concat(concat(QSYMM16_DATASET_ITER(3, 0), QSYMM16_DATASET_ITER(3, 1)), QSYMM16_DATASET_ITER(3, 2))
+    concat(QSYMM16_DATASET_ITER(3, 0), QSYMM16_DATASET_ITER(3, 1), QSYMM16_DATASET_ITER(3, 2))
 
 FIXTURE_DATA_TEST_CASE(RandomValue1D, CLQLSTMLayerNormalizationFixture<int16_t>, framework::DatasetMode::ALL, QSYMM16_DATASET_1D)
 {

--- a/tests/validation/CL/QuantizationLayer.cpp
+++ b/tests/validation/CL/QuantizationLayer.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<float>    tolerance_f32(1.0f); /**< Tolerance value for comparing reference's output against implementation's output for floating point data types */
@@ -105,17 +106,17 @@ TEST_CASE(ProperlyRoundedRequantizationGt16Elements, framework::DatasetMode::ALL
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Wrong output data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),  // Wrong output data type
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32), // Wrong output data type
                                                        TensorInfo(TensorShape(16U, 16U, 2U, 5U), 1, DataType::F32),   // Mismatching shapes
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32), // Valid
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::U16),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(16U, 16U, 16U, 5U), 1, DataType::QASYMM8),
                                                      }),
-               framework::dataset::make("Expected", { false, false, false, true})),
+               make("Expected", { false, false, false, true})),
                input_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLQuantizationLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -133,41 +134,41 @@ using CLQuantizationLayerQASYMM16Fixture = QuantizationValidationFixture<CLTenso
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, CLQuantizationLayerQASYMM8Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataTypeIn", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8_SIGNED, CLQuantizationLayerQASYMM8_SIGNEDFixture<float>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataTypeIn", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, CLQuantizationLayerQASYMM16Fixture<float>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataTypeIn", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_u16);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeQASYMM8, CLQuantizationLayerQASYMM8Fixture<float>, framework::DatasetMode::NIGHTLY, combine(QuantizationLargeShapes,
-                       framework::dataset::make("DataTypeIn", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataTypeIn", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeQASYMM16, CLQuantizationLayerQASYMM16Fixture<float>, framework::DatasetMode::NIGHTLY, combine(QuantizationLargeShapes,
-                       framework::dataset::make("DataTypeIn", DataType::F32),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataTypeIn", DataType::F32),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_u16);
@@ -176,17 +177,17 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, CLQuantizationLayerQASYMM8Fixture<half>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::F16),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataTypeIn", DataType::F16),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLargeQASYMM8, CLQuantizationLayerQASYMM8Fixture<half>, framework::DatasetMode::NIGHTLY, combine(QuantizationLargeShapes,
-                       framework::dataset::make("DataTypeIn", DataType::F16),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
+                       make("DataTypeIn", DataType::F16),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(0.5f, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -203,28 +204,28 @@ template <typename T>
 using CLQuantizationLayerQASYMM16GenFixture = QuantizationValidationGenericFixture<CLTensor, CLAccessor, CLQuantizationLayer, T, uint16_t>;
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, CLQuantizationLayerQASYMM8GenFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::QASYMM8),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(0.5f, 10) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(2.0f, 15) })))
+                       make("DataType", DataType::QASYMM8),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(0.5f, 10) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(2.0f, 15) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_u8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8_SIGNED, CLQuantizationLayerQASYMM8_SIGNEDGenFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.0f, 15) })))
+                       make("DataTypeIn", DataType::QASYMM8),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(1.0f, 15) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_s8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, CLQuantizationLayerQASYMM16GenFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::QASYMM8),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM16 }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(4.0f, 23) })))
+                       make("DataTypeIn", DataType::QASYMM8),
+                       make("DataTypeOut", { DataType::QASYMM16 }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(4.0f, 23) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_u16);
@@ -232,19 +233,19 @@ FIXTURE_DATA_TEST_CASE(RunSmallQASYMM16, CLQuantizationLayerQASYMM16GenFixture<u
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8_SIGNED, CLQuantizationLayerQASYMM8_SIGNEDGenFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataTypeIn", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
-                       framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
-                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(2.0f, 5) })))
+                       make("DataTypeIn", DataType::QASYMM8_SIGNED),
+                       make("DataTypeOut", { DataType::QASYMM8_SIGNED }),
+                       make("QuantizationInfoOutput", { QuantizationInfo(1.0f, 10) }),
+                       make("QuantizationInfoInput", { QuantizationInfo(2.0f, 5) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_s8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallQASYMM8, CLQuantizationLayerQASYMM8GenFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(QuantizationSmallShapes,
-                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                       framework::dataset::make("DataTypeOut", { DataType::QASYMM8 }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(2.0f, 10) }),
-                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(1.0f, 30) })))
+                       make("DataType", DataType::QASYMM8_SIGNED),
+                       make("DataTypeOut", { DataType::QASYMM8 }),
+                       make("QuantizationInfo", { QuantizationInfo(2.0f, 10) }),
+                       make("QuantizationInfo", { QuantizationInfo(1.0f, 30) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_u8);

--- a/tests/validation/CL/RNNLayer.cpp
+++ b/tests/validation/CL/RNNLayer.cpp
@@ -37,6 +37,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_f32(0.001f);        /**< Relative tolerance value for comparing reference's output against implementation's output for DataType:F32 */
@@ -49,7 +50,7 @@ TEST_SUITE(RNNLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::U8),      // Wrong data type
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::U8),      // Wrong data type
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32), // Wrong input size
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),     // Wrong weights size
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),     // Wrong recurrent weights size
@@ -57,7 +58,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),     // Wrong output size
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),     // Wrong hidden output size
                }),
-               framework::dataset::make("WeightsInfo", { TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
+               make("WeightsInfo", { TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 11U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
@@ -65,7 +66,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                }),
-               framework::dataset::make("RecurrentWeightsInfo", { TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
+               make("RecurrentWeightsInfo", { TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(25U, 11U, 2U), 1, DataType::F32),
@@ -73,7 +74,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                                   TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                                                                   TensorInfo(TensorShape(11U, 11U), 1, DataType::F32),
                }),
-               framework::dataset::make("BiasInfo", { TensorInfo(TensorShape(11U), 1, DataType::F32),
+               make("BiasInfo", { TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
@@ -81,7 +82,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(11U), 1, DataType::F32),
                }),
-               framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
+               make("OutputInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
@@ -89,7 +90,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                         TensorInfo(TensorShape(11U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                }),
-               framework::dataset::make("HiddenStateInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
+               make("HiddenStateInfo", { TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
@@ -97,7 +98,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                              TensorInfo(TensorShape(11U, 13U), 1, DataType::F32),
                                                              TensorInfo(TensorShape(11U, 13U, 2U), 1, DataType::F32),
                }),
-               framework::dataset::make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
+               make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
@@ -105,7 +106,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                                                             ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
                }),
-               framework::dataset::make("Expected", { false, false, false, false, false, false, false })),
+               make("Expected", { false, false, false, false, false, false, false })),
                input_info, weights_info, recurrent_weights_info, bias_info, output_info, hidden_output_info, info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLRNNLayer::validate(&input_info.clone()->set_is_resizable(false), &weights_info.clone()->set_is_resizable(false), &recurrent_weights_info.clone()->set_is_resizable(false), &bias_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), &hidden_output_info.clone()->set_is_resizable(false), info)) == expected, framework::LogLevel::ERRORS);
@@ -117,7 +118,7 @@ template <typename T>
 using CLRNNLayerFixture = RNNLayerValidationFixture<CLTensor, CLAccessor, CLRNNLayer, T>;
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRNNLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRNNLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -125,7 +126,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLRNNLayerFixture<float>, framework::DatasetMod
 TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRNNLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), framework::dataset::make("DataType", DataType::F16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRNNLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallRNNLayerDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, rel_tolerance_f16, 0.f, abs_tolerance_f16);

--- a/tests/validation/CL/ROIAlignLayer.cpp
+++ b/tests/validation/CL/ROIAlignLayer.cpp
@@ -39,6 +39,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr RelativeTolerance<float> relative_tolerance_f32(0.01f);
@@ -56,7 +57,7 @@ TEST_SUITE(RoiAlign)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32),                                         // Mismatching data type input/rois
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32),                                         // Mismatching data type input/output
                                                        TensorInfo(TensorShape(250U, 128U, 2U), 1, DataType::F32),                                         // Mismatching depth size input/output
@@ -66,7 +67,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::QASYMM8, QuantizationInfo(1.f / 255.f, 127)), // Invalid ROIS data type
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::QASYMM8, QuantizationInfo(1.f / 255.f, 127)), // Invalid ROIS Quantization Info
                                                      }),
-               framework::dataset::make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
+               make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
@@ -76,7 +77,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F32),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::QASYMM16, QuantizationInfo(0.2f, 0)),
                                                     }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
@@ -86,7 +87,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::QASYMM8, QuantizationInfo(1.f / 255.f, 120)),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::QASYMM8, QuantizationInfo(1.f / 255.f, 120)),
                                                      }),
-               framework::dataset::make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
+               make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
@@ -95,7 +96,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       }),
-               framework::dataset::make("Expected", { true, false, false, false, false, false, false, false, false })),
+               make("Expected", { true, false, false, false, false, false, false, false, false })),
                input_info, rois_info, output_info, pool_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLROIAlignLayer::validate(&input_info.clone()->set_is_resizable(true), &rois_info.clone()->set_is_resizable(true), &output_info.clone()->set_is_resizable(true), pool_info)) == expected, framework::LogLevel::ERRORS);
@@ -110,8 +111,8 @@ TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(Small, CLROIAlignLayerFloatFixture, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                       framework::dataset::make("DataType", { DataType::F32 }),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                       make("DataType", { DataType::F32 }),
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, relative_tolerance_f32, .02f, absolute_tolerance_f32);
@@ -120,8 +121,8 @@ TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(Small, CLROIAlignLayerHalfFixture, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                       framework::dataset::make("DataType", { DataType::F16 }),
-                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                       make("DataType", { DataType::F16 }),
+                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, relative_tolerance_f16, .02f, absolute_tolerance_f16);
@@ -136,10 +137,10 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(Small, CLROIAlignLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                                       framework::dataset::make("DataType", { DataType::QASYMM8 }),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
-                               framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
+                                                       make("DataType", { DataType::QASYMM8 }),
+                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
+                               make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -148,10 +149,10 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(Small, CLROIAlignLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                                       framework::dataset::make("DataType", { DataType::QASYMM8_SIGNED }),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 65) }),
-                               framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) })))
+                                                       make("DataType", { DataType::QASYMM8_SIGNED }),
+                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 65) }),
+                               make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 20) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8_s);

--- a/tests/validation/CL/ROIPoolingLayer.cpp
+++ b/tests/validation/CL/ROIPoolingLayer.cpp
@@ -38,6 +38,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::combine;
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> relative_tolerance_f32(0.01f);
@@ -51,7 +53,7 @@ TEST_SUITE(RoiPooling)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Successful test
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Successful test
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::QASYMM8), // Successful test (quantized)
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Incorrect rois type
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Mismatching data type input/output
@@ -61,7 +63,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(250U, 128U, 3U), 1, DataType::F32), // Mismatching height and width input/output
 
                                                      }),
-               framework::dataset::make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
+               make("RoisInfo", { TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::F16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
@@ -70,7 +72,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                       TensorInfo(TensorShape(4, 4U), 1, DataType::U16),
                                                       TensorInfo(TensorShape(5, 4U), 1, DataType::U16),
                                                     }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::QASYMM8),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F16),
@@ -79,7 +81,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(7U, 7U, 3U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 5U, 3U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
+               make("PoolInfo", { ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
@@ -88,7 +90,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       ROIPoolingLayerInfo(7U, 7U, 1./8),
                                                       }),
-               framework::dataset::make("Expected", { true, true, false, false, false, false, false })),
+               make("Expected", { true, true, false, false, false, false, false })),
                input_info, rois_info, output_info, pool_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLROIPoolingLayer::validate(&input_info.clone()->set_is_resizable(true), &rois_info.clone()->set_is_resizable(true), &output_info.clone()->set_is_resizable(true), pool_info)) == expected, framework::LogLevel::ERRORS);
@@ -98,9 +100,9 @@ using CLROIPoolingLayerFloatFixture = ROIPoolingLayerFixture<CLTensor, CLAccesso
 
 TEST_SUITE(Float)
 FIXTURE_DATA_TEST_CASE(Small, CLROIPoolingLayerFloatFixture, framework::DatasetMode::ALL,
-                       framework::dataset::combine(framework::dataset::combine(datasets::SmallROIDataset(),
-                                                    framework::dataset::make("DataType", { DataType::F32 })),
-                                                    framework::dataset::make("DataLayout", { DataLayout::NCHW })))
+                       combine(combine(datasets::SmallROIDataset(),
+                                                    make("DataType", { DataType::F32 })),
+                                                    make("DataLayout", { DataLayout::NCHW })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, relative_tolerance_f32, .02f, absolute_tolerance_f32);
@@ -116,10 +118,10 @@ TEST_SUITE(QASYMM8)
 
 FIXTURE_DATA_TEST_CASE(Small, CLROIPoolingLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(datasets::SmallROIDataset(),
-                                                       framework::dataset::make("DataType", { DataType::QASYMM8 }),
-                                               framework::dataset::make("DataLayout", { DataLayout::NCHW }),
-                                       framework::dataset::make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
-                               framework::dataset::make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
+                                                       make("DataType", { DataType::QASYMM8 }),
+                                               make("DataLayout", { DataLayout::NCHW }),
+                                       make("InputQuantizationInfo", { QuantizationInfo(1.f / 255.f, 127) }),
+                               make("OutputQuantizationInfo", { QuantizationInfo(2.f / 255.f, 120) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/CL/Range.cpp
+++ b/tests/validation/CL/Range.cpp
@@ -41,15 +41,16 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr RelativeTolerance<float> tolerance(0.01f);
 constexpr AbsoluteTolerance<float> abs_tolerance(0.02f);
-const auto                         start_dataset          = framework::dataset::make("Start", { float(3), float(-17), float(16) });
-const auto                         unsigned_start_dataset = framework::dataset::make("Start", { float(3), float(16) });
-const auto                         float_step_dataset     = framework::dataset::make("Step", { float(1), float(-0.2f), float(0.2), float(12.2), float(-12.2), float(-1.2), float(-3), float(3) });
-const auto                         step_dataset           = framework::dataset::make("Step", { float(1), float(12), float(-12), float(-1), float(-3), float(3) });
-const auto                         unsigned_step_dataset  = framework::dataset::make("Step", { float(1), float(12), float(3) });
+const auto                         start_dataset          = make("Start", { float(3), float(-17), float(16) });
+const auto                         unsigned_start_dataset = make("Start", { float(3), float(16) });
+const auto                         float_step_dataset     = make("Step", { float(1), float(-0.2f), float(0.2), float(12.2), float(-12.2), float(-1.2), float(-3), float(3) });
+const auto                         step_dataset           = make("Step", { float(1), float(12), float(-12), float(-1), float(-3), float(3) });
+const auto                         unsigned_step_dataset  = make("Step", { float(1), float(12), float(3) });
 } // namespace
 
 TEST_SUITE(CL)
@@ -58,7 +59,7 @@ TEST_SUITE(Range)
 // *INDENT-OFF*
 // clang-format off
 
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("OutputInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(27U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(32U), 1, DataType::U8),
@@ -67,10 +68,10 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                         TensorInfo(TensorShape(27U), 1, DataType::U8),
                                                         TensorInfo(TensorShape(10U), 1, DataType::U8),
                                                       }),
-               framework::dataset::make("Start",{ 0.0f, 15.0f, 1500.0f, 100.0f, -15.0f, 0.2f , 2.0f , 10.0f}),
-               framework::dataset::make("End",{ 100.0f, 15.0f, 2500.0f, -1000.0f, 15.0f, 10.0f, 10.0f,100.0f }),
-               framework::dataset::make("Step",{ 100.0f, 15.0f, 10.0f, 100.0f, -15.0f, 1.0f, 0.0f, 10.0f }),
-               framework::dataset::make("Expected", { false, //1-D tensor expected
+               make("Start",{ 0.0f, 15.0f, 1500.0f, 100.0f, -15.0f, 0.2f , 2.0f , 10.0f}),
+               make("End",{ 100.0f, 15.0f, 2500.0f, -1000.0f, 15.0f, 10.0f, 10.0f,100.0f }),
+               make("Step",{ 100.0f, 15.0f, 10.0f, 100.0f, -15.0f, 1.0f, 0.0f, 10.0f }),
+               make("Expected", { false, //1-D tensor expected
                                                     false, //start == end
                                                     false, //output vector size insufficient
                                                     false, //sign of step incorrect
@@ -90,10 +91,10 @@ template <typename T>
 using CLRangeFixture = RangeFixture<CLTensor, CLAccessor, CLRange, T>;
 
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(framework::dataset::make("DataType", DataType::U8),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(make("DataType", DataType::U8),
                                                                                                                  unsigned_start_dataset,
                                                                                                              unsigned_step_dataset,
-                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                     make("QuantizationInfo", { QuantizationInfo() })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance, 0.f, abs_tolerance);
@@ -103,10 +104,10 @@ TEST_SUITE_END() //U8
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(framework::dataset::make("DataType", DataType::QASYMM8),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(make("DataType", DataType::QASYMM8),
                                                                                                                  start_dataset,
                                                                                                              step_dataset,
-                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.3457f, 120.0f) })))
+                                                                                                     make("QuantizationInfo", { QuantizationInfo(0.3457f, 120.0f) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance, 0.f, abs_tolerance);
@@ -115,10 +116,10 @@ TEST_SUITE_END() //QASYMM8
 TEST_SUITE_END() //Quantized
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(framework::dataset::make("DataType", DataType::S16),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(make("DataType", DataType::S16),
                                                                                                                  start_dataset,
                                                                                                              step_dataset,
-                                                                                                     framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                     make("QuantizationInfo", { QuantizationInfo() })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance, 0.f, abs_tolerance);
@@ -127,10 +128,10 @@ TEST_SUITE_END() //S16
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<half>, framework::DatasetMode::PRECOMMIT, combine(framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<half>, framework::DatasetMode::PRECOMMIT, combine(make("DataType", DataType::F16),
                                                                                                               start_dataset,
                                                                                                           float_step_dataset,
-                                                                                                  framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                  make("QuantizationInfo", { QuantizationInfo() })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance, 0.f, abs_tolerance);
@@ -138,10 +139,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<half>, framework::DatasetMode::P
 TEST_SUITE_END() //FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<float>, framework::DatasetMode::PRECOMMIT, combine(framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRangeFixture<float>, framework::DatasetMode::PRECOMMIT, combine(make("DataType", DataType::F32),
                                                                                                                start_dataset,
                                                                                                            float_step_dataset,
-                                                                                                   framework::dataset::make("QuantizationInfo", { QuantizationInfo() })))
+                                                                                                   make("QuantizationInfo", { QuantizationInfo() })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance, 0.f, abs_tolerance);

--- a/tests/validation/CL/ReduceMean.cpp
+++ b/tests/validation/CL/ReduceMean.cpp
@@ -39,37 +39,38 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 constexpr AbsoluteTolerance<float>   tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for 32-bit floating-point type */
 constexpr AbsoluteTolerance<float>   tolerance_f16(0.03f);  /**< Tolerance value for comparing reference's output against implementation's output for 16-bit floating-point type */
 constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);  /**< Tolerance value for comparing reference's output against implementation's output for 8-bit asymmetric quantized type */
 
-const auto axis_keep = combine(framework::dataset::make("Axis", { Coordinates(0), Coordinates(1, 0), Coordinates(1, 2), Coordinates(0, 2), Coordinates(1, 3), Coordinates(2, 3), Coordinates(0, 1, 2, 3) }),
-                               framework::dataset::make("KeepDims", { true }));
-const auto axis_drop = combine(framework::dataset::make("Axis", { Coordinates(0), Coordinates(1), Coordinates(3), Coordinates(1, 2), Coordinates(2, 1) }), framework::dataset::make("KeepDims", { false }));
+const auto axis_keep = combine(make("Axis", { Coordinates(0), Coordinates(1, 0), Coordinates(1, 2), Coordinates(0, 2), Coordinates(1, 3), Coordinates(2, 3), Coordinates(0, 1, 2, 3) }),
+                               make("KeepDims", { true }));
+const auto axis_drop = combine(make("Axis", { Coordinates(0), Coordinates(1), Coordinates(3), Coordinates(1, 2), Coordinates(2, 1) }), make("KeepDims", { false }));
 } // namespace
 TEST_SUITE(CL)
 TEST_SUITE(ReduceMean)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid output shape
                                                 TensorInfo(TensorShape(32U, 16U, 16U, 2U), 1, DataType::F32),// OK
                                                 TensorInfo(TensorShape{228U, 19U, 2U, 2U}, 1, DataType::F32),// OK
                                                 TensorInfo(TensorShape{228U, 19U, 2U, 1U}, 1, DataType::F32) // Cannot support axis 3 not valid
         }),
-        framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
+        make("OutputInfo", { TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(27U, 3U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(32U, 16U, 1U, 2U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(19U), 1, DataType::F32),
                                                  TensorInfo(TensorShape(19U), 1, DataType::F32)
 
         }),
-        framework::dataset::make("Axis", { Coordinates(4), Coordinates(0,2), Coordinates(2), Coordinates(3,2,0), Coordinates(3,2,0) }),
-        framework::dataset::make("Keep", { true, true, true, false, false }),
-        framework::dataset::make("Expected", { false, false, true, true, false })),
+        make("Axis", { Coordinates(4), Coordinates(0,2), Coordinates(2), Coordinates(3,2,0), Coordinates(3,2,0) }),
+        make("Keep", { true, true, true, false, false }),
+        make("Expected", { false, false, true, true, false })),
         input_info, output_info, axis, keep, expected)
 {
     const Status status = CLReduceMean::validate(&input_info.clone()->set_is_resizable(false), axis, keep, &output_info.clone()->set_is_resizable(false));
@@ -86,7 +87,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLReduceMeanFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -95,7 +96,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLReduceMeanFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::F16), concat(axis_keep, axis_drop)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -106,7 +107,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLReduceMeanFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -115,7 +116,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLReduceMeanFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::F32), concat(axis_keep, axis_drop)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -131,9 +132,9 @@ TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLReduceMeanQuantizedFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -143,9 +144,9 @@ TEST_SUITE(Requant)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLReduceMeanQuantizedFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), axis_drop,
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 200, 16) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8), axis_drop,
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 200, 16) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -155,9 +156,9 @@ TEST_SUITE_END() // Requant
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLReduceMeanQuantizedFixture<uint8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::QASYMM8), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 255, 5) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 255, 5) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -168,9 +169,9 @@ TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLReduceMeanQuantizedFixture<int8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 102, 2) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 102, 2) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -180,9 +181,9 @@ TEST_SUITE(Requant)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLReduceMeanQuantizedFixture<int8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), axis_drop,
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 113, 10) })))
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), axis_drop,
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 113, 10) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -192,9 +193,9 @@ TEST_SUITE_END() // Requant
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLReduceMeanQuantizedFixture<int8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::Large4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
-                                       framework::dataset::make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
-                               framework::dataset::make("QuantizationInfoOutput", { QuantizationInfo(1.f / 102, 2) })))
+                       combine(datasets::Large4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), concat(axis_keep, axis_drop),
+                                       make("QuantizationInfoInput", { QuantizationInfo(1.f / 102, 2) }),
+                               make("QuantizationInfoOutput", { QuantizationInfo(1.f / 102, 2) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/CL/ReductionOperation.cpp
+++ b/tests/validation/CL/ReductionOperation.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Tolerance for float operations */
@@ -50,20 +51,20 @@ RelativeTolerance<float> rel_tolerance_f16(0.2f);
 /** Tolerance for quantized operations */
 RelativeTolerance<float> tolerance_qasymm8(1);
 
-const auto ReductionOperationsSumProdMean = framework::dataset::make("ReductionOperationsSumProdMean",
+const auto ReductionOperationsSumProdMean = make("ReductionOperationsSumProdMean",
 {
     ReductionOperation::SUM,
     ReductionOperation::PROD,
     ReductionOperation::MEAN_SUM
 
 });
-const auto ReductionOperationsMinMax = framework::dataset::make("ReductionMinMax",
+const auto ReductionOperationsMinMax = make("ReductionMinMax",
 {
     ReductionOperation::MIN,
     ReductionOperation::MAX,
 });
 
-const auto KeepDimensions = framework::dataset::make("KeepDims", { true, false });
+const auto KeepDimensions = make("KeepDims", { true, false });
 } // namespace
 
 TEST_SUITE(CL)
@@ -71,7 +72,7 @@ TEST_SUITE(ReductionOperation)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",          { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",          { TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Mismatching data type input/output
                                                      TensorInfo(TensorShape(128U, 64U), 3, DataType::F32), // Number of Input channels != 1
                                                      TensorInfo(TensorShape(128U, 64U), 1, DataType::S16), // DataType != QASYMM8/F16/F32
                                                      TensorInfo(TensorShape(128U, 64U), 1, DataType::F32), // Axis >= num_max_dimensions
@@ -80,7 +81,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                      TensorInfo(TensorShape(128U, 64U), 1, DataType::F32) // Kept Dimension when keep_dims = false
 
                                                    }),
-    framework::dataset::make("OutputInfo",         { TensorInfo(TensorShape(1U, 64U), 1, DataType::F16),
+    make("OutputInfo",         { TensorInfo(TensorShape(1U, 64U), 1, DataType::F16),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::S16),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32),
@@ -88,9 +89,9 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32),
                                                      TensorInfo(TensorShape(1U, 64U), 1, DataType::F32)
                                                    }),
-    framework::dataset::make("Axis",               { 0U, 0U, 0U, static_cast<unsigned int>(TensorShape::num_max_dimensions), 1U, 0U, 0U }),
-    framework::dataset::make("KeepDims",           { true, true, true, true, true, true, false }),
-    framework::dataset::make("Expected",           { false, false, false, false, false, true , false })),
+    make("Axis",               { 0U, 0U, 0U, static_cast<unsigned int>(TensorShape::num_max_dimensions), 1U, 0U, 0U }),
+    make("KeepDims",           { true, true, true, true, true, true, false }),
+    make("Expected",           { false, false, false, false, false, true , false })),
     input_info, output_info, axis, keep_dims, expected)
 {
     bool is_valid = bool(CLReductionOperation::validate(&input_info.clone()->set_is_resizable(false),
@@ -109,7 +110,7 @@ using CLReductionOperationFixture = ReductionOperationFixture<CLTensor, CLAccess
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall4D, CLReductionOperationFixture<half>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F16), framework::dataset::make("Axis", { 0, 1, 2, 3 }),
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F16), make("Axis", { 0, 1, 2, 3 }),
                                        concat(ReductionOperationsSumProdMean,
                                               ReductionOperationsMinMax),
                                KeepDimensions))
@@ -118,7 +119,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall4D, CLReductionOperationFixture<half>, framework:
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLReductionOperationFixture<half>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F16), framework::dataset::make("Axis", { 0, 1, 2, 3 }), concat(ReductionOperationsSumProdMean,
+                       combine(datasets::LargeShapes(), make("DataType", DataType::F16), make("Axis", { 0, 1, 2, 3 }), concat(ReductionOperationsSumProdMean,
                                        ReductionOperationsMinMax),
                                KeepDimensions))
 {
@@ -128,7 +129,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLReductionOperationFixture<half>, framework::D
 TEST_SUITE_END() // F16
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall4D, CLReductionOperationFixture<float>, framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::F32), framework::dataset::make("Axis", { 0, 1, 2, 3 }),
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::F32), make("Axis", { 0, 1, 2, 3 }),
                                        concat(ReductionOperationsSumProdMean,
                                               ReductionOperationsMinMax),
                                KeepDimensions))
@@ -137,7 +138,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall4D, CLReductionOperationFixture<float>, framework
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLReductionOperationFixture<float>, framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F32), framework::dataset::make("Axis", { 0, 1, 2, 3 }), concat(ReductionOperationsSumProdMean,
+                       combine(datasets::LargeShapes(), make("DataType", DataType::F32), make("Axis", { 0, 1, 2, 3 }), concat(ReductionOperationsSumProdMean,
                                        ReductionOperationsMinMax),
                                KeepDimensions))
 {
@@ -153,18 +154,18 @@ using CLReductionOperationQuantizedFixture = ReductionOperationQuantizedFixture<
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLReductionOperationQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("Axis", { 0, 1, 2, 3 }),
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8), make("Axis", { 0, 1, 2, 3 }),
                                                ReductionOperationsSumProdMean,
-                                       framework::dataset::make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
+                                       make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
                                KeepDimensions))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallMinMax, CLReductionOperationQuantizedFixture<uint8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8), framework::dataset::make("Axis", { 0, 1, 2, 3 }),
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8), make("Axis", { 0, 1, 2, 3 }),
                                                ReductionOperationsMinMax,
-                                       framework::dataset::make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
+                                       make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
                                KeepDimensions))
 {
     // Validate output
@@ -173,18 +174,18 @@ FIXTURE_DATA_TEST_CASE(RunSmallMinMax, CLReductionOperationQuantizedFixture<uint
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLReductionOperationQuantizedFixture<int8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("Axis", { 0, 1, 2, 3 }),
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), make("Axis", { 0, 1, 2, 3 }),
                                                ReductionOperationsSumProdMean,
-                                       framework::dataset::make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
+                                       make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
                                KeepDimensions))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunSmallMinMax, CLReductionOperationQuantizedFixture<int8_t>, framework::DatasetMode::ALL,
-                       combine(datasets::Small4DShapes(), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED), framework::dataset::make("Axis", { 0, 1, 2, 3 }),
+                       combine(datasets::Small4DShapes(), make("DataType", DataType::QASYMM8_SIGNED), make("Axis", { 0, 1, 2, 3 }),
                                                ReductionOperationsMinMax,
-                                       framework::dataset::make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
+                                       make("QuantizationInfo", QuantizationInfo(1.f / 64, 2)),
                                KeepDimensions))
 {
     // Validate output

--- a/tests/validation/CL/ReorgLayer.cpp
+++ b/tests/validation/CL/ReorgLayer.cpp
@@ -39,25 +39,26 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(ReorgLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::S64),    // Wrong output tensor
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::S64),    // Wrong output tensor
                                                        TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(10U, 12U, 1U, 2U), 1, DataType::F32),    // Wrong output tensor
                                                        TensorInfo(TensorShape(3U, 12U, 4U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(3U, 12U, 4U, 2U), 1, DataType::F32),     // Wrong data type
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::S64),
+               make("OutputInfo",{ TensorInfo(TensorShape(3U, 4U, 10U, 2U), 1, DataType::S64),
                                                        TensorInfo(TensorShape(5U, 6U, 4U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(5U, 6U, 2, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 4U, 36U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(1U, 4U, 36U, 2U), 1, DataType::F16),
                                                      }),
-               framework::dataset::make("Stride", { 2, 2, 4, 3 }),
-               framework::dataset::make("Expected", { false, true, false, true, false })),
+               make("Stride", { 2, 2, 4, 3 }),
+               make("Expected", { false, true, false, true, false })),
                input_info, output_info, stride, expected)
 {
     bool status = bool(CLReorgLayer::validate(&input_info, &output_info, stride));
@@ -70,17 +71,17 @@ template <typename T>
 using CLReorgLayerFixture = ReorgLayerValidationFixture<CLTensor, CLAccessor, CLReorgLayer, T>;
 
 TEST_SUITE(S32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReorgLayerFixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReorgLayerFixture<int32_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), make("DataType",
                                                                                                                   DataType::S32),
-                                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int32_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), make("DataType",
                                                                                                                 DataType::S32),
-                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -88,17 +89,17 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int32_t>, framework::Datase
 TEST_SUITE_END() // S32
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReorgLayerFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReorgLayerFixture<int16_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), make("DataType",
                                                                                                                   DataType::S16),
-                                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int16_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), make("DataType",
                                                                                                                 DataType::S16),
-                                                                                                        framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                        make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -106,16 +107,16 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int16_t>, framework::Datase
 TEST_SUITE_END() // S16
 
 TEST_SUITE(S8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReorgLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReorgLayerFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallReorgLayerDataset(), make("DataType",
                                                                                                                  DataType::S8),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), framework::dataset::make("DataType", DataType::S8),
-                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLReorgLayerFixture<int8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeReorgLayerDataset(), make("DataType", DataType::S8),
+                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/ReshapeLayer.cpp
+++ b/tests/validation/CL/ReshapeLayer.cpp
@@ -41,27 +41,28 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(ReshapeLayer)
 
 // *INDENT-OFF*
 // clang-format off
 
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",
 {
     TensorInfo(TensorShape(9U, 5U, 7U, 3U), 1, DataType::F32),
     TensorInfo(TensorShape(8U, 4U, 6U, 4U), 1, DataType::F32),
     TensorInfo(TensorShape(8U, 4U, 6U, 4U), 1, DataType::F32), // mismatching dimensions
     TensorInfo(TensorShape(9U, 5U, 7U, 3U), 1, DataType::F16), // mismatching types
 }),
-framework::dataset::make("OutputInfo",
+make("OutputInfo",
 {
     TensorInfo(TensorShape(9U, 5U, 21U), 1, DataType::F32),
     TensorInfo(TensorShape(8U, 24U, 4U), 1, DataType::F32),
     TensorInfo(TensorShape(192U, 192U),  1, DataType::F32),
     TensorInfo(TensorShape(9U, 5U, 21U), 1, DataType::F32),
 }),
-framework::dataset::make("Expected", { true, true, false, false })),
+make("Expected", { true, true, false, false })),
 input_info, output_info, expected)
 {
     // Create Fully Connected layer info
@@ -78,7 +79,7 @@ using CLReshapeLayerFixture = ReshapeLayerValidationFixture<CLTensor, CLAccessor
 
 TEST_SUITE(Float)
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::F32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -86,7 +87,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<float>, framework::Datase
 TEST_SUITE_END()
 
 TEST_SUITE(F16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType",
                                                                                                    DataType::F16)))
 {
     // Validate output
@@ -97,7 +98,7 @@ TEST_SUITE_END()
 
 TEST_SUITE(Integer)
 TEST_SUITE(U8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", { DataType::U8, DataType::QASYMM8 })))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", { DataType::U8, DataType::QASYMM8 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -105,7 +106,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<uint8_t>, framework::Data
 TEST_SUITE_END()
 
 TEST_SUITE(S8)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::S8)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::S8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -113,7 +114,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<int8_t>, framework::Datas
 TEST_SUITE_END()
 
 TEST_SUITE(S16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), framework::dataset::make("DataType", DataType::S16)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLReshapeLayerFixture<int16_t>, framework::DatasetMode::ALL, combine(datasets::SmallReshapeLayerDataset(), make("DataType", DataType::S16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/RoundLayer.cpp
+++ b/tests/validation/CL/RoundLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Arm Limited.
+ * Copyright (c) 2019, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(RoundLayer)
 template <typename T>
@@ -47,13 +48,13 @@ using CLRoundLayerFixture = RoundValidationFixture<CLTensor, CLAccessor, CLRound
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRoundLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRoundLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                        DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLRoundLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLRoundLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     // Validate output
@@ -62,13 +63,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLRoundLayerFixture<half>, framework::DatasetMo
 
 TEST_SUITE_END() // FP16
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRoundLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRoundLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                         DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLRoundLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLRoundLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output

--- a/tests/validation/CL/RsqrtLayer.cpp
+++ b/tests/validation/CL/RsqrtLayer.cpp
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float>             tolerance_fp32(0.000001f);
@@ -53,15 +54,15 @@ TEST_SUITE(RsqrtLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),     // Valid
                                                        TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(30U, 11U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { false, true, false })),
+               make("Expected", { false, true, false })),
                input_info, output_info, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLRsqrtLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false))) == expected, framework::LogLevel::ERRORS);
@@ -75,13 +76,13 @@ using CLRsqrtLayerQuantizedFixture = RsqrtQuantizedValidationFixture<CLTensor, C
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                        DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp16);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLRsqrtLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLRsqrtLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     // Validate output
@@ -90,13 +91,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLRsqrtLayerFixture<half>, framework::DatasetMo
 
 TEST_SUITE_END() // FP16
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                         DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLRsqrtLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLRsqrtLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output
@@ -108,10 +109,10 @@ TEST_SUITE_END() // Float
 
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8_SIGNED)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerQuantizedFixture<int8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                   DataType::QASYMM8_SIGNED),
-                                                                                                                  framework::dataset::make("SrcQInfo", { QuantizationInfo(0.4044, -128) }),
-                                                                                                                  framework::dataset::make("OutQInfo", { QuantizationInfo(0.0027, -128) })))
+                                                                                                                  make("SrcQInfo", { QuantizationInfo(0.4044, -128) }),
+                                                                                                                  make("OutQInfo", { QuantizationInfo(0.0027, -128) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8_s);
@@ -119,10 +120,10 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerQuantizedFixture<int8_t>, framework
 TEST_SUITE_END() // QASYMM8_SIGNED
 TEST_SUITE(QASYMM8)
 
-FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLRsqrtLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                                    DataType::QASYMM8),
-                                                                                                                   framework::dataset::make("SrcQInfo", { QuantizationInfo(0.4044, 0) }),
-                                                                                                                   framework::dataset::make("OutQInfo", { QuantizationInfo(0.0027, 0) })))
+                                                                                                                   make("SrcQInfo", { QuantizationInfo(0.4044, 0) }),
+                                                                                                                   make("OutQInfo", { QuantizationInfo(0.0027, 0) })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);

--- a/tests/validation/CL/Scale.cpp
+++ b/tests/validation/CL/Scale.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Arm Limited.
+ * Copyright (c) 2017-2021, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 using datasets::ScaleShapesBaseDataSet;
@@ -61,7 +62,7 @@ constexpr uint32_t num_elements_per_vector()
 }
 
 /** CNN data types */
-const auto ScaleDataTypes = framework::dataset::make("DataType",
+const auto ScaleDataTypes = make("DataType",
 {
     DataType::U8,
     DataType::S16,
@@ -70,7 +71,7 @@ const auto ScaleDataTypes = framework::dataset::make("DataType",
 });
 
 /** Quantization information data set */
-const auto QuantizationInfoSet = framework::dataset::make("QuantizationInfo",
+const auto QuantizationInfoSet = make("QuantizationInfo",
 {
     QuantizationInfo(0.5f, -1),
 });
@@ -206,7 +207,7 @@ using CLScaleMixedDataLayoutFixture = ScaleValidationFixture<CLTensor, CLAccesso
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-const auto f32_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<float>())), framework::dataset::make("DataType", DataType::F32));
+const auto f32_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<float>())), make("DataType", DataType::F32));
 FIXTURE_DATA_TEST_CASE(Run, CLScaleFixture<float>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(f32_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -234,7 +235,7 @@ FIXTURE_DATA_TEST_CASE(RunAlignCorners, CLScaleFixture<float>, framework::Datase
     // Validate output
     validate(CLAccessor(_target), _reference, valid_region, tolerance_f32, tolerance_num_f32, tolerance_f32_absolute);
 }
-const auto f32_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<float>())), framework::dataset::make("DataType", DataType::F32));
+const auto f32_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<float>())), make("DataType", DataType::F32));
 FIXTURE_DATA_TEST_CASE(RunNightly, CLScaleFixture<float>, framework::DatasetMode::NIGHTLY, ASSEMBLE_DATASET(f32_nightly_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -255,7 +256,7 @@ FIXTURE_DATA_TEST_CASE(RunNightlyAlignCorners, CLScaleFixture<float>, framework:
 }
 TEST_SUITE_END() // FP32
 TEST_SUITE(FP16)
-const auto f16_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<half>())), framework::dataset::make("DataType", DataType::F16));
+const auto f16_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<half>())), make("DataType", DataType::F16));
 FIXTURE_DATA_TEST_CASE(Run, CLScaleFixture<half>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(f16_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -274,7 +275,7 @@ FIXTURE_DATA_TEST_CASE(RunAlignCorners, CLScaleFixture<half>, framework::Dataset
     // Validate output
     validate(CLAccessor(_target), _reference, valid_region, tolerance_f16, 0.0f, abs_tolerance_f16);
 }
-const auto f16_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<half>())), framework::dataset::make("DataType", DataType::F16));
+const auto f16_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<half>())), make("DataType", DataType::F16));
 FIXTURE_DATA_TEST_CASE(RunNightly, CLScaleFixture<half>, framework::DatasetMode::NIGHTLY, ASSEMBLE_DATASET(f16_nightly_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -298,7 +299,7 @@ TEST_SUITE_END() // Float
 
 TEST_SUITE(Integer)
 TEST_SUITE(U8)
-const auto u8_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), framework::dataset::make("DataType", DataType::U8));
+const auto u8_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), make("DataType", DataType::U8));
 FIXTURE_DATA_TEST_CASE(Run, CLScaleFixture<uint8_t>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(u8_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -317,7 +318,7 @@ FIXTURE_DATA_TEST_CASE(RunAlignCorners, CLScaleFixture<uint8_t>, framework::Data
     // Validate output
     validate(CLAccessor(_target), _reference, valid_region, tolerance_q8);
 }
-const auto u8_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), framework::dataset::make("DataType", DataType::U8));
+const auto u8_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), make("DataType", DataType::U8));
 FIXTURE_DATA_TEST_CASE(RunNightly, CLScaleFixture<uint8_t>, framework::DatasetMode::NIGHTLY, ASSEMBLE_DATASET(u8_nightly_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -338,7 +339,7 @@ FIXTURE_DATA_TEST_CASE(RunNightlyAlignCorners, CLScaleFixture<uint8_t>, framewor
 }
 TEST_SUITE_END() // U8
 TEST_SUITE(S16)
-const auto s16_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<int16_t>())), framework::dataset::make("DataType", DataType::S16));
+const auto s16_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<int16_t>())), make("DataType", DataType::S16));
 FIXTURE_DATA_TEST_CASE(Run, CLScaleFixture<int16_t>, framework::DatasetMode::ALL, ASSEMBLE_DATASET(s16_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -357,7 +358,7 @@ FIXTURE_DATA_TEST_CASE(RunAlignCorners, CLScaleFixture<int16_t>, framework::Data
     // Validate output
     validate(CLAccessor(_target), _reference, valid_region, tolerance_s16);
 }
-const auto s16_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<int16_t>())), framework::dataset::make("DataType", DataType::S16));
+const auto s16_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<int16_t>())), make("DataType", DataType::S16));
 FIXTURE_DATA_TEST_CASE(RunNightly, CLScaleFixture<int16_t>, framework::DatasetMode::NIGHTLY, ASSEMBLE_DATASET(s16_nightly_shape, ScaleSamplingPolicySet))
 {
     //Create valid region
@@ -383,7 +384,7 @@ template <typename T>
 using CLScaleQuantizedFixture = ScaleValidationQuantizedFixture<CLTensor, CLAccessor, CLScale, T>;
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
-const auto qasymm8_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), framework::dataset::make("DataType", DataType::QASYMM8));
+const auto qasymm8_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), make("DataType", DataType::QASYMM8));
 FIXTURE_DATA_TEST_CASE(Run, CLScaleQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, ASSEMBLE_QUANTIZED_DATASET(qasymm8_shape, ScaleSamplingPolicySet, QuantizationInfoSet))
 {
     //Create valid region
@@ -403,7 +404,7 @@ FIXTURE_DATA_TEST_CASE(RunAlignCorners, CLScaleQuantizedFixture<uint8_t>, framew
     // Validate output
     validate(CLAccessor(_target), _reference, valid_region, tolerance_q8);
 }
-const auto qasymm8_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), framework::dataset::make("DataType", DataType::QASYMM8));
+const auto qasymm8_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<uint8_t>())), make("DataType", DataType::QASYMM8));
 FIXTURE_DATA_TEST_CASE(RunNightly, CLScaleQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, ASSEMBLE_QUANTIZED_DATASET(qasymm8_nightly_shape, ScaleSamplingPolicySet, QuantizationInfoSet))
 {
     //Create valid region
@@ -425,7 +426,7 @@ FIXTURE_DATA_TEST_CASE(RunNightlyAlignCorners, CLScaleQuantizedFixture<uint8_t>,
 }
 TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
-const auto qasymm8_signed_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<int8_t>())), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED));
+const auto qasymm8_signed_shape = combine((SCALE_PRECOMMIT_SHAPE_DATASET(num_elements_per_vector<int8_t>())), make("DataType", DataType::QASYMM8_SIGNED));
 FIXTURE_DATA_TEST_CASE(Run, CLScaleQuantizedFixture<int8_t>, framework::DatasetMode::ALL, ASSEMBLE_QUANTIZED_DATASET(qasymm8_signed_shape, ScaleSamplingPolicySet, QuantizationInfoSet))
 {
     //Create valid region
@@ -445,7 +446,7 @@ FIXTURE_DATA_TEST_CASE(RunAlignCorners, CLScaleQuantizedFixture<int8_t>, framewo
     // Validate output
     validate(CLAccessor(_target), _reference, valid_region, tolerance_qs8);
 }
-const auto qasymm8_signed_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<int8_t>())), framework::dataset::make("DataType", DataType::QASYMM8_SIGNED));
+const auto qasymm8_signed_nightly_shape = combine((SCALE_NIGHTLY_SHAPE_DATASET(num_elements_per_vector<int8_t>())), make("DataType", DataType::QASYMM8_SIGNED));
 FIXTURE_DATA_TEST_CASE(RunNightly, CLScaleQuantizedFixture<int8_t>, framework::DatasetMode::NIGHTLY, ASSEMBLE_QUANTIZED_DATASET(qasymm8_signed_nightly_shape, ScaleSamplingPolicySet,
                        QuantizationInfoSet))
 {

--- a/tests/validation/CL/ScatterLayer.cpp
+++ b/tests/validation/CL/ScatterLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Arm Limited.
+ * Copyright (c) 2024-2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -39,6 +39,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_f32(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for fp32 data type */
@@ -49,7 +50,6 @@ RelativeTolerance<int32_t> tolerance_int(0); /**< Tolerance value for comparing 
 template <typename T>
 using CLScatterLayerFixture = ScatterValidationFixture<CLTensor, CLAccessor, CLScatter, T>;
 
-using framework::dataset::make;
 
 TEST_SUITE(CL)
 TEST_SUITE(Scatter)

--- a/tests/validation/CL/Select.cpp
+++ b/tests/validation/CL/Select.cpp
@@ -41,10 +41,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-auto run_small_dataset = combine(datasets::SmallShapes(), framework::dataset::make("has_same_rank", { false, true }));
-auto run_large_dataset = combine(datasets::LargeShapes(), framework::dataset::make("has_same_rank", { false, true }));
+auto run_small_dataset = combine(datasets::SmallShapes(), make("has_same_rank", { false, true }));
+auto run_large_dataset = combine(datasets::LargeShapes(), make("has_same_rank", { false, true }));
 
 } // namespace
 TEST_SUITE(CL)
@@ -52,35 +53,35 @@ TEST_SUITE(Select)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("CInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S8), // Invalid condition datatype
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("CInfo", { TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S8), // Invalid condition datatype
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8), // Invalid output datatype
                                             TensorInfo(TensorShape(13U), 1, DataType::U8),          // Invalid c shape
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8), // Mismatching shapes
                                             TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                             TensorInfo(TensorShape(2U), 1, DataType::U8),
         }),
-        framework::dataset::make("XInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+        make("XInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 10U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("YInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+        make("YInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
+        make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::S8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::U8),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
         }),
-        framework::dataset::make("Expected", { false, false, false, false, true, true})),
+        make("Expected", { false, false, false, false, true, true})),
         c_info, x_info, y_info, output_info, expected)
 {
     Status s = CLSelect::validate(&c_info.clone()->set_is_resizable(false),
@@ -100,7 +101,7 @@ TEST_SUITE(F16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLSelectFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_small_dataset, make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -109,9 +110,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunOneDim,
                        CLSelectFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(framework::dataset::make("Shape", TensorShape(1U, 16U)),
-                                       framework::dataset::make("has_same_rank", { false, true }),
-                               framework::dataset::make("DataType", DataType::F16)))
+                       combine(make("Shape", TensorShape(1U, 16U)),
+                                       make("has_same_rank", { false, true }),
+                               make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -120,7 +121,7 @@ FIXTURE_DATA_TEST_CASE(RunOneDim,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLSelectFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F16)))
+                       combine(run_large_dataset, make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -131,7 +132,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLSelectFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_small_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -140,9 +141,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunOneDim,
                        CLSelectFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(framework::dataset::make("Shape", TensorShape(1U, 16U)),
-                                       framework::dataset::make("has_same_rank", { false, true }),
-                               framework::dataset::make("DataType", DataType::F32)))
+                       combine(make("Shape", TensorShape(1U, 16U)),
+                                       make("has_same_rank", { false, true }),
+                               make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -151,7 +152,7 @@ FIXTURE_DATA_TEST_CASE(RunOneDim,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLSelectFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::F32)))
+                       combine(run_large_dataset, make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -164,7 +165,7 @@ TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLSelectFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(run_small_dataset, framework::dataset::make("DataType", DataType::QASYMM8)))
+                       combine(run_small_dataset, make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -173,9 +174,9 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunOneDim,
                        CLSelectFixture<uint8_t>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(framework::dataset::make("Shape", TensorShape(1U, 16U)),
-                                       framework::dataset::make("has_same_rank", { false, true }),
-                               framework::dataset::make("DataType", DataType::QASYMM8)))
+                       combine(make("Shape", TensorShape(1U, 16U)),
+                                       make("has_same_rank", { false, true }),
+                               make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -184,7 +185,7 @@ FIXTURE_DATA_TEST_CASE(RunOneDim,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLSelectFixture<uint8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(run_large_dataset, framework::dataset::make("DataType", DataType::QASYMM8)))
+                       combine(run_large_dataset, make("DataType", DataType::QASYMM8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/SinLayer.cpp
+++ b/tests/validation/CL/SinLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Arm Limited.
+ * Copyright (c) 2019, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,6 +40,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 RelativeTolerance<float> tolerance_fp32(0.000001f);
@@ -52,13 +53,13 @@ using CLSinLayerFixture = SinValidationFixture<CLTensor, CLAccessor, CLSinLayer,
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLSinLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLSinLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                      DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp16);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLSinLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLSinLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                    DataType::F16)))
 {
     // Validate output
@@ -67,13 +68,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLSinLayerFixture<half>, framework::DatasetMode
 
 TEST_SUITE_END() // FP16
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLSinLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLSinLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType",
                                                                                                       DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_fp32);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLSinLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLSinLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType",
                                                                                                     DataType::F32)))
 {
     // Validate output

--- a/tests/validation/CL/Slice.cpp
+++ b/tests/validation/CL/Slice.cpp
@@ -40,19 +40,20 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Slice)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Negative begin
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Big number of coordinates
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Starts", { Coordinates(3, 1, 0), Coordinates(-3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
-        framework::dataset::make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, 3, 1) }),
-        framework::dataset::make("Expected", { false, false, false, true })),
+        make("Starts", { Coordinates(3, 1, 0), Coordinates(-3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
+        make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, 3, 1) }),
+        make("Expected", { false, false, false, true })),
         input_info, starts, ends, expected)
 {
     TensorInfo output_info;
@@ -70,7 +71,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLSliceFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallSliceDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -79,7 +80,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLSliceFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeSliceDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -90,7 +91,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLSliceFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -99,7 +100,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLSliceFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/SoftmaxLayer.cpp
+++ b/tests/validation/CL/SoftmaxLayer.cpp
@@ -46,6 +46,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 /** Tolerance for float operations */
@@ -57,7 +58,7 @@ constexpr AbsoluteTolerance<uint8_t> tolerance_qasymm8(1);
 constexpr AbsoluteTolerance<int8_t>  tolerance_qasymm8_signed(1);
 
 /** CNN data types */
-const auto CNNDataTypes = framework::dataset::make("DataType",
+const auto CNNDataTypes = make("DataType",
 {
     DataType::QASYMM8,
     DataType::F16,
@@ -111,7 +112,7 @@ TEST_CASE(SimpleMemoryManaged, framework::DatasetMode::ALL)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),    // Mismatching data types
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::F32),    // Mismatching shapes
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::QASYMM8, // Invalid output quantization info
                                                                   QuantizationInfo(1.f/256, 12)),
@@ -125,7 +126,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::QASYMM8_SIGNED, // Invalid axis low
                                                                   QuantizationInfo(1.f/256, 12))
                                                       }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U), 1, DataType::F16),
+               make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(27U, 11U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(27U, 13U), 1, DataType::QASYMM8,
                                                                   QuantizationInfo(1.f/256, 12)),
@@ -139,7 +140,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                        TensorInfo(TensorShape(32U, 13U), 1, DataType::QASYMM8_SIGNED,
                                                                   QuantizationInfo(1.f/256, -128)),
                                                      }),
-               framework::dataset::make("beta", { 1.0,
+               make("beta", { 1.0,
                                                   2.0,
                                                   1.0,
                                                   2.0,
@@ -148,7 +149,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                   1.0,
                                                   2.0,
                                                 }),
-               framework::dataset::make("axis", {
+               make("axis", {
                                                   0,
                                                   0,
                                                   0,
@@ -158,7 +159,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
                                                   2,
                                                   -3,
                                                 }),
-               framework::dataset::make("Expected", { false, false, false, true, true, true, false, false })),
+               make("Expected", { false, false, false, true, true, true, false, false })),
                input_info, output_info, beta, axis, expected)
 {
     ARM_COMPUTE_EXPECT(bool(CLSoftmaxLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), beta, axis)) == expected, framework::LogLevel::ERRORS);
@@ -172,25 +173,25 @@ using CLSoftmaxLayerFixture = SoftmaxValidationFixture<CLTensor, CLAccessor, CLS
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLSoftmaxLayerFixture<half>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F16),
-                                                                                                           framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                   framework::dataset::make("Axis", { 0, -1 })))
+                                                                                                                   make("DataType", DataType::F16),
+                                                                                                           make("Beta", { 1.0f, 2.0f }),
+                                                                                                   make("Axis", { 0, -1 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLSoftmaxLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::F16),
-                                                                                                               framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                       framework::dataset::make("Axis", { 0 })))
+                                                                                                                       make("DataType", DataType::F16),
+                                                                                                               make("Beta", { 1.0f, 2.0f }),
+                                                                                                       make("Axis", { 0 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
 }
 FIXTURE_DATA_TEST_CASE(Run4D, CLSoftmaxLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayer4DShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::F16),
-                                                                                                            framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                    framework::dataset::make("Axis", { 0, -1, 2 })))
+                                                                                                                    make("DataType", DataType::F16),
+                                                                                                            make("Beta", { 1.0f, 2.0f }),
+                                                                                                    make("Axis", { 0, -1, 2 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f16);
@@ -199,25 +200,25 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLSoftmaxLayerFixture<float>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                    framework::dataset::make("DataType", DataType::F32),
-                                                                                                            framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                    framework::dataset::make("Axis", { 0, 1 })))
+                                                                                                                    make("DataType", DataType::F32),
+                                                                                                            make("Beta", { 1.0f, 2.0f }),
+                                                                                                    make("Axis", { 0, 1 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLSoftmaxLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                        framework::dataset::make("DataType", DataType::F32),
-                                                                                                                framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                        framework::dataset::make("Axis", { 0 })))
+                                                                                                                        make("DataType", DataType::F32),
+                                                                                                                make("Beta", { 1.0f, 2.0f }),
+                                                                                                        make("Axis", { 0 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
 }
 FIXTURE_DATA_TEST_CASE(Run4D, CLSoftmaxLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayer4DShapes(),
-                                                                                                                     framework::dataset::make("DataType", DataType::F32),
-                                                                                                             framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                     framework::dataset::make("Axis", { 0, -2, 3 })))
+                                                                                                                     make("DataType", DataType::F32),
+                                                                                                             make("Beta", { 1.0f, 2.0f }),
+                                                                                                     make("Axis", { 0, -2, 3 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_f32);
@@ -231,28 +232,28 @@ using CLSoftmaxLayerQuantizedFixture = SoftmaxValidationQuantizedFixture<CLTenso
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLSoftmaxLayerQuantizedFixture<uint8_t>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
-                                                                                                                               framework::dataset::make("Beta", { 1.0f, 2.f }),
-                                                                                                               framework::dataset::make("Axis", { 0, 1 })))
+                                                                                                                       make("DataType", DataType::QASYMM8),
+                                                                                                                       make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
+                                                                                                                               make("Beta", { 1.0f, 2.f }),
+                                                                                                               make("Axis", { 0, 1 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLSoftmaxLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayerLargeShapes(),
-                                                                                                                   framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                   framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
-                                                                                                                           framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                                   framework::dataset::make("Axis", { 0 })))
+                                                                                                                   make("DataType", DataType::QASYMM8),
+                                                                                                                   make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
+                                                                                                                           make("Beta", { 1.0f, 2.0f }),
+                                                                                                                   make("Axis", { 0 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
 }
 FIXTURE_DATA_TEST_CASE(Run4D, CLSoftmaxLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::SoftmaxLayer4DShapes(),
-                                                                                                                        framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                        framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
-                                                                                                                                framework::dataset::make("Beta", { 1.0f, 2.0f }),
-                                                                                                                framework::dataset::make("Axis", { 0, -4, 1 })))
+                                                                                                                        make("DataType", DataType::QASYMM8),
+                                                                                                                        make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
+                                                                                                                                make("Beta", { 1.0f, 2.0f }),
+                                                                                                                make("Axis", { 0, -4, 1 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8);
@@ -263,10 +264,10 @@ TEST_SUITE_END() // QASYMM8
 TEST_SUITE(QASYMM8_SIGNED)
 
 FIXTURE_DATA_TEST_CASE(RunSmall, CLSoftmaxLayerQuantizedFixture<int8_t>, framework::DatasetMode::ALL, combine(datasets::SoftmaxLayerSmallShapes(),
-                                                                                                                      framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                      framework::dataset::make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
-                                                                                                                              framework::dataset::make("Beta", { 1.0f, 2.f }),
-                                                                                                              framework::dataset::make("Axis", { 0, 1 })))
+                                                                                                                      make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                      make("QuantizationInfo", { QuantizationInfo(0.5f, -10) }),
+                                                                                                                              make("Beta", { 1.0f, 2.f }),
+                                                                                                              make("Axis", { 0, 1 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference, tolerance_qasymm8_signed);

--- a/tests/validation/CL/SpaceToBatchLayer.cpp
+++ b/tests/validation/CL/SpaceToBatchLayer.cpp
@@ -42,6 +42,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(SpaceToBatchLayer)
 
@@ -50,49 +51,49 @@ using CLSpaceToBatchLayerFixture = SpaceToBatchLayerValidationFixture<CLTensor, 
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),    // Wrong data type block shape
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U, 4U), 1, DataType::F32),    // Wrong tensor shape
                                                      }),
-               framework::dataset::make("BlockShapeInfo",{ TensorInfo(TensorShape(2U), 1, DataType::S32),
+               make("BlockShapeInfo",{ TensorInfo(TensorShape(2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(2U), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("PaddingsShapeInfo",{ TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
+               make("PaddingsShapeInfo",{ TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
                                                        TensorInfo(TensorShape(2U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(2U, 2U), 1, DataType::S32),
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 13U, 2U, 2U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false})),
+               make("Expected", { true, false, false, false})),
                input_info, block_shape_info, paddings_info, output_info, expected)
 {
     bool has_error = bool(CLSpaceToBatchLayer::validate(&input_info.clone()->set_is_resizable(false), &block_shape_info.clone()->set_is_resizable(false), &paddings_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false)));
     ARM_COMPUTE_EXPECT(has_error == expected, framework::LogLevel::ERRORS);
 }
-DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
+DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Negative block shapes
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U, 4U), 1, DataType::F32), // Wrong tensor shape
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U, 4U), 1, DataType::F32), // Wrong paddings
                                                      }),
-               framework::dataset::make("BlockShapeX", { 2, 2, 2, 2, 2 }),
-               framework::dataset::make("BlockShapeY", { 2, 2, -2, 2, 2 }),
-               framework::dataset::make("PadLeft", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
-               framework::dataset::make("PadRight", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
+               make("BlockShapeX", { 2, 2, 2, 2, 2 }),
+               make("BlockShapeY", { 2, 2, -2, 2, 2 }),
+               make("PadLeft", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
+               make("PadRight", { Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(0, 0), Size2D(3, 11) }),
+               make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 2U, 4U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("Expected", { true, false, false, false, false})),
+               make("Expected", { true, false, false, false, false})),
                input_info, block_shape_x, block_shape_y, padding_left, padding_right, output_info, expected)
 {
     bool has_error = bool(CLSpaceToBatchLayer::validate(&input_info.clone()->set_is_resizable(false), block_shape_x, block_shape_y, padding_left, padding_right, &output_info.clone()->set_is_resizable(false)));
@@ -104,15 +105,15 @@ DATA_TEST_CASE(ValidateStatic, framework::DatasetMode::ALL, zip(framework::datas
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(Small, CLSpaceToBatchLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToBatchLayerDataset(),
-                                                                                                                    framework::dataset::make("DataType", DataType::F32),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                    make("DataType", DataType::F32),
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(Large, CLSpaceToBatchLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToBatchLayerDataset(),
-                                                                                                                  framework::dataset::make("DataType", DataType::F32),
-                                                                                                          framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                  make("DataType", DataType::F32),
+                                                                                                          make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -121,15 +122,15 @@ TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(Small, CLSpaceToBatchLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToBatchLayerDataset(),
-                                                                                                                   framework::dataset::make("DataType", DataType::F16),
-                                                                                                           framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                   make("DataType", DataType::F16),
+                                                                                                           make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(Large, CLSpaceToBatchLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToBatchLayerDataset(),
-                                                                                                                 framework::dataset::make("DataType", DataType::F16),
-                                                                                                         framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                                 make("DataType", DataType::F16),
+                                                                                                         make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -143,17 +144,17 @@ using CLSpaceToBatchLayerQuantizedFixture = SpaceToBatchLayerValidationQuantized
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(Small, CLSpaceToBatchLayerQuantizedFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToBatchLayerDataset(),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                       framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                       framework::dataset::make("QuantizationInfo", { 1.f / 255.f, 9.f })))
+                                                                                                                       make("DataType", DataType::QASYMM8),
+                                                                                                                       make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                       make("QuantizationInfo", { 1.f / 255.f, 9.f })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(Large, CLSpaceToBatchLayerQuantizedFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToBatchLayerDataset(),
-                                                                                                                     framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
-                                                                                                                     framework::dataset::make("QuantizationInfo", { 1.f / 255.f, 9.f })))
+                                                                                                                     make("DataType", DataType::QASYMM8),
+                                                                                                                     make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC }),
+                                                                                                                     make("QuantizationInfo", { 1.f / 255.f, 9.f })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/SpaceToDepthLayer.cpp
+++ b/tests/validation/CL/SpaceToDepthLayer.cpp
@@ -41,6 +41,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(SpaceToDepthLayer)
 
@@ -49,18 +50,18 @@ using CLSpaceToDepthLayerFixture = SpaceToDepthLayerValidationFixture<CLTensor, 
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Mismatching data types
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U), 1, DataType::F32),    // Negative block shapes
                                                        TensorInfo(TensorShape(32U, 16U, 2U, 1U, 4U), 1, DataType::F32), // Wrong tensor shape
                                                      }),
-               framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 8U, 1U), 1, DataType::F32),
+               make("OutputInfo",{ TensorInfo(TensorShape(16U, 8U, 8U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 8U, 1U), 1, DataType::F16),
                                                        TensorInfo(TensorShape(32U, 8U, 8U, 1U), 1, DataType::F32),
                                                        TensorInfo(TensorShape(32U, 8U, 8U, 1U), 1, DataType::F32),
                                                      }),
-               framework::dataset::make("BlockShape", { 2, 2, -2, 2 }),
-               framework::dataset::make("Expected", { true, false, false, false})),
+               make("BlockShape", { 2, 2, -2, 2 }),
+               make("Expected", { true, false, false, false})),
                input_info, output_info, block_shape, expected)
 {
     bool has_error = bool(CLSpaceToDepthLayer::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), block_shape));
@@ -71,16 +72,16 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
 
 TEST_SUITE(Float)
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLSpaceToDepthLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLSpaceToDepthLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                        DataType::F32),
-                                                                                                               framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                               make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLSpaceToDepthLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLSpaceToDepthLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                      DataType::F32),
-                                                                                                             framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                             make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -88,16 +89,16 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLSpaceToDepthLayerFixture<float>, framework::D
 TEST_SUITE_END() // FP32
 
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLSpaceToDepthLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunSmall, CLSpaceToDepthLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                       DataType::F16),
-                                                                                                              framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                              make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLSpaceToDepthLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLSpaceToDepthLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeSpaceToDepthLayerDataset(), make("DataType",
                                                                                                                     DataType::F16),
-                                                                                                            framework::dataset::make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
+                                                                                                            make("DataLayout", { DataLayout::NCHW, DataLayout::NHWC })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/Split.cpp
+++ b/tests/validation/CL/Split.cpp
@@ -40,18 +40,19 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Split)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid axis
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32), // Invalid number of splits
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Axis", { 4, 2, 2 }),
-        framework::dataset::make("Splits", { 4, 5, 4 }),
-        framework::dataset::make("Expected", { false, false, true })),
+        make("Axis", { 4, 2, 2 }),
+        make("Splits", { 4, 5, 4 }),
+        make("Expected", { false, false, true })),
         input_info, axis, splits, expected)
 {
     std::vector<TensorInfo> outputs_info(splits);
@@ -65,16 +66,16 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
     ARM_COMPUTE_EXPECT(bool(status) == expected, framework::LogLevel::ERRORS);
 }
 
-DATA_TEST_CASE(ValidateSplitShapes, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32),
+DATA_TEST_CASE(ValidateSplitShapes, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(27U, 3U, 16U, 2U), 1, DataType::F32)
         }),
-        framework::dataset::make("Axis", { 2, 2 }),
-        framework::dataset::make("Splits", { std::vector<TensorInfo>{TensorInfo(TensorShape(27U, 3U, 4U,  2U), 1, DataType::F32),
+        make("Axis", { 2, 2 }),
+        make("Splits", { std::vector<TensorInfo>{TensorInfo(TensorShape(27U, 3U, 4U,  2U), 1, DataType::F32),
                                                                      TensorInfo(TensorShape(27U, 3U, 4U,  2U), 1, DataType::F32),
                                                                      TensorInfo(TensorShape(27U, 3U, 8U,  2U), 1, DataType::F32)},
                                              std::vector<TensorInfo>{TensorInfo(TensorShape(27U, 3U, 3U,  2U), 1, DataType::F32),
                                                                      TensorInfo(TensorShape(27U, 3U, 13U, 2U), 1, DataType::F32)} }),
-        framework::dataset::make("Expected", { true, true })),
+        make("Expected", { true, true })),
         input_info, axis, splits, expected)
 {
     std::vector<ITensorInfo*> outputs_info_ptr;
@@ -100,7 +101,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLSplitFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSplitDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallSplitDataset(), make("DataType", DataType::F16)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)
@@ -112,7 +113,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLSplitFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSplitDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeSplitDataset(), make("DataType", DataType::F16)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)
@@ -124,7 +125,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
 FIXTURE_DATA_TEST_CASE(RunSmallSplitShapes,
                        CLSplitShapesFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSplitShapesDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallSplitShapesDataset(), make("DataType", DataType::F16)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)
@@ -138,7 +139,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLSplitFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSplitDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallSplitDataset(), make("DataType", DataType::F32)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)
@@ -150,7 +151,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLSplitFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeSplitDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeSplitDataset(), make("DataType", DataType::F32)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)
@@ -162,7 +163,7 @@ FIXTURE_DATA_TEST_CASE(RunLarge,
 FIXTURE_DATA_TEST_CASE(RunSmallSplitShapes,
                        CLSplitShapesFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallSplitShapesDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallSplitShapesDataset(), make("DataType", DataType::F32)))
 {
     // Validate outputs
     for(unsigned int i = 0; i < _target.size(); ++i)

--- a/tests/validation/CL/StackLayer.cpp
+++ b/tests/validation/CL/StackLayer.cpp
@@ -45,36 +45,37 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
 // *INDENT-OFF*
 // clang-format off
 /** Num tensors values to test */
-const auto n_values = framework::dataset::make("NumTensors", { 3, 4 });
+const auto n_values = make("NumTensors", { 3, 4 });
 
 /** Shapes 1D to test */
-const auto shapes_1d_small = combine(datasets::Small1DShapes(), framework::dataset::make("Axis", -1, 2));
+const auto shapes_1d_small = combine(datasets::Small1DShapes(), make("Axis", -1, 2));
 
 /** Shapes 2D to test */
-const auto shapes_2d_small = combine(datasets::Small2DShapes(), framework::dataset::make("Axis", -2, 3));
+const auto shapes_2d_small = combine(datasets::Small2DShapes(), make("Axis", -2, 3));
 
 /** Shapes 3D to test */
-const auto shapes_3d_small = combine(datasets::Small3DShapes(), framework::dataset::make("Axis", -3, 4));
+const auto shapes_3d_small = combine(datasets::Small3DShapes(), make("Axis", -3, 4));
 
 /** Shapes 4D to test */
-const auto shapes_4d_small = combine(datasets::Small4DShapes(), framework::dataset::make("Axis", -4, 5));
+const auto shapes_4d_small = combine(datasets::Small4DShapes(), make("Axis", -4, 5));
 
 /** Shapes 1D to test */
-const auto shapes_1d_large = combine(datasets::Large1DShapes(), framework::dataset::make("Axis", -1, 2));
+const auto shapes_1d_large = combine(datasets::Large1DShapes(), make("Axis", -1, 2));
 
 /** Shapes 2D to test */
-const auto shapes_2d_large = combine(datasets::Medium2DShapes(), framework::dataset::make("Axis", -2, 3));
+const auto shapes_2d_large = combine(datasets::Medium2DShapes(), make("Axis", -2, 3));
 
 /** Shapes 3D to test */
-const auto shapes_3d_large = combine(datasets::Medium3DShapes(), framework::dataset::make("Axis", -3, 4));
+const auto shapes_3d_large = combine(datasets::Medium3DShapes(), make("Axis", -3, 4));
 
 /** Shapes 4D to test */
-const auto shapes_4d_large = combine(datasets::Medium4DShapes(), framework::dataset::make("Axis", -4, 5));
+const auto shapes_4d_large = combine(datasets::Medium4DShapes(), make("Axis", -4, 5));
 } // namespace
 
 /** Fixture to use */
@@ -88,20 +89,20 @@ TEST_SUITE(StackLayer)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { std::vector<TensorInfo>{ TensorInfo(TensorShape(9U, 8U), 1, DataType::U8) },
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { std::vector<TensorInfo>{ TensorInfo(TensorShape(9U, 8U), 1, DataType::U8) },
                          std::vector<TensorInfo>{ TensorInfo(TensorShape(1U, 2U), 1, DataType::U8) , TensorInfo(TensorShape(1U, 2U), 1, DataType::U8), TensorInfo(TensorShape(1U, 2U), 1, DataType::U8)},
                          std::vector<TensorInfo>{ TensorInfo(TensorShape(2U, 3U), 1, DataType::S32) },
                          std::vector<TensorInfo>{ TensorInfo(TensorShape(7U, 5U, 3U, 8U, 2U), 1, DataType::S32), TensorInfo(TensorShape(7U, 5U, 3U, 8U, 2U), 1, DataType::S32)},
                          std::vector<TensorInfo>{ TensorInfo(TensorShape(9U, 8U), 1, DataType::S32) },
                          }),
-                         framework::dataset::make("OutputInfo", { TensorInfo(TensorShape(1U, 9U, 8U), 1, DataType::U8),   // Passes, stack 1 tensor on x axis
+                         make("OutputInfo", { TensorInfo(TensorShape(1U, 9U, 8U), 1, DataType::U8),   // Passes, stack 1 tensor on x axis
                                                                   TensorInfo(TensorShape(1U, 3U, 2U), 1, DataType::U8),   // Passes, stack 3 tensors on y axis
                                                                   TensorInfo(TensorShape(1U, 2U, 3U), 1, DataType::S32),  // fails axis <  (- input's rank)
                                                                   TensorInfo(TensorShape(3U, 7U, 5U), 1, DataType::S32),  // fails, input dimensions > 4
                                                                   TensorInfo(TensorShape(1U, 2U, 3U), 1, DataType::U8),   // fails mismatching data types
                          }),
-                         framework::dataset::make("Axis", { -3, 1, -4, -3, 1 }),
-                         framework::dataset::make("Expected", { true, true, false, false, false })),
+                         make("Axis", { -3, 1, -4, -3, 1 }),
+                         make("Expected", { true, true, false, false, false })),
                          input_info, output_info, axis, expected)
 {
     std::vector<TensorInfo>    ti(input_info);
@@ -119,7 +120,7 @@ TEST_SUITE(Shapes1D)
 TEST_SUITE(S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMode::ALL,
                        combine(shapes_1d_small,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -128,7 +129,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMod
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<int>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_1d_large,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -139,7 +140,7 @@ TEST_SUITE_END() // S32
 TEST_SUITE(S16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetMode::ALL,
                        combine(shapes_1d_small,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -148,7 +149,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetM
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<short>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_1d_large,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -159,7 +160,7 @@ TEST_SUITE_END() // S16
 TEST_SUITE(S8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMode::ALL,
                        combine(shapes_1d_small,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output
@@ -168,7 +169,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMo
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<char>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_1d_large,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output
@@ -181,7 +182,7 @@ TEST_SUITE(Shapes2D)
 TEST_SUITE(S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMode::ALL,
                        combine(shapes_2d_small,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -190,7 +191,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMod
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<int>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_2d_large,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -201,7 +202,7 @@ TEST_SUITE_END() // S32
 TEST_SUITE(S16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetMode::ALL,
                        combine(shapes_2d_small,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -210,7 +211,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetM
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<short>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_2d_large,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -221,7 +222,7 @@ TEST_SUITE_END() // S16
 TEST_SUITE(S8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMode::ALL,
                        combine(shapes_2d_small,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output
@@ -230,7 +231,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMo
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<char>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_2d_large,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output
@@ -243,7 +244,7 @@ TEST_SUITE(Shapes3D)
 TEST_SUITE(S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMode::ALL,
                        combine(shapes_3d_small,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -252,7 +253,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMod
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<int>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_3d_large,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -263,7 +264,7 @@ TEST_SUITE_END() // S32
 TEST_SUITE(S16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetMode::ALL,
                        combine(shapes_3d_small,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -272,7 +273,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetM
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<short>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_3d_large,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -283,7 +284,7 @@ TEST_SUITE_END() // S16
 TEST_SUITE(S8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMode::ALL,
                        combine(shapes_3d_small,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output
@@ -292,7 +293,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMo
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<char>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_3d_large,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output
@@ -305,7 +306,7 @@ TEST_SUITE(Shapes4D)
 TEST_SUITE(S32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMode::ALL,
                        combine(shapes_4d_small,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -314,7 +315,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<int>, framework::DatasetMod
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<int>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_4d_large,
-                                       framework::dataset::make("DataType", { DataType::S32 }),
+                                       make("DataType", { DataType::S32 }),
                                n_values))
 {
     // Validate output
@@ -325,7 +326,7 @@ TEST_SUITE_END() // S32
 TEST_SUITE(S16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetMode::ALL,
                        combine(shapes_4d_small,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -334,7 +335,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<short>, framework::DatasetM
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<short>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_4d_large,
-                                       framework::dataset::make("DataType", { DataType::S16 }),
+                                       make("DataType", { DataType::S16 }),
                                n_values))
 {
     // Validate output
@@ -345,7 +346,7 @@ TEST_SUITE_END() // S16
 TEST_SUITE(S8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMode::ALL,
                        combine(shapes_4d_small,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output
@@ -354,7 +355,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLStackLayerFixture<char>, framework::DatasetMo
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CLStackLayerFixture<char>, framework::DatasetMode::NIGHTLY,
                        combine(shapes_4d_large,
-                                       framework::dataset::make("DataType", { DataType::S8 }),
+                                       make("DataType", { DataType::S8 }),
                                n_values))
 {
     // Validate output

--- a/tests/validation/CL/StridedSlice.cpp
+++ b/tests/validation/CL/StridedSlice.cpp
@@ -41,21 +41,22 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(StridedSlice)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(27U, 3U, 2U, 5U, 3U), 1, DataType::F32), // Invalid input shape
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Zero stride
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Big number of coordinates
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32),         // Invalid Coords/Strides
                                                 TensorInfo(TensorShape(27U, 3U, 2U), 1, DataType::F32)
                                               }),
-        framework::dataset::make("Starts", { Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
-        framework::dataset::make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, -1, 1), Coordinates(13, 3, 1) }),
-        framework::dataset::make("Strides", { BiStrides(2, 1, 1),  BiStrides(2, 0, 1), BiStrides(2, 1, 1), BiStrides(2, -1, 1), BiStrides(2, 1, 1) }),
-        framework::dataset::make("Expected", { false, false, false, false, true })),
+        make("Starts", { Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0), Coordinates(3, 1, 0) }),
+        make("Ends", { Coordinates(13, 3, 0),  Coordinates(13, 3, 1), Coordinates(13, 3, 1, 1), Coordinates(13, -1, 1), Coordinates(13, 3, 1) }),
+        make("Strides", { BiStrides(2, 1, 1),  BiStrides(2, 0, 1), BiStrides(2, 1, 1), BiStrides(2, -1, 1), BiStrides(2, 1, 1) }),
+        make("Expected", { false, false, false, false, true })),
         input_info, starts, ends, strides, expected)
 {
     TensorInfo output_info;
@@ -72,7 +73,7 @@ TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLStridedSliceFixture<half>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallStridedSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::SmallStridedSliceDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -81,7 +82,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLStridedSliceFixture<half>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeStridedSliceDataset(), framework::dataset::make("DataType", DataType::F16)))
+                       combine(datasets::LargeStridedSliceDataset(), make("DataType", DataType::F16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -92,7 +93,7 @@ TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall,
                        CLStridedSliceFixture<float>,
                        framework::DatasetMode::PRECOMMIT,
-                       combine(datasets::SmallStridedSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::SmallStridedSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -101,7 +102,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
 FIXTURE_DATA_TEST_CASE(RunLarge,
                        CLStridedSliceFixture<float>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(datasets::LargeStridedSliceDataset(), framework::dataset::make("DataType", DataType::F32)))
+                       combine(datasets::LargeStridedSliceDataset(), make("DataType", DataType::F32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/Tile.cpp
+++ b/tests/validation/CL/Tile.cpp
@@ -39,9 +39,10 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-const auto MultiplesDataset = framework::dataset::make("Multiples", { Multiples{ 3 },
+const auto MultiplesDataset = make("Multiples", { Multiples{ 3 },
                                                                       Multiples{ 7 },
                                                                       Multiples{ 2, 2 },
                                                                       Multiples{ 1, 1, 3, 4 },
@@ -55,16 +56,16 @@ TEST_SUITE(Tile)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(10, 10), 1, DataType::F32),
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(10, 10), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10, 10), 1, DataType::F32),  // Mismatching shape
                                                 TensorInfo(TensorShape(10, 10), 1, DataType::F16), // Mismatching type
                                                 TensorInfo(TensorShape(10, 10), 1, DataType::F32)}), // Wrong multiples
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(10, 20), 1, DataType::F32),
+        make("OutputInfo",{ TensorInfo(TensorShape(10, 20), 1, DataType::F32),
                                                 TensorInfo(TensorShape(20, 20), 1, DataType::F32),
                                                 TensorInfo(TensorShape(20, 20), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10, 20), 1, DataType::F32)}),
-        framework::dataset::make("Multiples",{ Multiples{1, 2}, Multiples{1, 2}, Multiples{0, 1} }),
-        framework::dataset::make("Expected", {true, false, false, false })),
+        make("Multiples",{ Multiples{1, 2}, Multiples{1, 2}, Multiples{0, 1} }),
+        make("Expected", {true, false, false, false })),
         input_info, output_info, multiples, expected)
 {
     const Status status = CLTile::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), multiples);
@@ -78,13 +79,13 @@ using CLTileFixture = TileValidationFixture<CLTensor, CLAccessor, CLTile, T>;
 
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLTileFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F16),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLTileFixture<half>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F16),
                                                                                                  MultiplesDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLTileFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F16), MultiplesDataset))
+FIXTURE_DATA_TEST_CASE(RunLarge, CLTileFixture<half>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F16), MultiplesDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -92,13 +93,13 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLTileFixture<half>, framework::DatasetMode::NI
 TEST_SUITE_END() // FP16
 
 TEST_SUITE(FP32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLTileFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(RunSmall, CLTileFixture<float>, framework::DatasetMode::PRECOMMIT, combine(datasets::SmallShapes(), make("DataType", DataType::F32),
                                                                                                   MultiplesDataset))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLTileFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), framework::dataset::make("DataType", DataType::F32),
+FIXTURE_DATA_TEST_CASE(RunLarge, CLTileFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::LargeShapes(), make("DataType", DataType::F32),
                                                                                                 MultiplesDataset))
 {
     // Validate output
@@ -111,7 +112,7 @@ TEST_SUITE(Integer)
 TEST_SUITE(S8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLTileFixture<int8_t>, framework::DatasetMode::ALL,
                        combine(
-                           datasets::SmallShapes(), framework::dataset::make("DataType", { DataType::S8 }),
+                           datasets::SmallShapes(), make("DataType", { DataType::S8 }),
                            MultiplesDataset))
 {
     // Validate output
@@ -124,7 +125,7 @@ TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLTileFixture<uint8_t>, framework::DatasetMode::ALL,
                        combine(
-                           datasets::SmallShapes(), framework::dataset::make("DataType", { DataType::QASYMM8 }),
+                           datasets::SmallShapes(), make("DataType", { DataType::QASYMM8 }),
                            MultiplesDataset))
 {
     // Validate output

--- a/tests/validation/CL/Transpose.cpp
+++ b/tests/validation/CL/Transpose.cpp
@@ -41,22 +41,23 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(Transpose)
 
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo", { TensorInfo(TensorShape(21U, 13U), 1, DataType::U16), // Invalid shape
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo", { TensorInfo(TensorShape(21U, 13U), 1, DataType::U16), // Invalid shape
                                             TensorInfo(TensorShape(20U, 13U), 1, DataType::U8),  // Wrong data type
                                             TensorInfo(TensorShape(20U, 16U), 1, DataType::U32), // Valid
                                             TensorInfo(TensorShape(20U, 16U, 3U, 3U), 1, DataType::U16), // Transpose only first two dimensions
                                           }),
-    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(13U, 20U), 1, DataType::U32),
+    make("OutputInfo",{ TensorInfo(TensorShape(13U, 20U), 1, DataType::U32),
                                             TensorInfo(TensorShape(31U, 20U), 1, DataType::U16),
                                             TensorInfo(TensorShape(16U, 20U), 1, DataType::U32),
                                             TensorInfo(TensorShape(16U, 20U, 3U, 3U), 1, DataType::U16),
                                            }),
-    framework::dataset::make("Expected", { false, false, true, true })),
+    make("Expected", { false, false, true, true })),
     a_info, output_info, expected)
 {
     // Lock tensors
@@ -70,13 +71,13 @@ using CLTransposeFixture = TransposeValidationFixture<CLTensor, CLAccessor, CLTr
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLTransposeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
-                                                                                                         framework::dataset::make("DataType", DataType::U8)))
+                                                                                                         make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLTransposeFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
-                                                                                                       framework::dataset::make("DataType", DataType::U8)))
+                                                                                                       make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -84,9 +85,8 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLTransposeFixture<uint8_t>, framework::Dataset
 FIXTURE_DATA_TEST_CASE(RunLargeHighDimensional,
                        CLTransposeFixture<uint8_t>,
                        framework::DatasetMode::NIGHTLY,
-                       combine(concat(concat(datasets::Large3DShapes(), datasets::Large4DShapes()),
-                                      datasets::Large5dShapes()),
-                               framework::dataset::make("DataType", DataType::U8)))
+                       combine(concat(datasets::Large3DShapes(), datasets::Large4DShapes(), datasets::Large5dShapes()),
+                               make("DataType", DataType::U8)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -95,13 +95,13 @@ TEST_SUITE_END() // U8
 
 TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLTransposeFixture<uint16_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
-                                                                                                          framework::dataset::make("DataType", DataType::U16)))
+                                                                                                          make("DataType", DataType::U16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLTransposeFixture<uint16_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
-                                                                                                        framework::dataset::make("DataType", DataType::U16)))
+                                                                                                        make("DataType", DataType::U16)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -109,10 +109,10 @@ FIXTURE_DATA_TEST_CASE(RunLarge, CLTransposeFixture<uint16_t>, framework::Datase
 TEST_SUITE_END() // U16
 
 TEST_SUITE(U32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLTransposeFixture<uint32_t>, framework::DatasetMode::PRECOMMIT, combine(concat(concat(framework::dataset::make("Shape", { TensorShape{ 1U, 5U }, TensorShape{ 4U, 5U }, TensorShape{ 3, 12 } }),
-                                                                                                                        datasets::Small1DShapes()),
-                                                                                                                 datasets::Small2DShapes()),
-                                                                                                          framework::dataset::make("DataType", DataType::U32)))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLTransposeFixture<uint32_t>, framework::DatasetMode::PRECOMMIT, combine(concat(make("Shape", { TensorShape{ 1U, 5U }, TensorShape{ 4U, 5U }, TensorShape{ 3, 12 } }),
+                                                                                                                        datasets::Small1DShapes(),
+                                                                                                                        datasets::Small2DShapes()),
+                                                                                                         make("DataType", DataType::U32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -121,13 +121,13 @@ FIXTURE_DATA_TEST_CASE(RunSmallHighDimensional,
                        CLTransposeFixture<uint32_t>,
                        framework::DatasetMode::PRECOMMIT,
                        combine(concat(datasets::Small3DShapes(), datasets::Small4DShapes()),
-                               framework::dataset::make("DataType", DataType::U32)))
+                               make("DataType", DataType::U32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLTransposeFixture<uint32_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
-                                                                                                        framework::dataset::make("DataType", DataType::U32)))
+                                                                                                        make("DataType", DataType::U32)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/UNIT/DynamicTensor.cpp
+++ b/tests/validation/CL/UNIT/DynamicTensor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Arm Limited.
+ * Copyright (c) 2019-2021, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -47,6 +47,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+using framework::dataset::zip;
 namespace
 {
 constexpr AbsoluteTolerance<float> absolute_tolerance_float(0.0001f); /**< Absolute Tolerance value for comparing reference's output against implementation's output for DataType::F32 */
@@ -76,8 +78,8 @@ using CLDynamicTensorType3SingleFunction = DynamicTensorType3SingleFunction<CLTe
  *  The memory manager should be able to update the inner structures and allocate the requested memory
  * */
 FIXTURE_DATA_TEST_CASE(DynamicTensorType3Single, CLDynamicTensorType3SingleFunction, framework::DatasetMode::ALL,
-                       framework::dataset::zip(framework::dataset::make("Level0Shape", { TensorShape(12U, 11U, 3U), TensorShape(256U, 8U, 12U) }),
-                                               framework::dataset::make("Level1Shape", { TensorShape(67U, 31U, 15U), TensorShape(11U, 2U, 3U) })))
+                       zip(make("Level0Shape", { TensorShape(12U, 11U, 3U), TensorShape(256U, 8U, 12U) }),
+                                               make("Level1Shape", { TensorShape(67U, 31U, 15U), TensorShape(11U, 2U, 3U) })))
 {
     ARM_COMPUTE_EXPECT(internal_l0.size() == internal_l1.size(), framework::LogLevel::ERRORS);
     ARM_COMPUTE_EXPECT(cross_l0.size() == cross_l1.size(), framework::LogLevel::ERRORS);
@@ -116,12 +118,12 @@ using CLDynamicTensorType3ComplexFunction = DynamicTensorType3ComplexFunction<CL
  *  The memory manager should be able to update the inner structures and allocate the requested memory
  * */
 FIXTURE_DATA_TEST_CASE(DynamicTensorType3Complex, CLDynamicTensorType3ComplexFunction, framework::DatasetMode::ALL,
-                       framework::dataset::zip(framework::dataset::zip(framework::dataset::zip(framework::dataset::zip(
-                                                                                                   framework::dataset::make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 16U), TensorShape(64U, 64U, 16U) } }),
-                                                                                                   framework::dataset::make("WeightsManager", { TensorShape(3U, 3U, 16U, 5U) })),
-                                                                                               framework::dataset::make("BiasShape", { TensorShape(5U) })),
-                                                                       framework::dataset::make("OutputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 5U), TensorShape(64U, 64U, 5U) } })),
-                                               framework::dataset::make("PadStrideInfo", { PadStrideInfo(1U, 1U, 1U, 1U) })))
+                       zip(zip(zip(zip(
+                                                                                                   make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 16U), TensorShape(64U, 64U, 16U) } }),
+                                                                                                   make("WeightsManager", { TensorShape(3U, 3U, 16U, 5U) })),
+                                                                                               make("BiasShape", { TensorShape(5U) })),
+                                                                       make("OutputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 5U), TensorShape(64U, 64U, 5U) } })),
+                                               make("PadStrideInfo", { PadStrideInfo(1U, 1U, 1U, 1U) })))
 {
     for(unsigned int i = 0; i < num_iterations; ++i)
     {
@@ -136,7 +138,7 @@ using CLDynamicTensorType2PipelineFunction = DynamicTensorType2PipelineFunction<
  *  Create and manage the tensors needed to run a pipeline. After the function is executed, resize the input size and rerun.
  */
 FIXTURE_DATA_TEST_CASE(DynamicTensorType2Pipeline, CLDynamicTensorType2PipelineFunction, framework::DatasetMode::ALL,
-                       framework::dataset::make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 6U), TensorShape(128U, 128U, 6U) } }))
+                       make("InputShape", { std::vector<TensorShape>{ TensorShape(12U, 12U, 6U), TensorShape(128U, 128U, 6U) } }))
 {
 }
 

--- a/tests/validation/CL/Unstack.cpp
+++ b/tests/validation/CL/Unstack.cpp
@@ -40,17 +40,18 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 namespace
 {
-const auto unstack_axis_dataset  = framework::dataset::make("Axis", -3, 3);
-const auto unstack_num_dataset   = framework::dataset::make("Num", 1, 3); // The length of the dimension axis
+const auto unstack_axis_dataset  = make("Axis", -3, 3);
+const auto unstack_num_dataset   = make("Num", 1, 3); // The length of the dimension axis
 const auto unstack_dataset_small = datasets::Small3DShapes() * unstack_axis_dataset * unstack_num_dataset;
 } //namespace
 
 TEST_SUITE(CL)
 TEST_SUITE(Unstack)
 
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",
 {
     TensorInfo(TensorShape(1U, 9U, 8U), 1, DataType::U8),   // Passes, 1 slice on x axis
     TensorInfo(TensorShape(1U, 2U, 3U), 1, DataType::U8),   // fails because axis > input's rank
@@ -59,15 +60,15 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
     TensorInfo(TensorShape(13U, 7U, 5U), 1, DataType::S16), // fails, too few output slices
     TensorInfo(TensorShape(1U, 2U, 3U), 1, DataType::U8),   // fails mismatching data types
 }),
-framework::dataset::make("OutputInfo",
+make("OutputInfo",
 {
     std::vector<TensorInfo>{ TensorInfo(TensorShape(9U, 8U), 1, DataType::U8) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(2U, 3U), 1, DataType::U8) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(2U, 3U), 1, DataType::S32) },
 
     std::vector<TensorInfo>{ TensorInfo(TensorShape(7U, 5U), 1, DataType::S32), TensorInfo(TensorShape(7U, 5U), 1, DataType::S32), TensorInfo(TensorShape(7U, 5U), 1, DataType::S32) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(7U, 5U), 1, DataType::S16) }, std::vector<TensorInfo>{ TensorInfo(TensorShape(9U, 8U), 1, DataType::S32) },
 }),
-framework::dataset::make("Axis", { -3, 3, -4, -3, 1, 1 }),
-framework::dataset::make("Num", { 1, 1, 1, 1, 0, 1 }),
-framework::dataset::make("Expected", { true, false, false, true, false, false })),
+make("Axis", { -3, 3, -4, -3, 1, 1 }),
+make("Num", { 1, 1, 1, 1, 0, 1 }),
+make("Expected", { true, false, false, true, false, false })),
 input_info, output_info, axis, num, expected)
 {
     std::vector<TensorInfo>    ti(output_info);
@@ -83,7 +84,7 @@ template <typename T>
 using CLUnstackFixture = UnstackValidationFixture<CLTensor, ICLTensor, CLAccessor, CLUnstack, T>;
 
 TEST_SUITE(F32)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<float>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * framework::dataset::make("DataType", { DataType::F32 }))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<float>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * make("DataType", { DataType::F32 }))
 {
     ARM_COMPUTE_ERROR_ON(_target.size() != _reference.size());
     // Validate output
@@ -95,7 +96,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<float>, framework::DatasetMode
 TEST_SUITE_END() // F32
 
 TEST_SUITE(F16)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<half>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * framework::dataset::make("DataType", { DataType::F16 }))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<half>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * make("DataType", { DataType::F16 }))
 {
     ARM_COMPUTE_ERROR_ON(_target.size() != _reference.size());
     // Validate output
@@ -107,7 +108,7 @@ FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<half>, framework::DatasetMode:
 TEST_SUITE_END() // F16
 
 TEST_SUITE(Quantized)
-FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * framework::dataset::make("DataType", { DataType::QASYMM8 }))
+FIXTURE_DATA_TEST_CASE(RunSmall, CLUnstackFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, unstack_dataset_small * make("DataType", { DataType::QASYMM8 }))
 {
     ARM_COMPUTE_ERROR_ON(_target.size() != _reference.size());
     // Validate output

--- a/tests/validation/CL/WeightsReshape.cpp
+++ b/tests/validation/CL/WeightsReshape.cpp
@@ -38,6 +38,7 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(WeightsReshape)
 
@@ -55,7 +56,7 @@ using ClWeightsReshape = ClSynthetizeOperatorWithBorder<opencl::kernels::ClWeigh
  *     - num_groups != 1 is only supported for NCHW data layout
  *     - Bias' shape need to match input's shape.
  */
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo",
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo",
 {
     TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),                   // Mismatching data type
     TensorInfo(TensorShape(3U, 3U, 2U, 4U), 1, DataType::F32),                   // Mismatching data type
@@ -64,7 +65,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::ma
     TensorInfo(TensorShape(3U, 3U, 2U, 4U, 4U), 1, DataType::F32),               // Bias' shape need to match input's shape
     TensorInfo(TensorShape(3U, 3U, 2U, 4U, 4U), 1, DataType::F32),               // Bias' shape need to match input's shape
 }),
-framework::dataset::make("BiasesInfo",
+make("BiasesInfo",
 {
     TensorInfo(TensorShape(4U), 1, DataType::F16),
     TensorInfo(TensorShape(4U), 1, DataType::F32),
@@ -73,7 +74,7 @@ framework::dataset::make("BiasesInfo",
     TensorInfo(TensorShape(4U, 3U), 1, DataType::F32),
     TensorInfo(TensorShape(3U, 4U), 1, DataType::F32),
 }),
-framework::dataset::make("OutputInfo",
+make("OutputInfo",
 {
     TensorInfo(TensorShape(4U, 19U), 1, DataType::F32),
     TensorInfo(TensorShape(4U, 19U), 1, DataType::F16),
@@ -82,8 +83,8 @@ framework::dataset::make("OutputInfo",
     TensorInfo(TensorShape(4U, 19U), 1, DataType::F32),
     TensorInfo(TensorShape(4U, 19U), 1, DataType::F32),
 }),
-framework::dataset::make("NumGroups", { 1, 1, 1, 2, 1, 2 }),
-framework::dataset::make("Expected", { false, false, false, false, false, false })),
+make("NumGroups", { 1, 1, 1, 2, 1, 2 }),
+make("Expected", { false, false, false, false, false, false })),
 input_info, biases_info, output_info, num_groups, expected)
 {
     bool status = bool(opencl::kernels::ClWeightsReshapeKernel::validate(&input_info, &biases_info, &output_info, num_groups));
@@ -94,28 +95,28 @@ template <typename T>
 using ClWeightsReshapeFixture = WeightsReshapeOpValidationFixture<CLTensor, CLAccessor, ClWeightsReshape, T>;
 
 TEST_SUITE(Float)
-FIXTURE_DATA_TEST_CASE(FP32, ClWeightsReshapeFixture<float>, framework::DatasetMode::ALL, combine(framework::dataset::make("InputShape", { TensorShape(3U, 3U, 48U, 120U) }),
-                                                                                                                  framework::dataset::make("DataType", DataType::F32),
-                                                                                                          framework::dataset::make("HasBias", { true, false }),
-                                                                                                  framework::dataset::make("NumGroups", { 1, 2 })))
+FIXTURE_DATA_TEST_CASE(FP32, ClWeightsReshapeFixture<float>, framework::DatasetMode::ALL, combine(make("InputShape", { TensorShape(3U, 3U, 48U, 120U) }),
+                                                                                                                  make("DataType", DataType::F32),
+                                                                                                          make("HasBias", { true, false }),
+                                                                                                  make("NumGroups", { 1, 2 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(FP16, ClWeightsReshapeFixture<half>, framework::DatasetMode::ALL, combine(framework::dataset::make("InputShape", { TensorShape(13U, 13U, 96U, 240U) }),
-                                                                                                                 framework::dataset::make("DataType", DataType::F16),
-                                                                                                         framework::dataset::make("HasBias", { true, false }),
-                                                                                                 framework::dataset::make("NumGroups", { 3, 4 })))
+FIXTURE_DATA_TEST_CASE(FP16, ClWeightsReshapeFixture<half>, framework::DatasetMode::ALL, combine(make("InputShape", { TensorShape(13U, 13U, 96U, 240U) }),
+                                                                                                                 make("DataType", DataType::F16),
+                                                                                                         make("HasBias", { true, false }),
+                                                                                                 make("NumGroups", { 3, 4 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(BFloat16, ClWeightsReshapeFixture<half>, framework::DatasetMode::ALL, combine(framework::dataset::make("InputShape", { TensorShape(9U, 9U, 96U, 240U) }),
-                                                                                                                     framework::dataset::make("DataType", DataType::BFLOAT16),
-                                                                                                             framework::dataset::make("HasBias", { false }),
-                                                                                                     framework::dataset::make("NumGroups", { 3, 4 })))
+FIXTURE_DATA_TEST_CASE(BFloat16, ClWeightsReshapeFixture<half>, framework::DatasetMode::ALL, combine(make("InputShape", { TensorShape(9U, 9U, 96U, 240U) }),
+                                                                                                                     make("DataType", DataType::BFLOAT16),
+                                                                                                             make("HasBias", { false }),
+                                                                                                     make("NumGroups", { 3, 4 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -124,19 +125,19 @@ FIXTURE_DATA_TEST_CASE(BFloat16, ClWeightsReshapeFixture<half>, framework::Datas
 TEST_SUITE_END()
 
 TEST_SUITE(Quantized)
-FIXTURE_DATA_TEST_CASE(QASYMM8, ClWeightsReshapeFixture<uint8_t>, framework::DatasetMode::ALL, combine(framework::dataset::make("InputShape", { TensorShape(5U, 5U, 48U, 120U) }),
-                                                                                                                       framework::dataset::make("DataType", DataType::QASYMM8),
-                                                                                                               framework::dataset::make("HasBias", { false }),
-                                                                                                       framework::dataset::make("NumGroups", { 1, 2 })))
+FIXTURE_DATA_TEST_CASE(QASYMM8, ClWeightsReshapeFixture<uint8_t>, framework::DatasetMode::ALL, combine(make("InputShape", { TensorShape(5U, 5U, 48U, 120U) }),
+                                                                                                                       make("DataType", DataType::QASYMM8),
+                                                                                                               make("HasBias", { false }),
+                                                                                                       make("NumGroups", { 1, 2 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 
-FIXTURE_DATA_TEST_CASE(QASYMM8_SIGNED, ClWeightsReshapeFixture<uint8_t>, framework::DatasetMode::ALL, combine(framework::dataset::make("InputShape", { TensorShape(5U, 5U, 48U, 120U) }),
-                                                                                                                      framework::dataset::make("DataType", DataType::QASYMM8_SIGNED),
-                                                                                                                      framework::dataset::make("HasBias", { false }),
-                                                                                                              framework::dataset::make("NumGroups", { 1, 2 })))
+FIXTURE_DATA_TEST_CASE(QASYMM8_SIGNED, ClWeightsReshapeFixture<uint8_t>, framework::DatasetMode::ALL, combine(make("InputShape", { TensorShape(5U, 5U, 48U, 120U) }),
+                                                                                                                      make("DataType", DataType::QASYMM8_SIGNED),
+                                                                                                                      make("HasBias", { false }),
+                                                                                                              make("NumGroups", { 1, 2 })))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CL/WidthConcatenateLayer.cpp
+++ b/tests/validation/CL/WidthConcatenateLayer.cpp
@@ -39,31 +39,32 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
 TEST_SUITE(CL)
 TEST_SUITE(WidthConcatenateLayer)
 // *INDENT-OFF*
 // clang-format off
-DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(framework::dataset::make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
+DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(make("InputInfo1", {  TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching data type input/output
                                                         TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching y dimension
                                                         TensorInfo(TensorShape(23U, 27U, 5U), 1, DataType::F32), // Mismatching total width
                                                         TensorInfo(TensorShape(16U, 27U, 5U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(21U, 35U, 5U), 1, DataType::F32)
 
               }),
-              framework::dataset::make("InputInfo2", {  TensorInfo(TensorShape(24U, 27U, 4U), 1, DataType::F32),
+              make("InputInfo2", {  TensorInfo(TensorShape(24U, 27U, 4U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(52U, 27U, 5U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(52U, 27U, 5U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(16U, 27U, 5U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(10U, 35U, 5U), 1, DataType::F32)
               }),
-              framework::dataset::make("OutputInfo", {  TensorInfo(TensorShape(47U, 27U, 5U), 1, DataType::F16),
+              make("OutputInfo", {  TensorInfo(TensorShape(47U, 27U, 5U), 1, DataType::F16),
                                                         TensorInfo(TensorShape(75U, 12U, 5U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(11U, 27U, 5U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(32U, 27U, 5U), 1, DataType::F32),
                                                         TensorInfo(TensorShape(31U, 35U, 5U), 1, DataType::F32)
 
               }),
-              framework::dataset::make("Expected", { false, false, false, true, true })),
+              make("Expected", { false, false, false, true, true })),
               input_info1, input_info2, output_info,expected)
 {
     std::vector<TensorInfo> inputs_vector_info;
@@ -89,18 +90,18 @@ using CLWidthConcatenateLayerFixture = ConcatenateLayerValidationFixture<CLTenso
 TEST_SUITE(Float)
 TEST_SUITE(FP16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLWidthConcatenateLayerFixture<half>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                  framework::dataset::make("DataType",
+                                                                                                                  make("DataType",
                                                                                                                           DataType::F16),
-                                                                                                                  framework::dataset::make("Axis", 0)))
+                                                                                                                  make("Axis", 0)))
 
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
 FIXTURE_DATA_TEST_CASE(RunLarge, CLWidthConcatenateLayerFixture<half>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large2DShapes(), datasets::Small4DShapes()),
-                                                                                                                        framework::dataset::make("DataType",
+                                                                                                                        make("DataType",
                                                                                                                                 DataType::F16),
-                                                                                                                framework::dataset::make("Axis", 0)))
+                                                                                                                make("Axis", 0)))
 
 {
     // Validate output
@@ -110,17 +111,17 @@ TEST_SUITE_END()
 
 TEST_SUITE(FP32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLWidthConcatenateLayerFixture<float>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                   framework::dataset::make("DataType",
+                                                                                                                   make("DataType",
                                                                                                                            DataType::F32),
-                                                                                                                   framework::dataset::make("Axis", 0)))
+                                                                                                                   make("Axis", 0)))
 
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLWidthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLWidthConcatenateLayerFixture<float>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                  DataType::F32),
-                                                                                                                 framework::dataset::make("Axis", 0)))
+                                                                                                                 make("Axis", 0)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
@@ -131,16 +132,16 @@ TEST_SUITE_END()
 TEST_SUITE(Quantized)
 TEST_SUITE(QASYMM8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CLWidthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small2DShapes(), datasets::Tiny4DShapes()),
-                                                                                                                     framework::dataset::make("DataType",
+                                                                                                                     make("DataType",
                                                                                                                              DataType::QASYMM8),
-                                                                                                                     framework::dataset::make("Axis", 0)))
+                                                                                                                     make("Axis", 0)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);
 }
-FIXTURE_DATA_TEST_CASE(RunLarge, CLWidthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), framework::dataset::make("DataType",
+FIXTURE_DATA_TEST_CASE(RunLarge, CLWidthConcatenateLayerFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(datasets::ConcatenateLayerShapes(), make("DataType",
                                                                                                                    DataType::QASYMM8),
-                                                                                                                   framework::dataset::make("Axis", 0)))
+                                                                                                                   make("Axis", 0)))
 {
     // Validate output
     validate(CLAccessor(_target), _reference);

--- a/tests/validation/CPP/DFT.cpp
+++ b/tests/validation/CPP/DFT.cpp
@@ -45,30 +45,33 @@ namespace validation
 {
 namespace
 {
-auto shapes_1d_dft = framework::dataset::make("TensorShape", { TensorShape(33U),
-                                                               TensorShape(8U),
-                                                               TensorShape(23U, 7U),
-                                                               TensorShape(16U, 8U, 4U)
-                                                             });
+using framework::dataset::make;
+using framework::dataset::zip;
 
-auto shapes_2d_dft = framework::dataset::make("TensorShape", { TensorShape(33U, 14U),
-                                                               TensorShape(8U, 9U),
-                                                               TensorShape(23U, 7U, 3U),
-                                                               TensorShape(16U, 8U, 4U)
-                                                             });
+auto shapes_1d_dft = make("TensorShape", { TensorShape(33U),
+                                           TensorShape(8U),
+                                           TensorShape(23U, 7U),
+                                           TensorShape(16U, 8U, 4U)
+                                         });
 
-auto conv_dataset_dft = framework::dataset::zip(framework::dataset::zip(framework::dataset::make("InputShape", { TensorShape(8U, 7U, 3U, 2U),
-                                                                                                                 TensorShape(18U, 22U, 4U),
-                                                                                                                 TensorShape(32U, 48U, 8U)
-                                                                                                               }),
-                                                                        framework::dataset::make("WeightShape", { TensorShape(3U, 3U, 3U, 6U),
-                                                                                                                  TensorShape(5U, 5U, 4U, 3U),
-                                                                                                                  TensorShape(9U, 9U, 8U, 3U)
-                                                                                                                })),
-                                                framework::dataset::make("ConvInfo", { PadStrideInfo(1, 1, 1, 1),
-                                                                                       PadStrideInfo(1, 1, 2, 2),
-                                                                                       PadStrideInfo(1, 1, 4, 4)
-                                                                                     }));
+auto shapes_2d_dft = make("TensorShape", { TensorShape(33U, 14U),
+                                           TensorShape(8U, 9U),
+                                           TensorShape(23U, 7U, 3U),
+                                           TensorShape(16U, 8U, 4U)
+                                         });
+
+auto conv_dataset_dft = zip(zip(make("InputShape", { TensorShape(8U, 7U, 3U, 2U),
+                                                     TensorShape(18U, 22U, 4U),
+                                                     TensorShape(32U, 48U, 8U)
+                                                   }),
+                             make("WeightShape", { TensorShape(3U, 3U, 3U, 6U),
+                                                   TensorShape(5U, 5U, 4U, 3U),
+                                                   TensorShape(9U, 9U, 8U, 3U)
+                                                 })),
+                       make("ConvInfo", { PadStrideInfo(1, 1, 1, 1),
+                                          PadStrideInfo(1, 1, 2, 2),
+                                          PadStrideInfo(1, 1, 4, 4)
+                                        }));
 } // namespace
 TEST_SUITE(CPP)
 TEST_SUITE(DFT)

--- a/tests/validation/CPP/DetectionPostProcessLayer.cpp
+++ b/tests/validation/CPP/DetectionPostProcessLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Arm Limited.
+ * Copyright (c) 2019-2020, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -39,6 +39,8 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::make;
+using framework::dataset::zip;
 namespace
 {
 template <typename U, typename T>
@@ -210,58 +212,58 @@ TEST_SUITE(DetectionPostProcessLayer)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(zip(zip(zip(zip(zip(zip(
-        framework::dataset::make("BoxEncodingsInfo", { TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
+        make("BoxEncodingsInfo", { TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 3U), 1, DataType::F32),  // Mismatching batch_size
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::S8), // Unsupported data type
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32), // Wrong Detection Info
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32), // Wrong boxes dimensions
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::QASYMM8), // Wrong score dimension
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::QASYMM8_SIGNED)}), // Wrong score dimension
-        framework::dataset::make("ClassPredsInfo",{ TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
+        make("ClassPredsInfo",{ TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::QASYMM8),
                                                 TensorInfo(TensorShape(3U ,10U), 1, DataType::QASYMM8_SIGNED)})),
-        framework::dataset::make("AnchorsInfo",{ TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
+        make("AnchorsInfo",{ TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::QASYMM8),
                                                 TensorInfo(TensorShape(4U, 10U, 1U), 1, DataType::QASYMM8_SIGNED)})),
-        framework::dataset::make("OutputBoxInfo", { TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
+        make("OutputBoxInfo", { TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::S8),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U, 5U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(4U, 3U, 1U), 1, DataType::F32)})),
-        framework::dataset::make("OuputClassesInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
+        make("OuputClassesInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(6U, 1U), 1, DataType::F32)})),
-        framework::dataset::make("OutputScoresInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
+        make("OutputScoresInfo",{ TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(3U, 1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(6U, 1U), 1, DataType::F32)})),
-        framework::dataset::make("NumDetectionsInfo",{ TensorInfo(TensorShape(1U), 1, DataType::F32),
+        make("NumDetectionsInfo",{ TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32),
                                                 TensorInfo(TensorShape(1U), 1, DataType::F32)})),
-        framework::dataset::make("DetectionPostProcessLayerInfo",{ DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
+        make("DetectionPostProcessLayerInfo",{ DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 1.5f, 2, {0.0f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f}),
                                                 DetectionPostProcessLayerInfo(3, 1, 0.0f, 0.5f, 2, {0.1f,0.1f,0.1f,0.1f})})),
-        framework::dataset::make("Expected", {true, false, false, false, false, false })),
+        make("Expected", {true, false, false, false, false, false })),
         box_encodings_info, classes_info, anchors_info, output_boxes_info, output_classes_info,output_scores_info, num_detection_info, detect_info, expected)
 {
     const Status status = CPPDetectionPostProcessLayer::validate(&box_encodings_info.clone()->set_is_resizable(false),

--- a/tests/validation/CPP/NonMaximumSuppression.cpp
+++ b/tests/validation/CPP/NonMaximumSuppression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Arm Limited.
+ * Copyright (c) 2019, 2025 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -40,11 +40,14 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::combine;
+using framework::dataset::make;
+using framework::dataset::zip;
 namespace
 {
-const auto max_output_boxes_dataset  = framework::dataset::make("MaxOutputBoxes", 1, 10);
-const auto score_threshold_dataset   = framework::dataset::make("ScoreThreshold", { 0.1f, 0.5f, 0.f, 1.f });
-const auto iou_nms_threshold_dataset = framework::dataset::make("NMSThreshold", { 0.1f, 0.5f, 0.f, 1.f });
+const auto max_output_boxes_dataset  = make("MaxOutputBoxes", 1, 10);
+const auto score_threshold_dataset   = make("ScoreThreshold", { 0.1f, 0.5f, 0.f, 1.f });
+const auto iou_nms_threshold_dataset = make("NMSThreshold", { 0.1f, 0.5f, 0.f, 1.f });
 const auto NMSParametersSmall        = datasets::Small2DNonMaxSuppressionShapes() * max_output_boxes_dataset * score_threshold_dataset * iou_nms_threshold_dataset;
 const auto NMSParametersBig          = datasets::Large2DNonMaxSuppressionShapes() * max_output_boxes_dataset * score_threshold_dataset * iou_nms_threshold_dataset;
 
@@ -56,7 +59,7 @@ TEST_SUITE(NMS)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(zip(zip(zip(zip(
-                                                framework::dataset::make("BoundingBox",{
+                                                make("BoundingBox",{
                                                                                         TensorInfo(TensorShape(4U, 100U), 1, DataType::F32),
                                                                                         TensorInfo(TensorShape(1U, 4U, 2U), 1, DataType::F32),    // invalid shape
                                                                                         TensorInfo(TensorShape(4U, 2U), 1, DataType::S32),    // invalid data type
@@ -68,7 +71,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(zip(zip(zip(zip(
                                                                                         TensorInfo(TensorShape(4U, 100U), 1, DataType::F32),
                                                                                         TensorInfo(TensorShape(4U, 100U), 1, DataType::F32),
                                                                                     }),
-                                                framework::dataset::make("Scores", {
+                                                make("Scores", {
                                                                                         TensorInfo(TensorShape(100U), 1, DataType::F32),
                                                                                         TensorInfo(TensorShape(37U, 2U, 13U, 27U), 1, DataType::F32), // invalid shape
                                                                                         TensorInfo(TensorShape(4U), 1, DataType::F32),
@@ -80,7 +83,7 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(zip(zip(zip(zip(
                                                                                         TensorInfo(TensorShape(100U), 1, DataType::F32),
                                                                                         TensorInfo(TensorShape(100U), 1, DataType::F32),
                                                                                     })),
-                                                framework::dataset::make("Indices", {
+                                                make("Indices", {
                                                                                         TensorInfo(TensorShape(100U), 1, DataType::S32),
                                                                                         TensorInfo(TensorShape(100U), 1, DataType::S32),
                                                                                         TensorInfo(TensorShape(4U), 1, DataType::S32),
@@ -93,23 +96,23 @@ DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(zip(zip(zip(zip(
                                                                                         TensorInfo(TensorShape(100U), 1, DataType::S32),
 
                                                                                     })),
-                                                framework::dataset::make("max_output", {
+                                                make("max_output", {
                                                                                         10U, 2U,4U, 3U,66U, 1U,
                                                                                         0U, /* invalid, must be greater than 0 */
                                                                                         10000U, /* OK, clamped to indices' size */
                                                                                         100U,
                                                                                         10U,
                                                                                      })),
-                                                framework::dataset::make("score_threshold", {
+                                                make("score_threshold", {
                                                                                         0.1f, 0.4f, 0.2f,0.8f,0.3f, 0.01f, 0.5f, 0.45f,
                                                                                         -1.f, /* invalid value, must be in [0,1] */
                                                                                         0.5f,
                                                                                      })),
-                                                framework::dataset::make("nms_threshold", {
+                                                make("nms_threshold", {
                                                                                         0.3f, 0.7f, 0.1f,0.13f,0.2f, 0.97f, 0.76f, 0.87f, 0.1f,
                                                                                         10.f, /* invalid value, must be in [0,1]*/
                                                                                      })),
-                                                framework::dataset::make("Expected", {
+                                                make("Expected", {
                                                                                         true, false, false, false, true, false, false,true, false, false
                                                                                      })),
 

--- a/tests/validation/CPP/Permute.cpp
+++ b/tests/validation/CPP/Permute.cpp
@@ -40,9 +40,11 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::concat;
+using framework::dataset::make;
 namespace
 {
-const auto PermuteVectors = framework::dataset::make("PermutationVector",
+const auto PermuteVectors = make("PermutationVector",
 {
     PermutationVector(2U, 0U, 1U),
     PermutationVector(1U, 2U, 0U),
@@ -51,7 +53,7 @@ const auto PermuteVectors = framework::dataset::make("PermutationVector",
     PermutationVector(1U, 0U, 2U),
     PermutationVector(2U, 1U, 0U),
 });
-const auto PermuteParametersSmall = concat(concat(datasets::Small2DShapes(), datasets::Small3DShapes()), datasets::Small4DShapes()) * PermuteVectors;
+const auto PermuteParametersSmall = concat(datasets::Small2DShapes(), datasets::Small3DShapes(), datasets::Small4DShapes()) * PermuteVectors;
 const auto PermuteParametersLarge = datasets::Large4DShapes() * PermuteVectors;
 
 } // namespace
@@ -63,14 +65,14 @@ using CPPPermuteFixture = PermuteValidationFixture<Tensor, Accessor, CPPPermute,
 
 TEST_SUITE(U8)
 FIXTURE_DATA_TEST_CASE(RunSmall, CPPPermuteFixture<uint8_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U8))
+                       PermuteParametersSmall * make("DataType", DataType::U8))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CPPPermuteFixture<uint8_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U8))
+                       PermuteParametersLarge * make("DataType", DataType::U8))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -80,14 +82,14 @@ TEST_SUITE_END()
 
 TEST_SUITE(U16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CPPPermuteFixture<uint16_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U16))
+                       PermuteParametersSmall * make("DataType", DataType::U16))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CPPPermuteFixture<uint16_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U16))
+                       PermuteParametersLarge * make("DataType", DataType::U16))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -96,14 +98,14 @@ TEST_SUITE_END()
 
 TEST_SUITE(U32)
 FIXTURE_DATA_TEST_CASE(RunSmall, CPPPermuteFixture<uint32_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::U32))
+                       PermuteParametersSmall * make("DataType", DataType::U32))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CPPPermuteFixture<uint32_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::U32))
+                       PermuteParametersLarge * make("DataType", DataType::U32))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -112,7 +114,7 @@ TEST_SUITE_END()
 
 TEST_SUITE(QASYMM8_SIGNED)
 FIXTURE_DATA_TEST_CASE(RunSmall, CPPPermuteFixture<int8_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::QASYMM8_SIGNED))
+                       PermuteParametersSmall * make("DataType", DataType::QASYMM8_SIGNED))
 {
     // Validate output
     validate(Accessor(_target), _reference);
@@ -123,14 +125,14 @@ TEST_SUITE_END() // QASYMM8_SIGNED
 #ifdef ARM_COMPUTE_ENABLE_FP16
 TEST_SUITE(F16)
 FIXTURE_DATA_TEST_CASE(RunSmall, CPPPermuteFixture<float16_t>, framework::DatasetMode::PRECOMMIT,
-                       PermuteParametersSmall * framework::dataset::make("DataType", DataType::F16))
+                       PermuteParametersSmall * make("DataType", DataType::F16))
 {
     // Validate output
     validate(Accessor(_target), _reference);
 }
 
 FIXTURE_DATA_TEST_CASE(RunLarge, CPPPermuteFixture<float16_t>, framework::DatasetMode::NIGHTLY,
-                       PermuteParametersLarge * framework::dataset::make("DataType", DataType::F16))
+                       PermuteParametersLarge * make("DataType", DataType::F16))
 {
     // Validate output
     validate(Accessor(_target), _reference);

--- a/tests/validation/CPP/TopKV.cpp
+++ b/tests/validation/CPP/TopKV.cpp
@@ -40,7 +40,9 @@ namespace test
 {
 namespace validation
 {
+using framework::dataset::combine;
 using framework::dataset::make;
+using framework::dataset::zip;
 namespace
 {
 template <typename U, typename T>
@@ -56,24 +58,24 @@ TEST_SUITE(TopKV)
 // *INDENT-OFF*
 // clang-format off
 DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(zip(zip(
-        framework::dataset::make("PredictionsInfo", { TensorInfo(TensorShape(20, 10), 1, DataType::F32),
+        make("PredictionsInfo", { TensorInfo(TensorShape(20, 10), 1, DataType::F32),
                                                 TensorInfo(TensorShape(10, 20), 1, DataType::F16),  // Mismatching batch_size
                                                 TensorInfo(TensorShape(20, 10), 1, DataType::S8), // Unsupported data type
                                                 TensorInfo(TensorShape(10, 10, 10), 1, DataType::F32), // Wrong predictions dimensions
                                                 TensorInfo(TensorShape(20, 10), 1, DataType::F32)}), // Wrong output dimension
-        framework::dataset::make("TargetsInfo",{ TensorInfo(TensorShape(10), 1, DataType::U32),
+        make("TargetsInfo",{ TensorInfo(TensorShape(10), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10), 1, DataType::U32),
                                                 TensorInfo(TensorShape(10), 1, DataType::U32)})),
-        framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(10), 1, DataType::U8),
+        make("OutputInfo",{ TensorInfo(TensorShape(10), 1, DataType::U8),
                                                 TensorInfo(TensorShape(10), 1, DataType::U8),
                                                 TensorInfo(TensorShape(10), 1, DataType::U8),
                                                 TensorInfo(TensorShape(10), 1, DataType::U8),
                                                 TensorInfo(TensorShape(1), 1, DataType::U8)})),
 
-        framework::dataset::make("k",{ 0, 1, 2, 3, 4 })),
-        framework::dataset::make("Expected", {true, false, false, false, false })),
+        make("k",{ 0, 1, 2, 3, 4 })),
+        make("Expected", {true, false, false, false, false })),
         prediction_info, targets_info, output_info, k, expected)
 {
     const Status status = CPPTopKV::validate(&prediction_info.clone()->set_is_resizable(false),&targets_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), k);


### PR DESCRIPTION
Updated CL/CPP validation tests to use the local make alias instead of fully qualifying framework::dataset::make.

Change-Id: I363d51ad9bbf15b2e972dda0a533f2929f3a4395