### PR TITLE
fix: remove private include from public header

### DIFF
--- a/arm_compute/runtime/experimental/operators/CpuQuantize.h
+++ b/arm_compute/runtime/experimental/operators/CpuQuantize.h
@@ -31,8 +31,6 @@
 #include "arm_compute/core/ITensorInfo.h"
 #include "arm_compute/runtime/NEON/INEOperator.h"
 
-#include "src/cpu/ICpuOperator.h"
-
 #include <memory>
 
 /*


### PR DESCRIPTION
Fixes: #1177 

Removes an unused dependency on a private header.