### PR TITLE
fix: Exclude the FP16 MMUL Reshaped RHS kernel for MMUL extension version less than 1.1.0

### DIFF
--- a/src/gpu/cl/kernels/gemm/ClGemmHelpers.cpp
+++ b/src/gpu/cl/kernels/gemm/ClGemmHelpers.cpp
@@ -183,21 +183,25 @@ bool is_mmul_kernel_preferred_fp16_acc(const unsigned int m,
                                        unsigned int      &best_m0,
                                        unsigned int      &best_n0)
 {
-    ARM_COMPUTE_ERROR_ON(data_type != DataType::F16);
-    ARM_COMPUTE_UNUSED(n, k, b, data_type);
+    if (data_type == DataType::F16 && arm_matrix_multiply_fp16_supported(CLKernelLibrary::get().get_device()))
+    {
+        ARM_COMPUTE_UNUSED(n, k, b);
 
-    const unsigned int mmul_k0 = 4;
-    const unsigned int mmul_n0 = 4;
+        const unsigned int mmul_k0 = 4;
+        const unsigned int mmul_n0 = 4;
 
-    // Block sizes are chosen empirically.
-    best_m0 = 4;
-    best_n0 = (n >= 8 * mmul_n0) ? 8 : 4;
+        // Block sizes are chosen empirically.
+        best_m0 = 4;
+        best_n0 = (n >= 8 * mmul_n0) ? 8 : 4;
 
-    const unsigned int ceil_to_multiple_m_m0             = ceil_to_multiple(m, best_m0);
-    const unsigned int m_div_m0                          = ceil_to_multiple_m_m0 / best_m0;
-    const unsigned int ceil_to_multiple_m_div_m0_mmul_k0 = ceil_to_multiple(m_div_m0, mmul_k0);
-    const unsigned int gws_y                             = ceil_to_multiple_m_div_m0_mmul_k0 / mmul_k0;
-    return ((k % mmul_k0) == 0) && (gws_y >= 4);
+        const unsigned int ceil_to_multiple_m_m0             = ceil_to_multiple(m, best_m0);
+        const unsigned int m_div_m0                          = ceil_to_multiple_m_m0 / best_m0;
+        const unsigned int ceil_to_multiple_m_div_m0_mmul_k0 = ceil_to_multiple(m_div_m0, mmul_k0);
+        const unsigned int gws_y                             = ceil_to_multiple_m_div_m0_mmul_k0 / mmul_k0;
+        return ((k % mmul_k0) == 0) && (gws_y >= 4);
+    }
+
+    return false;
 }
 
 std::pair<GEMMLHSMatrixInfo, GEMMRHSMatrixInfo>


### PR DESCRIPTION
Partially Resolves: [COMPMID-8596]


Change-Id: I98fb24ac420f978c8456596493fc4013090676cb