### PR TITLE
revert: "fix: feat: enable SME/SME2 detection on Windows®"

### DIFF
--- a/src/common/cpuinfo/CpuInfo.cpp
+++ b/src/common/cpuinfo/CpuInfo.cpp
@@ -442,8 +442,6 @@ CpuInfo CpuInfo::build()
         isainfo.fp16 = IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE);
         isainfo.sve  = IsProcessorFeaturePresent(PF_ARM_SVE_INSTRUCTIONS_AVAILABLE);
         isainfo.i8mm = IsProcessorFeaturePresent(PF_ARM_SVE_I8MM_INSTRUCTIONS_AVAILABLE);
-        isainfo.sme  = IsProcessorFeaturePresent(PF_ARM_SME_INSTRUCTIONS_AVAILABLE);
-        isainfo.sme2 = IsProcessorFeaturePresent(PF_ARM_SME2_INSTRUCTIONS_AVAILABLE);
     }
     SYSTEM_INFO sysinfo;
     GetSystemInfo(&sysinfo);


### PR DESCRIPTION
This reverts commit b175867715b92960e2b90e1cbd9c7cf618eac076.

Change-Id: I06ff312e84499da966fb7f44f820ff9aa736179c