### PR TITLE
fix: Potential -Wdeprecated-literal-operator error in half.hpp inclusion

### DIFF
--- a/tests/validation/CPP/LUT.cpp
+++ b/tests/validation/CPP/LUT.cpp
@@ -22,12 +22,11 @@
  * SOFTWARE.
  */
 #include "src/core/helpers/LUTManager.h"
+#include "support/Half.h"
 #include "tests/framework/Asserts.h"
 #include "tests/framework/Macros.h"
 #include "tests/validation/Helpers.h"
 #include "tests/validation/Validation.h"
-
-#include "include/half/half.hpp"
 
 namespace arm_compute
 {


### PR DESCRIPTION
While compiling with clang v20+, it was emitting -Wdeprecated-literal-operator, and in future versions, this warning can be emitted as an error.

Since we don't want to change the third party, we fixed this inside support/Half.h in this commit: afd78dd9e9c4cf07997db1c8f5e3939f8e4587b0

However, there is another direct inclusion of  half/half.hpp inside tests/validation/CPP/LUT.cpp, and we could potentially hit this issue there again. Currently, we don't because of possible transitive inclusions including support/Half.h before we explicitly include half/half.hpp. But, relying on this is not stable and we'd like to use support/Half.h for every usage/inclusion of half.hpp members.

You can easily reproduce an error by moving the include of half.hpp to the top, confirming our hypothesis that the error was suppressed only because it was suppressed through a transitive support/Half.h inclusion.

Partially Resolves: COMPMID-7924

Change-Id: I204b14eebabe27b06eebf3024938e41748500785