### PR TITLE
test: Adjust chosen scales in tests for Int8 x Int8 -> f32 Convolution

### DIFF
--- a/tests/validation/NEON/ConvolutionLayer.cpp
+++ b/tests/validation/NEON/ConvolutionLayer.cpp
@@ -93,8 +93,8 @@ constexpr float                tolerance_num = 0.07f;   /**< Tolerance number fo
 #endif                                                  /* ARM_COMPUTE_ENABLE_FP16 */
 
 #if __aarch64__
-constexpr float tolerance_num_dequantize_f32 = 0.07f; /**< Tolerance number for the FP32 dequantization */
-#endif                                                // #if __aarch64__
+constexpr float tolerance_num_dequantize_f32 = 1e-5; /**< Tolerance number for the FP32 dequantization */
+#endif                                               // #if __aarch64__
 
 constexpr AbsoluteTolerance<float> tolerance_qasymm8(
     0.0); /**< Tolerance value for comparing reference's output against implementation's output for quantized data types */


### PR DESCRIPTION
Int8 x Int8 -> f32 convolution is picking random scales as if the output is Int8/UInt8, too. In fully quantized convolutions, given input & weight quantizations, we pick the dst quantization info in such a way that the results don't saturate in the 8-bit integer representation.

In f32 outputs, the bias is f32, too, and we don't have a dst quant. info to adjust. In this case, randomly chosen input & weight quant. infos might cause large multiplication outputs. But, the random bias is not chosen according to this, and this causes rounding errors.

The situation usually happens when one of the output values w/o added bias is close to 0. Because the large multiplication output is cancelled by the offset contribution, which makes the output 0, and the result should be equal to bias. However, the bias is added in the assembly kernel before the offset contribution is added to the multiplication output. If the multiplication output is much larger than the bias, it results in big rounding errors int the final sum. When the offset contribution cancels the multiplication output, the rounded bias becomes equal to the result. However, the rounding error sometimes exceeds the tolerance in such cases. This is not healthy as increasing tolerance could result in ignoring the bias and future errors related to that all together.

This commit adjusts the input and weight quantization info to prevent such cases.

Resolves: COMPMID-8660

Change-Id: I554b6c9faabfdc1d3b755487dbe253f9658d03e2