### PR TITLE
fix: Stop ignoring txt files in git history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ CMakeUserPresets.json
 *cscope*
 
 # Text files
-*.txt
-!CMakeLists.txt
 *.xml
 *.embed
 *.diff


### PR DESCRIPTION
Ignoring .txt files in version control is harmful than it's useful because we have several .txt files in our source tree (e.g. CMake related ones) and needs special treatment and license files in our third parties. These get ignored w/o us knowing about them unless they've been included in the tracking explicitly.

This patch removes *.txt and special treatment required by CMakeLists.txt from .gitignore.

Change-Id: Ib5da1959e3a172baf48ea3ebb07ab1649f473f67