### PR TITLE
fix: Remove deprecated clang-tidy config option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 Checks:          'clang-diagnostic-*,*,-llvm-include-order,clang-analyzer-*,-abseil-*,-fuchsia-*,-bugprone-*,-hicpp-*,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cert-err58-cpp,-cppcoreguidelines-pro-type-reinterpret-cast,-google-runtime-references,-google-build-using-namespace,-readability-redundant-member-init,-readability-redundant-declaration,-readability-else-after-return,-performance-type-promotion-in-math-fn,-cert-err60-cpp,-cppcoreguidelines-narrowing-conversions,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-readability-named-parameter,-readability-implicit-bool-conversion,-readability-uppercase-literal-suffix,-clang-analyzer-optin.cplusplus.VirtualCall,-cppcoreguidelines-macro-usage'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:             cert-dcl16-c.IgnoreMacros
     value:           '1'

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -38,7 +38,7 @@ path = [
 	".clang-tidy",
 	"SECURITY.md"
 ]
-SPDX-FileCopyrightText = "2020 Arm Limited"
+SPDX-FileCopyrightText = "2020, 2026 Arm Limited"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]


### PR DESCRIPTION
The option `AnalyzeTemporaryDtors` has been [deprecated since `clang-tidy` version 16 and was removed in version 18](
https://github.com/llvm/llvm-project/issues/62020). As a result, this config option will throw errors with newer versions of these tools while not providing any practical benefit.