### PR TITLE
fix: CpuGemmDirectConv2d: accumulate in fp32 unless in fast_mode

### DIFF
--- a/src/cpu/operators/CpuGemmDirectConv2d.cpp
+++ b/src/cpu/operators/CpuGemmDirectConv2d.cpp
@@ -93,6 +93,7 @@ cpu::AsmGemmInfo init_assembly_metadata(const Conv2dInfo &info, bool is_indirect
     asm_info.fast_mode               = info.enable_fast_math;
     asm_info.fixed_format            = info.weights_info.weight_format() != WeightFormat::UNSPECIFIED;
     asm_info.weight_format           = info.weights_info.weight_format();
+    asm_info.use_fp32_acc            = !info.enable_fast_math;
     return asm_info;
 }
 } // namespace


### PR DESCRIPTION
We have a bug in PyTorch+oneDNN+ACL where numerical errors were observed in certain f16 convs.
PyTorch issue: https://github.com/pytorch/pytorch/issues/177245
oneDNN issue: https://github.com/uxlfoundation/oneDNN/issues/5106

The root cause is that we are accumulating in `f16` rather than in `f32` even when `fast_mode` is `false`. The reason this happens is because `CpuGemmDirectConv2d::configure()` calls `CpuGemmAssemblyDispatch::configure()` here: 
https://github.com/ARM-software/ComputeLibrary/blob/d619e50c501039665dd9fc4045728a0f6254fc20/src/cpu/operators/CpuGemmDirectConv2d.cpp#L136
Which does the following:
https://github.com/ARM-software/ComputeLibrary/blob/d619e50c501039665dd9fc4045728a0f6254fc20/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp#L853-L856

My solution is therefore to change `CpuGemmDirectConv2d::init_assembly_metadata()` such that `use_fp32_acc` is `true` unless `enable_fast_mode` is set. This resolves the bug at the oneDNN level. Hopefully @robert-hardwick can confirm if this fixes the PyTorch bug as well.