### PR TITLE
fix: default ScaleKernelInfo to no padding

### DIFF
--- a/arm_compute/core/KernelDescriptors.h
+++ b/arm_compute/core/KernelDescriptors.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, 2025 Arm Limited.
+ * Copyright (c) 2019-2023, 2025-2026 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -208,7 +208,7 @@ struct ScaleKernelInfo
      * @param[in] border_mode           Border mode policy
      * @param[in] constant_border_value (Optional) Constant value to use for borders if border_mode is set to CONSTANT and use_padding is set to false. Defaults to default @ref PixelValue
      * @param[in] sampling_policy       (Optional) Sampling policy used by the interpolation. Defaults to @ref SamplingPolicy::CENTER
-     * @param[in] use_padding           (Optional) Is padding in use or not. Defaults to true.
+     * @param[in] use_padding           (Optional) Is padding in use or not. Defaults to false.
      * @param[in] align_corners         (Optional) Align corners of input and output, only affecting bilinear policy with TOP_LEFT sampling policy. Defaults to false.
      * @param[in] data_layout           (Optional) Data layout used by the layer. Defaults to @ref DataLayout::UNKNOWN
      */
@@ -216,7 +216,7 @@ struct ScaleKernelInfo
                     BorderMode          border_mode,
                     PixelValue          constant_border_value = PixelValue(),
                     SamplingPolicy      sampling_policy       = SamplingPolicy::CENTER,
-                    bool                use_padding           = true,
+                    bool                use_padding           = false,
                     bool                align_corners         = false,
                     DataLayout          data_layout           = DataLayout::UNKNOWN) noexcept
         : interpolation_policy{interpolation_policy},

--- a/tests/validation/NEON/Scale.cpp
+++ b/tests/validation/NEON/Scale.cpp
@@ -210,6 +210,16 @@ TEST_CASE(MissmatchingDataType, framework::DatasetMode::ALL)
     ARM_COMPUTE_EXPECT(bool(result) == false, framework::LogLevel::ERRORS);
 }
 
+TEST_CASE(DefaultScaleKernelInfoUsesNoPadding, framework::DatasetMode::ALL)
+{
+    const auto input  = TensorInfo{input_shape, 1, default_data_type, default_data_layout};
+    const auto output = TensorInfo{output_shape, 1, default_data_type, default_data_layout};
+    Status     result{};
+
+    result = NEScale::validate(&input, &output, ScaleKernelInfo{default_interpolation_policy, default_border_mode});
+    ARM_COMPUTE_EXPECT(bool(result) == true, framework::LogLevel::ERRORS);
+}
+
 TEST_CASE(UsePadding, framework::DatasetMode::ALL)
 {
     const auto input  = TensorInfo{input_shape, 1, default_data_type, default_data_layout};


### PR DESCRIPTION
The short ScaleKernelInfo(policy, border_mode) form implicitly enabled use_padding, but the CPU/NEON scale kernel rejects padding as an unsupported configuration. That made NEScale::configure() fail unless callers explicitly overrode the default.

Change the default use_padding value to false so the public API matches the supported behavior, and add validation coverage for the default ScaleKernelInfo path.

This solves https://github.com/ARM-software/ComputeLibrary/issues/1284

Change-Id: I86645004f33234268fb8257147a1dc7a9a62637e