### PR TITLE
docs: Change OpenBSD(R) support to experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Pre-build binaries are generated with the following security / good coding pract
 - Android™
 - Bare Metal
 - Linux®
-- OpenBSD®
+- OpenBSD® (Experimental)
 - macOS®
 - Tizen™
 - QNX® (Experimental)

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -53,7 +53,7 @@ SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = ["README.md"]
-SPDX-FileCopyrightText = "2018-2025 Arm Limited"
+SPDX-FileCopyrightText = "2018-2026 Arm Limited"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]


### PR DESCRIPTION
The OpenBSD(R) support is still there. The experimental support means that we're still happy to receive contributions but won't be checking them against an OpenBSD(R) build and validation run in our CI.

Partially Resolves: MLINFRA-4228

Change-Id: Idb45ff75e0f6d16b495409078dd3a7d129526746