### PR TITLE
feat: Expose accumulation mode flag via Conv2dInfo

### DIFF
--- a/arm_compute/runtime/FunctionDescriptors.h
+++ b/arm_compute/runtime/FunctionDescriptors.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, 2025 Arm Limited.
+ * Copyright (c) 2019-2023, 2025-2026 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -67,13 +67,15 @@ struct Conv2dInfo
                const ActivationLayerInfo &act_info,
                bool                       enable_fast_math,
                unsigned int               num_groups,
-               const WeightsInfo         &weights_info = WeightsInfo())
+               const WeightsInfo         &weights_info = WeightsInfo(),
+               bool                       use_fp32_acc = false)
         : conv_info(conv_info),
           dilation(dilation),
           act_info(act_info),
           enable_fast_math(enable_fast_math),
           num_groups(num_groups),
-          weights_info(weights_info)
+          weights_info(weights_info),
+          use_fp32_acc(use_fp32_acc)
     {
     }
 
@@ -83,6 +85,7 @@ struct Conv2dInfo
     bool                enable_fast_math{false};
     unsigned int        num_groups{1};
     WeightsInfo         weights_info{};
+    bool                use_fp32_acc{false}; // relevant only for FP16
 };
 
 /** Descriptor used by the 3d Convolution function */

--- a/src/cpu/operators/CpuGemmDirectConv2d.cpp
+++ b/src/cpu/operators/CpuGemmDirectConv2d.cpp
@@ -93,7 +93,7 @@ cpu::AsmGemmInfo init_assembly_metadata(const Conv2dInfo &info, bool is_indirect
     asm_info.fast_mode               = info.enable_fast_math;
     asm_info.fixed_format            = info.weights_info.weight_format() != WeightFormat::UNSPECIFIED;
     asm_info.weight_format           = info.weights_info.weight_format();
-    asm_info.use_fp32_acc            = !info.enable_fast_math;
+    asm_info.use_fp32_acc            = info.use_fp32_acc;
     return asm_info;
 }
 } // namespace

--- a/tests/validation/NEON/ConvolutionLayer.cpp
+++ b/tests/validation/NEON/ConvolutionLayer.cpp
@@ -64,11 +64,10 @@ void configure_conv_function<NEGEMMConv2d, Tensor>(NEGEMMConv2d              &fu
                                                    const WeightsInfo         &weights_info,
                                                    const Size2D              &dilation,
                                                    const ActivationLayerInfo &act_info,
-                                                   unsigned int               num_groups)
+                                                   unsigned int               num_groups,
+                                                   bool                       use_fp32_acc)
 {
-    ARM_COMPUTE_UNUSED(weights_info);
-
-    Conv2dInfo conv_info(info, dilation, act_info, false, num_groups);
+    Conv2dInfo conv_info(info, dilation, act_info, false, num_groups, weights_info, use_fp32_acc);
     func.configure(src, weights, bias, dst, conv_info);
 }
 } // namespace detail
@@ -87,10 +86,14 @@ constexpr float               tolerance_num_f16 = 0.15f;
 
 #ifdef ARM_COMPUTE_ENABLE_FP16
 const RelativeTolerance<half_float::half>
-    rel_tolerance_f16(half_float::half(0.2f));          /**< Relative tolerance value for FP16 types */
-const AbsoluteTolerance<float> abs_tolerance_f16(0.2f); /**< Absolute tolerance for FP16 types */
-constexpr float                tolerance_num = 0.07f;   /**< Tolerance number for the FP16 implementation */
-#endif                                                  /* ARM_COMPUTE_ENABLE_FP16 */
+    rel_tolerance_f16(half_float::half(0.2f));                     /**< Relative tolerance value for FP16 types */
+const AbsoluteTolerance<float>            abs_tolerance_f16(0.2f); /**< Absolute tolerance for FP16 types */
+constexpr float                           tolerance_num = 0.07f;   /**< Tolerance number for the FP16 implementation */
+const RelativeTolerance<half_float::half> rel_tolerance_f16_fp32_acc(
+    half_float::half(0.001f)); /**< Relative tolerance value for FP16 types with FP32 accumulation */
+const AbsoluteTolerance<float>
+    abs_tolerance_f16_fp32_acc(0.01f); /**< Absolute tolerance value for FP16 types with FP32 accumulation */
+#endif                                 /* ARM_COMPUTE_ENABLE_FP16 */
 
 #if __aarch64__
 constexpr float tolerance_num_dequantize_f32 = 1e-5; /**< Tolerance number for the FP32 dequantization */
@@ -1854,6 +1857,10 @@ TEST_SUITE(DirectGEMMConv2d)
 template <typename T>
 using NEDirectGEMMConv2dLayerFixture = ConvolutionValidationFixture<Tensor, Accessor, NEGEMMConv2d, T>;
 
+template <typename T>
+using NEDirectGEMMConv2dLayerFP16Fixture =
+    NEDirectGEMMConv2dLayerFP16WithAccModeFixture<Tensor, Accessor, NEGEMMConv2d, T>;
+
 /** Test case for memory injection in @ref cpu::CpuGemmDirectConv2d.
  *
  * Configure the operator once and inject memory at run-time in multiple executions.
@@ -1967,6 +1974,39 @@ FIXTURE_DATA_TEST_CASE(RunSmall,
     validate(Accessor(_target), _reference, rel_tolerance_f32, 0.f, float(abs_tolerance_f32));
 }
 TEST_SUITE_END() // FP32
+
+#ifdef ARM_COMPUTE_ENABLE_FP16
+TEST_SUITE(FP16)
+FIXTURE_DATA_TEST_CASE(RunSmall,
+                       NEDirectGEMMConv2dLayerFP16Fixture<half>,
+                       framework::DatasetMode::PRECOMMIT,
+                       combine(datasets::SmallConvolutionLayerDataset(),
+                               make("ReshapeWeights", {true}),
+                               make("DataType", DataType::F16),
+                               make("DataLayout", {DataLayout::NHWC}),
+                               NoActivation,
+                               make("UseFP32Acc", {false, true})))
+{
+    if (CPUInfo::get().has_fp16())
+    {
+        // Validate output
+        if (_use_fp32_acc)
+        {
+            validate(Accessor(_target), _reference, rel_tolerance_f16_fp32_acc, 0.f, abs_tolerance_f16_fp32_acc);
+        }
+        else
+        {
+            validate(Accessor(_target), _reference, rel_tolerance_f16, tolerance_num, abs_tolerance_f16);
+        }
+    }
+    else
+    {
+        ARM_COMPUTE_TEST_WARNING("Device does not support fp16 vector operations. Test SKIPPED.");
+        framework::ARM_COMPUTE_PRINT_WARNING();
+    }
+}
+TEST_SUITE_END() // FP16
+#endif           /* ARM_COMPUTE_ENABLE_FP16 */
 TEST_SUITE_END() // Float
 
 #ifdef __aarch64__

--- a/tests/validation/fixtures/ConvolutionLayerFixture.h
+++ b/tests/validation/fixtures/ConvolutionLayerFixture.h
@@ -75,8 +75,10 @@ configure_conv_function(ConvolutionFunction       &func,
                         const WeightsInfo         &weights_info,
                         const Size2D              &dilation,
                         const ActivationLayerInfo &act_info,
-                        unsigned int               num_groups)
+                        unsigned int               num_groups,
+                        bool                       use_fp32_acc = false)
 {
+    ARM_COMPUTE_UNUSED(use_fp32_acc);
     func.configure(src, weights, bias, dst, info, weights_info, dilation, act_info, false /* enable_fast_math */,
                    num_groups);
 }
@@ -93,8 +95,10 @@ configure_conv_function(ConvolutionFunction       &func,
                         const WeightsInfo         &weights_info,
                         const Size2D              &dilation,
                         const ActivationLayerInfo &act_info,
-                        unsigned int               num_groups)
+                        unsigned int               num_groups,
+                        bool                       use_fp32_acc = false)
 {
+    ARM_COMPUTE_UNUSED(use_fp32_acc);
     func.configure(src, weights, bias, dst, info, weights_info, dilation, act_info, num_groups);
 }
 #endif // ARM_COMPUTE_OPENCL_ENABLED
@@ -196,7 +200,8 @@ public:
                bool                mixed_layout                 = false,
                PaddingList         pre_pad_layer                = PaddingList({}),
                bool                padded_weights               = false,
-               bool                updated_sq_info_after_config = false)
+               bool                updated_sq_info_after_config = false,
+               bool                use_fp32_acc                 = false)
     {
 #ifndef ARM_COMPUTE_CPU_ENABLED
         ARM_COMPUTE_UNUSED(updated_sq_info_after_config);
@@ -252,7 +257,7 @@ public:
 #endif // ARM_COMPUTE_CPU_ENABLED
         {
             _target = compute_target(input_shape, weights_shape, bias_shape, output_shape, info, reshape_weights,
-                                     dilation, act_info, pre_pad_layer, padded_weights);
+                                     dilation, act_info, pre_pad_layer, padded_weights, use_fp32_acc);
         }
 
         _reference = compute_reference(input_shape, weights_shape, bias_shape, output_shape, info, dilation, act_info,
@@ -385,7 +390,8 @@ protected:
                               const Size2D             &dilation,
                               const ActivationLayerInfo act_info,
                               PaddingList               pre_pad_layer  = PaddingList({}),
-                              bool                      padded_weights = false)
+                              bool                      padded_weights = false,
+                              bool                      use_fp32_acc   = false)
     {
         ARM_COMPUTE_ERROR_ON((input_shape[2] % weights_shape[2]) != 0);
 
@@ -442,12 +448,12 @@ protected:
                                               info.pad_right() + pad_w.second, info.pad_top() + pad_h.first,
                                               info.pad_bottom() + pad_h.second, info.round());
             detail::configure_conv_function(conv, &src, &weights, &bias, &dst, new_conv_info, weights_info, dilation,
-                                            act_info, num_groups);
+                                            act_info, num_groups, use_fp32_acc);
         }
         else
         {
             detail::configure_conv_function(conv, &src, &weights, &bias, &dst, info, weights_info, dilation, act_info,
-                                            num_groups);
+                                            num_groups, use_fp32_acc);
         }
 
         ARM_COMPUTE_ASSERT(src.info()->is_resizable());
@@ -709,6 +715,84 @@ public:
             input_shape, weights_shape, bias_shape, output_shape, info, dilation, reshape_weights, data_type, data_type,
             data_layout, QuantizationInfo(), QuantizationInfo(), act_info, mixed_layout);
     }
+};
+
+template <typename TensorType, typename AccessorType, typename FunctionType, typename T, bool mixed_layout = false>
+class NEDirectGEMMConv2dLayerFP16WithAccModeFixture
+    : public ConvolutionValidationGenericFixture<TensorType, AccessorType, FunctionType, T, T>
+{
+    static_assert(std::is_same<typename std::decay<T>::type, half>::value,
+                  "NEDirectGEMMConv2dLayerFP16WithAccModeFixture only supports half");
+
+public:
+    void setup(TensorShape         input_shape,
+               TensorShape         weights_shape,
+               TensorShape         bias_shape,
+               TensorShape         output_shape,
+               PadStrideInfo       info,
+               Size2D              dilation,
+               bool                reshape_weights,
+               DataType            data_type,
+               DataLayout          data_layout,
+               ActivationLayerInfo act_info,
+               bool                use_fp32_acc)
+    {
+        ARM_COMPUTE_ERROR_ON(data_type != DataType::F16);
+        _use_fp32_acc = use_fp32_acc;
+        ConvolutionValidationGenericFixture<TensorType, AccessorType, FunctionType, T, T>::setup(
+            input_shape, weights_shape, bias_shape, output_shape, info, dilation, reshape_weights, data_type, data_type,
+            data_layout, QuantizationInfo(), QuantizationInfo(), act_info, mixed_layout, PaddingList({}), false, false,
+            use_fp32_acc);
+
+        if (std::is_same<TensorType, Tensor>::value && !CPUInfo::get().has_fp16())
+        {
+            return;
+        }
+
+        this->_reference =
+            compute_reference_fp32_acc(input_shape, weights_shape, bias_shape, output_shape, info, dilation, act_info);
+    }
+
+protected:
+    SimpleTensor<half> compute_reference_fp32_acc(const TensorShape        &input_shape,
+                                                  const TensorShape        &weights_shape,
+                                                  const TensorShape        &bias_shape,
+                                                  const TensorShape        &output_shape,
+                                                  const PadStrideInfo      &info,
+                                                  const Size2D             &dilation,
+                                                  const ActivationLayerInfo act_info)
+    {
+        ARM_COMPUTE_ERROR_ON((input_shape[2] % weights_shape[2]) != 0);
+
+        const unsigned int num_groups = input_shape[2] / weights_shape[2];
+
+        SimpleTensor<half> src{input_shape, DataType::F16};
+        SimpleTensor<half> weights{weights_shape, DataType::F16};
+        SimpleTensor<half> bias{bias_shape, DataType::F16};
+
+        this->fill(src, 0 + this->_hash);
+        this->fill(weights, 1 + this->_hash);
+        this->fill(bias, 2 + this->_hash);
+
+        auto conv_fp32 = reference::convolution_layer<half, half, half, float>(src, weights, bias, output_shape, info,
+                                                                               dilation, num_groups);
+
+        SimpleTensor<half> conv{output_shape, DataType::F16};
+        for (int i = 0; i < conv.num_elements(); ++i)
+        {
+            conv[i] = half(conv_fp32[i]);
+        }
+
+        if (act_info.enabled())
+        {
+            return reference::activation_layer<half>(conv, act_info);
+        }
+
+        return conv;
+    }
+
+public:
+    bool _use_fp32_acc{false};
 };
 
 template <typename TensorType, typename AccessorType, typename FunctionType, typename T, bool mixed_layout = false>

--- a/tests/validation/reference/ConvolutionLayer.cpp
+++ b/tests/validation/reference/ConvolutionLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020, 2025 Arm Limited.
+ * Copyright (c) 2017-2020, 2025-2026 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -175,6 +175,15 @@ template SimpleTensor<half> convolution_layer<half, half, half, half>(const Simp
                                                                       const Size2D             &dilation,
                                                                       unsigned int              num_groups,
                                                                       QuantizationInfo          out_quant_info);
+
+template SimpleTensor<float> convolution_layer<half, half, half, float>(const SimpleTensor<half> &src,
+                                                                        const SimpleTensor<half> &weights,
+                                                                        const SimpleTensor<half> &bias,
+                                                                        const TensorShape        &output_shape,
+                                                                        const PadStrideInfo      &info,
+                                                                        const Size2D             &dilation,
+                                                                        unsigned int              num_groups,
+                                                                        QuantizationInfo          out_quant_info);
 
 template SimpleTensor<uint8_t>
 convolution_layer<uint8_t, uint8_t, int32_t, uint8_t>(const SimpleTensor<uint8_t> &src,


### PR DESCRIPTION
Users of the functional and experimental operator convolution APIs, e.g, `arm_compute::NEGEMMConv2d`, or
`arm_compute::experimental::op::CpuGemmDirectConv2d`, can make use of `fp32` accumulation by setting this flag in Conv2dInfo during the validate() and configure() steps.

Commit 5e40456e changed the default behaviour of `CpuGemmDirectConv2d` to accumulate in `fp32` unless `enable_fast_math` was set. However, this can produce regressions for users expecting the old behaviour. This change exposes the flag to user directly, making `fp32` accumulation opt-in.

Change-Id: I3203bdbbfa5152a64438941dd138bab6feb1cec2