### PR TITLE
feat: Add experimental SME/SVE runtime selection controls

### DIFF
--- a/arm_compute/core/CPP/CPPTypes.h
+++ b/arm_compute/core/CPP/CPPTypes.h
@@ -168,6 +168,27 @@ public:
      * @return true if the cpu supports sme_b16f32, false otherwise
      */
     bool has_sme_b16f32() const;
+    /** Sets whether SVE and SVE2 implementations are allowed to be selected at runtime.
+     *
+     * @experimental This API is under development and may change or be removed without notice in future releases.
+     *
+     * @param[in] is_allowed True to expose detected SVE/SVE2 support, false to hide SVE/SVE2 from runtime selectors.
+     */
+    void set_sve_allowed(bool is_allowed);
+    /** Sets whether SME and SME2 implementations are allowed to be selected at runtime.
+     *
+     * @experimental This API is under development and may change or be removed without notice in future releases.
+     *
+     * @param[in] is_allowed True to expose detected SME/SME2 support, false to hide SME/SME2 from runtime selectors.
+     */
+    void set_sme_allowed(bool is_allowed);
+    /** Returns whether SME and SME2 implementations are allowed to be selected at runtime.
+     *
+     * @experimental This API is under development and may change or be removed without notice in future releases.
+     *
+     * @return true if detected SME/SME2 support is exposed to runtime selectors, false otherwise.
+     */
+    bool is_sme_allowed() const;
     /** Gets the cpu model for a given cpuid.
      *
      * @param[in] cpuid the id of the cpu core to be retrieved,

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -261,7 +261,8 @@ TAB_SIZE               = 4
 # newlines.
 
 ALIASES                = \
-    "publicapi=\xrefitem semver \"\" \"\""
+    "publicapi=\xrefitem semver \"\" \"\"" \
+    "experimental=@par Experimental:\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/src/core/CPP/CPPTypes.cpp
+++ b/src/core/CPP/CPPTypes.cpp
@@ -39,6 +39,8 @@ struct CPUInfo::Impl
     cpuinfo::CpuInfo info{};
     unsigned int     L1_cache_size = 32768;
     unsigned int     L2_cache_size = 262144;
+    bool             sve_allowed   = true;
+    bool             sme_allowed   = true;
 };
 
 CPUInfo &CPUInfo::get()
@@ -71,7 +73,7 @@ bool CPUInfo::has_bf16() const
 
 bool CPUInfo::has_svebf16() const
 {
-    return _impl->info.has_svebf16();
+    return _impl->sve_allowed && _impl->info.has_svebf16();
 }
 
 bool CPUInfo::has_dotprod() const
@@ -81,7 +83,7 @@ bool CPUInfo::has_dotprod() const
 
 bool CPUInfo::has_svef32mm() const
 {
-    return _impl->info.has_svef32mm();
+    return _impl->sve_allowed && _impl->info.has_svef32mm();
 }
 
 bool CPUInfo::has_i8mm() const
@@ -91,7 +93,7 @@ bool CPUInfo::has_i8mm() const
 
 bool CPUInfo::has_svei8mm() const
 {
-    return _impl->info.has_svei8mm();
+    return _impl->sve_allowed && _impl->info.has_svei8mm();
 }
 
 bool CPUInfo::has_fhm() const
@@ -101,42 +103,57 @@ bool CPUInfo::has_fhm() const
 
 bool CPUInfo::has_sve() const
 {
-    return _impl->info.has_sve();
+    return _impl->sve_allowed && _impl->info.has_sve();
 }
 
 bool CPUInfo::has_sve2() const
 {
-    return _impl->info.has_sve2();
+    return _impl->sve_allowed && _impl->info.has_sve2();
 }
 
 bool CPUInfo::has_sme() const
 {
-    return _impl->info.has_sme();
+    return _impl->sme_allowed && _impl->info.has_sme();
 }
 
 bool CPUInfo::has_sme2() const
 {
-    return _impl->info.has_sme2();
+    return _impl->sme_allowed && _impl->info.has_sme2();
 }
 
 bool CPUInfo::has_sme_i8i32() const
 {
-    return _impl->info.has_sme_i8i32();
+    return _impl->sme_allowed && _impl->info.has_sme_i8i32();
 }
 
 bool CPUInfo::has_sme_f16f32() const
 {
-    return _impl->info.has_sme_f16f32();
+    return _impl->sme_allowed && _impl->info.has_sme_f16f32();
 }
 
 bool CPUInfo::has_sme_f32f32() const
 {
-    return _impl->info.has_sme_f32f32();
+    return _impl->sme_allowed && _impl->info.has_sme_f32f32();
 }
 
 bool CPUInfo::has_sme_b16f32() const
 {
-    return _impl->info.has_sme_b16f32();
+    return _impl->sme_allowed && _impl->info.has_sme_b16f32();
+}
+
+void CPUInfo::set_sve_allowed(bool is_allowed)
+{
+    _impl->sve_allowed = is_allowed;
+}
+
+void CPUInfo::set_sme_allowed(bool is_allowed)
+{
+    _impl->sme_allowed = is_allowed;
+}
+
+bool CPUInfo::is_sme_allowed() const
+{
+    return _impl->sme_allowed;
 }
 
 CPUModel CPUInfo::get_cpu_model() const
@@ -151,7 +168,25 @@ CPUModel CPUInfo::get_cpu_model(unsigned int cpuid) const
 
 cpuinfo::CpuIsaInfo CPUInfo::get_isa() const
 {
-    return _impl->info.isa();
+    cpuinfo::CpuIsaInfo isa = _impl->info.isa();
+    if (!_impl->sve_allowed)
+    {
+        isa.sve      = false;
+        isa.sve2     = false;
+        isa.svebf16  = false;
+        isa.svei8mm  = false;
+        isa.svef32mm = false;
+    }
+    if (!_impl->sme_allowed)
+    {
+        isa.sme        = false;
+        isa.sme2       = false;
+        isa.sme_b16f32 = false;
+        isa.sme_f16f32 = false;
+        isa.sme_f32f32 = false;
+        isa.sme_i8i32  = false;
+    }
+    return isa;
 }
 
 unsigned int CPUInfo::get_L1_cache_size() const


### PR DESCRIPTION
Expose experimental runtime controls in CPUInfo so clients can mask SME/SME2 and SVE capabilities when selecting CPU kernels. This lets higher-level frameworks steer ACL away from ISA paths that should not be used for a graph while preserving default hardware-based selection when no override is supplied.

Full context in the ArmNN PR: https://github.com/ARM-software/armnn/pull/820

Signed-off-by: Damien Dooley <damien.dooley@arm.com>

Change-Id: I602cebdd58942930d248948788bfac9e2be56474