### PR TITLE
fix: correct `__aarch64__` preprocessor guard typo

### DIFF
--- a/tests/validation/NEON/ConvolutionLayer.cpp
+++ b/tests/validation/NEON/ConvolutionLayer.cpp
@@ -156,7 +156,7 @@ const auto QuantizationData = make("QuantizationInfo",
 TEST_SUITE(NEON)
 TEST_SUITE(ConvolutionLayer)
 
-#ifdef __aarch64_
+#ifdef __aarch64__
 DATA_TEST_CASE(
     DequantFP32_SupportedTypes,
     framework::DatasetMode::ALL,
@@ -195,7 +195,7 @@ DATA_TEST_CASE(
 
     ARM_COMPUTE_EXPECT(bool(status) == expected, framework::LogLevel::ERRORS);
 }
-#endif // __aarch64_
+#endif // __aarch64__
 
 DATA_TEST_CASE(SupportedTypes,
                framework::DatasetMode::ALL,


### PR DESCRIPTION
 The DequantFP32_SupportedTypes test in tests/validation/NEON/ConvolutionLayer.cpp is surrounded by:
```
  #ifdef __aarch64_   // single trailing underscore — never defined
  ...
  #endif // __aarch64_
```
The standard AArch64 compiler-predefined macro is `__aarch64__` (two underscores). Because `__aarch64_` is never defined, the entire test block has been silently dead code since it was introduced - it never executes on any platform.

**Fix**
Replace both occurrences with the correct __aarch64__ macro. No logic changes.

**Testing**
After this fix, `DequantFP32_SupportedTypes` runs on AArch64 targets and exercises the seven type-combination cases that validate `NEConvolutionLayer` correctly accepts `QASYMM8_SIGNED` + `QASYMM8_SIGNED` + `F32` bias → `F32` and rejects all invalid combinations.