### PR TITLE
fix: Fix OpenCL(TM) C++ header include path in cl_definitions.h

### DIFF
--- a/arm_compute/core/CL/cl_definitions.h
+++ b/arm_compute/core/CL/cl_definitions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Arm Limited.
+ * Copyright (c) 2025-2026 Arm Limited.
  *
  * SPDX-License-Identifier: MIT
  *
@@ -25,7 +25,7 @@
 #ifndef ACL_ARM_COMPUTE_CORE_CL_CL_DEFINITIONS_H
 #define ACL_ARM_COMPUTE_CORE_CL_CL_DEFINITIONS_H
 
-#include "include/CL/opencl.hpp"
+#include <CL/opencl.hpp>
 
 #define CL_DEVICE_MATRIX_MULTIPLY_FP16_WITH_FP16_ACCUMULATORS_ARM (1ULL << 0)
 #define CL_DEVICE_MATRIX_MULTIPLY_CAPABILITIES_ARM                0x41F4


### PR DESCRIPTION
Commit 5c4dc9469632bef3c86da6b52506863450232b28 moved the OpenCL(TM) C++ bindings include into cl_definitions.h but used the source-tree relative path "include/CL/opencl.hpp".

This breaks consumers using installed ComputeLibrary headers, such as Arm NN with OpenCL(TM) enabled, because the installed public header is available as <CL/opencl.hpp>.

Use the public include path so cl_definitions.h works both from the source tree and from installed/package layouts.


Change-Id: If381cd88f2139cfd17b696e6173c8f192fc35089