### PR TITLE
fix: replace std::deque with std::vector in HeuristicTree BFS

### DIFF
--- a/src/runtime/CL/mlgo/HeuristicTree.cpp
+++ b/src/runtime/CL/mlgo/HeuristicTree.cpp
@@ -28,8 +28,8 @@
 #include "support/Cast.h"
 
 #include <algorithm>
-#include <deque>
 #include <set>
+#include <vector>
 namespace arm_compute
 {
 namespace mlgo
@@ -175,13 +175,15 @@ bool HeuristicTree::add_branch(NodeID id, Condition cond, NodeID t_node, NodeID 
 
 bool HeuristicTree::check_if_structurally_correct() const
 {
-    std::set<NodeID>   visited;
-    std::deque<NodeID> to_visit{_root};
+    std::set<NodeID>    visited;
+    std::vector<NodeID> to_visit;
+    to_visit.push_back(_root);
+    std::size_t front = 0;
 
-    while (!to_visit.empty())
+    while (front < to_visit.size())
     {
-        auto id = to_visit.front();
-        to_visit.pop_front();
+        auto id = to_visit[front];
+        ++front;
         if (_tree.find(id) == _tree.end())
         {
             ARM_COMPUTE_LOG_INFO_MSG_WITH_FORMAT_CORE("Missing node %zu", id);


### PR DESCRIPTION
GCC 14 triggers -Wstrict-overflow=2 inside std::deque internals
(_M_create_nodes and _M_destroy_nodes) when the container is used in
check_if_structurally_correct(). Both the initializer-list constructor
and the destructor inline into the call site, causing the warning to
fire as a -Werror build failure on Raspberry Pi OS and other GCC 14
environments.

Replace std::deque with std::vector and an index-based front pointer.
std::vector does not have the pointer-comparison loops in its internals
that trigger the warning. The BFS semantics and traversal order are
unchanged.

Testing: Reproduced with g++-14 -std=c++14 -O3 -Wstrict-overflow=2 -Werror.
Before: build fails with two -Wstrict-overflow errors from stl_deque.h:683 and :699.
After: compiles cleanly.

Fixes: #1303 